### PR TITLE
Cache system properties for enabling/disabling instrumentation

### DIFF
--- a/tritium-brave/src/main/java/com/palantir/tritium/brave/BraveLocalTracingInvocationEventHandler.java
+++ b/tritium-brave/src/main/java/com/palantir/tritium/brave/BraveLocalTracingInvocationEventHandler.java
@@ -23,6 +23,7 @@ import com.palantir.tritium.api.event.InvocationContext;
 import com.palantir.tritium.api.functions.BooleanSupplier;
 import com.palantir.tritium.event.AbstractInvocationEventHandler;
 import com.palantir.tritium.event.DefaultInvocationContext;
+import com.palantir.tritium.event.InstrumentationProperties;
 import java.lang.reflect.Method;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -76,7 +77,7 @@ public final class BraveLocalTracingInvocationEventHandler extends AbstractInvoc
     }
 
     static BooleanSupplier getEnabledSupplier(String component) {
-        return getSystemPropertySupplier(component);
+        return InstrumentationProperties.getSystemPropertySupplier(component);
     }
 
 }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
@@ -16,10 +16,8 @@
 
 package com.palantir.tritium.event;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Strings;
 import com.palantir.tritium.api.event.InvocationContext;
 import com.palantir.tritium.api.event.InvocationEventHandler;
 import com.palantir.tritium.api.functions.BooleanSupplier;
@@ -34,7 +32,6 @@ import javax.annotation.Nullable;
 public abstract class AbstractInvocationEventHandler<C extends InvocationContext>
         implements InvocationEventHandler<C> {
 
-    private static final String INSTRUMENT_PREFIX = "instrument";
     private static final Object[] NO_ARGS = {};
 
     private final BooleanSupplier isEnabledSupplier;
@@ -68,17 +65,7 @@ public abstract class AbstractInvocationEventHandler<C extends InvocationContext
     protected static BooleanSupplier getSystemPropertySupplier(
             Class<? extends InvocationEventHandler<InvocationContext>> clazz) {
         checkNotNull(clazz, "clazz");
-        return getSystemPropertySupplier(clazz.getName());
-    }
-
-    protected static BooleanSupplier getSystemPropertySupplier(String name) {
-        checkArgument(!Strings.isNullOrEmpty(name), "name cannot be null or empty, was '%s'", name);
-        boolean isGloballyDisabled = "false".equalsIgnoreCase(System.getProperty(INSTRUMENT_PREFIX));
-        String qualifiedValue = System.getProperty(INSTRUMENT_PREFIX + "." + name);
-        boolean isSpecificallyEnabled = "true".equalsIgnoreCase(qualifiedValue);
-        final boolean instrumentationEnabled = !isGloballyDisabled
-                && (isSpecificallyEnabled || qualifiedValue == null);
-        return () -> instrumentationEnabled;
+        return InstrumentationProperties.getSystemPropertySupplier(clazz.getName());
     }
 
     public static Object[] nullToEmpty(@Nullable Object[] args) {

--- a/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationProperties.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationProperties.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.event;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.base.Strings;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.tritium.api.functions.BooleanSupplier;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class InstrumentationProperties {
+    private static final Logger log = LoggerFactory.getLogger(InstrumentationProperties.class);
+
+    private InstrumentationProperties() {}
+
+    private static final String INSTRUMENT_PREFIX = "instrument";
+
+    private static volatile Supplier<Map<String, String>> instrumentationProperties = createSupplier();
+
+    public static BooleanSupplier getSystemPropertySupplier(String name) {
+        checkArgument(!Strings.isNullOrEmpty(name), "name cannot be null or empty, was '%s'", name);
+        boolean instrumentationEnabled = isGloballyEnabled() && isSpecificEnabled(name);
+        return () -> instrumentationEnabled;
+    }
+
+    public static boolean isSpecificEnabled(String name) {
+        String qualifiedValue = instrumentationProperties().get(INSTRUMENT_PREFIX + "." + name);
+        return "true".equalsIgnoreCase(qualifiedValue) || qualifiedValue == null;
+    }
+
+    public static boolean isGloballyEnabled() {
+        return !isGloballyDisabled();
+    }
+
+    private static boolean isGloballyDisabled() {
+        return "false".equalsIgnoreCase(instrumentationProperties().get(INSTRUMENT_PREFIX));
+    }
+
+    /**
+     * Reload the instrumentation properties.
+     * <p>
+     * Note this should only be used for testing purposes when manipulating system properties at runtime.
+     */
+    public static void reload() {
+        instrumentationProperties = createSupplier();
+    }
+
+    private static Supplier<Map<String, String>> createSupplier() {
+        return Suppliers.memoizeWithExpiration(
+                InstrumentationProperties::createInstrumentationSystemProperties,
+                1L, TimeUnit.MINUTES);
+    }
+
+    private static Map<String, String> instrumentationProperties() {
+        return instrumentationProperties.get();
+    }
+
+    private static Map<String, String> createInstrumentationSystemProperties() {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        copySystemProperties().forEach((key, value) -> {
+            if (String.valueOf(key).startsWith(INSTRUMENT_PREFIX)) {
+                builder.put(String.valueOf(key), String.valueOf(value));
+            }
+        });
+        Map<String, String> map = builder.build();
+        log.debug("Reloaded instrumentation properties {}", map);
+        return map;
+    }
+
+    private static Map<Object, Object> copySystemProperties() {
+        /*
+         * Since system properties are a hash table, they can be a point of contention
+         * as all access is synchronized. We therefore take an approach of copying all the
+         * keys at once, but must hold the lock on the entire Hashtable.
+         */
+        Properties properties = System.getProperties();
+        //noinspection SynchronizationOnLocalVariableOrMethodParameter
+        synchronized (properties) {
+            return ImmutableMap.copyOf(properties);
+        }
+    }
+
+}

--- a/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationPropertiesTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,13 @@
 package com.palantir.tritium.event;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.tritium.api.functions.BooleanSupplier;
 import org.junit.Before;
 import org.junit.Test;
 
-public class AbstractInvocationEventHandlerTest {
+public class InstrumentationPropertiesTest {
 
     @Before
     public void before() {
@@ -34,42 +35,50 @@ public class AbstractInvocationEventHandlerTest {
 
     @Test
     public void testSystemPropertySupplierEnabledByDefault() {
-        BooleanSupplier supplier = AbstractInvocationEventHandler
-                .getSystemPropertySupplier(CompositeInvocationEventHandler.class);
+        BooleanSupplier supplier = InstrumentationProperties.getSystemPropertySupplier("test");
         assertThat(supplier.asBoolean()).isTrue();
     }
 
     @Test
     public void testSystemPropertySupplierInstrumentFalse() {
         System.setProperty("instrument", "false");
-        BooleanSupplier supplier = AbstractInvocationEventHandler
-                .getSystemPropertySupplier(CompositeInvocationEventHandler.class);
+        BooleanSupplier supplier = InstrumentationProperties
+                .getSystemPropertySupplier("test");
         assertThat(supplier.asBoolean()).isFalse();
     }
 
     @Test
     public void testSystemPropertySupplierInstrumentTrue() {
         System.setProperty("instrument", "true");
-        BooleanSupplier supplier = AbstractInvocationEventHandler
-                .getSystemPropertySupplier(CompositeInvocationEventHandler.class);
+        BooleanSupplier supplier = InstrumentationProperties
+                .getSystemPropertySupplier("test");
         assertThat(supplier.asBoolean()).isTrue();
     }
 
     @Test
     public void testSystemPropertySupplierInstrumentClassFalse() {
-        System.setProperty("instrument." + CompositeInvocationEventHandler.class.getName(), "false");
-        BooleanSupplier supplier = AbstractInvocationEventHandler
-                .getSystemPropertySupplier(CompositeInvocationEventHandler.class);
+        System.setProperty("instrument.test", "false");
+        BooleanSupplier supplier = InstrumentationProperties
+                .getSystemPropertySupplier("test");
         assertThat(supplier.asBoolean()).isFalse();
     }
 
     @Test
     public void testSystemPropertySupplierInstrumentClassTrue() {
         System.clearProperty("instrument");
-        System.setProperty("instrument." + CompositeInvocationEventHandler.class.getName(), "true");
-        BooleanSupplier supplier = AbstractInvocationEventHandler
-                .getSystemPropertySupplier(CompositeInvocationEventHandler.class);
+        System.setProperty("instrument.test", "true");
+        BooleanSupplier supplier = InstrumentationProperties
+                .getSystemPropertySupplier("test");
         assertThat(supplier.asBoolean()).isTrue();
     }
 
+    @Test
+    public void invalid() {
+        assertThatThrownBy(() -> InstrumentationProperties.getSystemPropertySupplier(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("name cannot be null or empty");
+        assertThatThrownBy(() -> InstrumentationProperties.getSystemPropertySupplier(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("name cannot be null or empty");
+    }
 }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
@@ -26,6 +26,7 @@ import com.palantir.tritium.api.event.InvocationEventHandler;
 import com.palantir.tritium.api.functions.BooleanSupplier;
 import com.palantir.tritium.event.AbstractInvocationEventHandler;
 import com.palantir.tritium.event.DefaultInvocationContext;
+import com.palantir.tritium.event.InstrumentationProperties;
 import com.palantir.tritium.event.metrics.annotations.AnnotationHelper;
 import com.palantir.tritium.event.metrics.annotations.MetricGroup;
 import java.lang.reflect.Method;
@@ -97,7 +98,7 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
     }
 
     static BooleanSupplier getEnabledSupplier(final String serviceName) {
-        return getSystemPropertySupplier(serviceName);
+        return InstrumentationProperties.getSystemPropertySupplier(serviceName);
     }
 
     @Override

--- a/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/MetricsBooleanSupplierTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/MetricsBooleanSupplierTest.java
@@ -20,6 +20,7 @@ package com.palantir.tritium.event.metrics;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.tritium.api.functions.BooleanSupplier;
+import com.palantir.tritium.event.InstrumentationProperties;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -71,6 +72,7 @@ public class MetricsBooleanSupplierTest {
         Set<Map.Entry<Object, Object>> entries = System.getProperties().entrySet();
         entries.removeIf(objectObjectEntry ->
                 String.valueOf(objectObjectEntry.getKey()).startsWith(METRICS_SYSTEM_PROPERTY_PREFIX));
+        InstrumentationProperties.reload();
     }
 
     @Test

--- a/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java
+++ b/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java
@@ -22,6 +22,7 @@ import com.palantir.tritium.api.event.InvocationContext;
 import com.palantir.tritium.api.functions.BooleanSupplier;
 import com.palantir.tritium.event.AbstractInvocationEventHandler;
 import com.palantir.tritium.event.DefaultInvocationContext;
+import com.palantir.tritium.event.InstrumentationProperties;
 import java.lang.reflect.Method;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -71,7 +72,7 @@ public final class TracingInvocationEventHandler extends AbstractInvocationEvent
     }
 
     static BooleanSupplier getEnabledSupplier(String component) {
-        return getSystemPropertySupplier(component);
+        return InstrumentationProperties.getSystemPropertySupplier(component);
     }
 
 }


### PR DESCRIPTION
Since system properties are a hash table, they can be a point of contention as all access is synchronized. We therefore take an approach of periodically copying all the keys at once, but must hold the lock on the entire Hashtable.