### PR TITLE
Fix publishing break caused by dirty directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ generated_testSrc/
 bin/
 build/
 out/
+
+# Gc logs
+build*.gc.log


### PR DESCRIPTION
comes from PR 82 internal.

publishing would fail because the repo was dirty causing the version to not match the release regex.  Could be solved in a variety of ways, I chose this one, could also just amend circle.yml deployment command to clean first.

```
ubuntu@box257:~/tritium$ ./gradlew printVersion
The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead.
:printVersion
0.6.0.dirty
:tritium-jmh:printVersion
0.6.0.dirty

BUILD SUCCESSFUL

Total time: 20.955 secs
ubuntu@box257:~/tritium$ git status
On branch develop
Your branch is up-to-date with 'origin/develop'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	build-2017-03-15_14-43-58-pid16247.gc.log
	build-2017-03-15_14-44-44-pid17733.gc.log
	tritium-api/build-2017-03-15_14-45-23-pid18299.gc.log
	tritium-brave/build-2017-03-15_14-45-41-pid18587.gc.log
	tritium-brave/build-2017-03-15_14-46-26-pid18892.gc.log
	tritium-caffeine/build-2017-03-15_14-45-37-pid18424.gc.log
	tritium-caffeine/build-2017-03-15_14-46-32-pid19042.gc.log
	tritium-core/build-2017-03-15_14-45-36-pid18373.gc.log
	tritium-core/build-2017-03-15_14-46-29-pid18952.gc.log
	tritium-jmh/build-2017-03-15_14-47-48-pid19612.gc.log
	tritium-jmh/build-2017-03-15_14-48-32-pid19704.gc.log
	tritium-lib/build-2017-03-15_14-45-37-pid18404.gc.log
	tritium-lib/build-2017-03-15_14-46-48-pid19195.gc.log
	tritium-metrics/build-2017-03-15_14-45-37-pid18411.gc.log
	tritium-metrics/build-2017-03-15_14-46-34-pid19118.gc.log
	tritium-slf4j/build-2017-03-15_14-45-42-pid18605.gc.log
	tritium-slf4j/build-2017-03-15_14-46-21-pid18836.gc.log
	tritium-tracing/build-2017-03-15_14-45-42-pid18612.gc.log
	tritium-tracing/build-2017-03-15_14-46-30-pid18990.gc.log
```
