### PR TITLE
Add InstrumentationFilter interface to allow filtering instrumentation

### DIFF
--- a/tritium-api/src/main/java/com/palantir/tritium/event/InstrumentationFilter.java
+++ b/tritium-api/src/main/java/com/palantir/tritium/event/InstrumentationFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.event;
+
+import java.lang.reflect.Method;
+import javax.annotation.Nonnull;
+
+public interface InstrumentationFilter {
+
+    /**
+     * Invoked prior to a method invocation, allowing control whether the
+     * invocation will be instrumented.
+     *
+     * @param method the {@code Method} corresponding to the interface method
+     * invoked on the instance.
+     *
+     * @param args an array of objects containing the values of the arguments
+     * passed in the method invocation on the instance, or empty array if
+     * interface method takes no arguments. Arguments of primitive types are
+     * wrapped in instances of the appropriate primitive wrapper class, such as
+     * {@code java.lang.Integer} or {@code java.lang.Boolean}.
+     *
+     * @return true if invocation should be instrumented, false if invocation should not be instrumented
+     */
+    boolean shouldInstrument(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args);
+
+}

--- a/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationFilters.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationFilters.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.event;
+
+import com.palantir.tritium.api.functions.BooleanSupplier;
+import java.lang.reflect.Method;
+import javax.annotation.Nonnull;
+
+public enum InstrumentationFilters implements InstrumentationFilter {
+
+    INSTRUMENT_ALL {
+        @Override
+        public boolean shouldInstrument(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args) {
+            return true;
+        }
+    },
+
+    INSTRUMENT_NONE {
+        @Override
+        public boolean shouldInstrument(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args) {
+            return false;
+        }
+    };
+
+    public static InstrumentationFilter from(final BooleanSupplier isEnabledSupplier) {
+        return new InstrumentationFilter() {
+            @Override
+            public boolean shouldInstrument(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args) {
+                return isEnabledSupplier.asBoolean();
+            }
+        };
+    }
+}

--- a/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationFiltersTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationFiltersTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.event;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.palantir.tritium.api.functions.BooleanSupplier;
+import com.palantir.tritium.test.TestImplementation;
+import com.palantir.tritium.test.TestInterface;
+import java.lang.reflect.Method;
+import org.junit.Test;
+
+public class InstrumentationFiltersTest {
+
+    private TestInterface instance = mock(TestImplementation.class);
+    private Method method = testMethod();
+    private Object[] args = new Object[0];
+
+    @Test
+    public void testInstrumentAll() throws Exception {
+        assertThat(InstrumentationFilters.INSTRUMENT_ALL.shouldInstrument(instance, method, args)).isTrue();
+    }
+
+    @Test
+    public void testInstrumentNone() throws Exception {
+        assertThat(InstrumentationFilters.INSTRUMENT_NONE.shouldInstrument(instance, method, args)).isFalse();
+    }
+
+    @Test
+    public void testFromTrueSupplier() throws Exception {
+        InstrumentationFilter filter = InstrumentationFilters.from(BooleanSupplier.TRUE);
+        assertThat(filter.shouldInstrument(instance, method, args)).isTrue();
+    }
+
+    @Test
+    public void testFromFalseSupplier() throws Exception {
+        InstrumentationFilter filter = InstrumentationFilters.from(BooleanSupplier.FALSE);
+        assertThat(filter.shouldInstrument(instance, method, args)).isFalse();
+    }
+
+    private static Method testMethod() {
+        try {
+            return TestInterface.class.getDeclaredMethod("test");
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/InstrumentationProxy.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/InstrumentationProxy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.proxy;
+
+import com.palantir.tritium.event.InstrumentationFilter;
+import com.palantir.tritium.event.InvocationContext;
+import com.palantir.tritium.event.InvocationEventHandler;
+import java.util.List;
+
+class InstrumentationProxy<T> extends InvocationEventProxy<InvocationContext> {
+
+    private final T delegate;
+
+    InstrumentationProxy(InstrumentationFilter instrumentationFilter,
+            List<InvocationEventHandler<InvocationContext>> handlers, T delegate) {
+        super(instrumentationFilter, handlers);
+        this.delegate = delegate;
+    }
+
+    @Override
+    T getDelegate() {
+        return delegate;
+    }
+
+}


### PR DESCRIPTION
Can now specify an `InstrumentationFilter` via `Instrumentation.Builder#withFilter`, where the `InstrumentationFilter` interface is `boolean shouldInstrument(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args)` so that one can `return false` when instrumentation should not occur (e.g. `return !"dontInstrumentMe".equals(method.getName());`)