### PR TITLE
Fix additional backward compatibility breaks

### DIFF
--- a/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
@@ -18,21 +18,19 @@ package com.palantir.tritium.event;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 
 /**
  * Abstract invocation event handler implementation.
  *
- * @param <C>
- *        invocation context
+ * @param <C> invocation context
  */
 public abstract class AbstractInvocationEventHandler<C extends InvocationContext>
         implements InvocationEventHandler<C> {
 
     private static final Object[] NO_ARGS = {};
 
-    private final BooleanSupplier isEnabledSupplier;
+    private final java.util.function.BooleanSupplier isEnabledSupplier;
 
     /**
      * Always enabled instrumentation handler.
@@ -41,7 +39,14 @@ public abstract class AbstractInvocationEventHandler<C extends InvocationContext
         this(com.palantir.tritium.api.functions.BooleanSupplier.TRUE);
     }
 
-    protected AbstractInvocationEventHandler(BooleanSupplier isEnabledSupplier) {
+    /**
+     * Bridge for backward compatibility.
+     */
+    protected AbstractInvocationEventHandler(com.palantir.tritium.api.functions.BooleanSupplier isEnabledSupplier) {
+        this((java.util.function.BooleanSupplier) isEnabledSupplier);
+    }
+
+    protected AbstractInvocationEventHandler(java.util.function.BooleanSupplier isEnabledSupplier) {
         this.isEnabledSupplier = checkNotNull(isEnabledSupplier, "isEnabledSupplier");
     }
 
@@ -60,7 +65,7 @@ public abstract class AbstractInvocationEventHandler<C extends InvocationContext
      *        instrumentation handler class
      * @return false if "instrument.fully.qualified.class.Name" is set to "false", otherwise true
      */
-    protected static BooleanSupplier getSystemPropertySupplier(
+    protected static com.palantir.tritium.api.functions.BooleanSupplier getSystemPropertySupplier(
             Class<? extends InvocationEventHandler<InvocationContext>> clazz) {
         checkNotNull(clazz, "clazz");
         return InstrumentationProperties.getSystemPropertySupplier(clazz.getName());

--- a/tritium-slf4j/src/test/java/com/palantir/tritium/event/log/LoggingInvocationEventHandlerTest.java
+++ b/tritium-slf4j/src/test/java/com/palantir/tritium/event/log/LoggingInvocationEventHandlerTest.java
@@ -16,10 +16,7 @@
 
 package com.palantir.tritium.event.log;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -116,10 +113,10 @@ public class LoggingInvocationEventHandlerTest {
 
     @Test
     public void testGenerateMessagePattern() {
-        assertThat(LoggingInvocationEventHandler.generateMessagePattern(0), equalTo("{}.{}() took {}ms"));
-        assertThat(LoggingInvocationEventHandler.generateMessagePattern(1), equalTo("{}.{}({}) took {}ms"));
-        assertThat(LoggingInvocationEventHandler.generateMessagePattern(2), equalTo("{}.{}({}, {}) took {}ms"));
-        assertThat(LoggingInvocationEventHandler.generateMessagePattern(3), equalTo("{}.{}({}, {}, {}) took {}ms"));
+        assertThat(LoggingInvocationEventHandler.generateMessagePattern(0)).isEqualTo("{}.{}() took {}ms");
+        assertThat(LoggingInvocationEventHandler.generateMessagePattern(1)).isEqualTo("{}.{}({}) took {}ms");
+        assertThat(LoggingInvocationEventHandler.generateMessagePattern(2)).isEqualTo("{}.{}({}, {}) took {}ms");
+        assertThat(LoggingInvocationEventHandler.generateMessagePattern(3)).isEqualTo("{}.{}({}, {}, {}) took {}ms");
     }
 
     @Test
@@ -138,8 +135,7 @@ public class LoggingInvocationEventHandlerTest {
 
         Object[] logParams = LoggingInvocationEventHandler.getLogParams(method, args, durationNanoseconds, level);
         String logMessage = MessageFormatter.arrayFormat(messagePattern, logParams).getMessage();
-        assertThat(logMessage,
-                startsWith("TestInterface.multiArgumentMethod(String, int, Collection[3]) took 1.235ms"));
+        assertThat(logMessage).startsWith("TestInterface.multiArgumentMethod(String, int, Collection[3]) took 1.235ms");
     }
 
     @Test
@@ -154,16 +150,23 @@ public class LoggingInvocationEventHandlerTest {
         args[0] = ImmutableSet.of("a", "b");
         Object[] logParams = LoggingInvocationEventHandler.getLogParams(method, args, durationNanoseconds, level);
         String logMessage = MessageFormatter.arrayFormat(messagePattern, logParams).getMessage();
-        assertThat(logMessage,
-                startsWith("TestInterface.bulk(Set[2]) took 1.235ms"));
+        assertThat(logMessage).startsWith("TestInterface.bulk(Set[2]) took 1.235ms");
     }
 
     @Test
     public void testGetMessagePattern() {
         for (int i = 0; i < 20; i++) {
-            assertThat(LoggingInvocationEventHandler.getMessagePattern(new Object[i]),
-                    containsString("{}"));
+            assertThat(LoggingInvocationEventHandler.getMessagePattern(new Object[i])).contains("{}");
         }
+    }
+
+    @Test
+    public void testBackwardCompatibility() {
+        assertThat(LoggingInvocationEventHandler.LOG_DURATIONS_GREATER_THAN_1_MICROSECOND)
+                .isInstanceOf(com.palantir.tritium.api.functions.LongPredicate.class);
+
+        com.palantir.tritium.api.functions.LongPredicate legacyPredicate = input -> false;
+        assertThat(new LoggingInvocationEventHandler(getLogger(), LoggingLevel.TRACE, legacyPredicate)).isNotNull();
     }
 
 }


### PR DESCRIPTION
Addresses backward compatibility breaks introduced by https://github.com/palantir/tritium/pull/50 due to field type change from `com.palantir.tritium.api.functions.LongPredicate` to `java.util.functions.LongPredicate`

Restore types on LoggingInvocationEventHandler constants to `com.palantir.tritium.api.functions.LongPredicate`

Add explicit backward compatibility bridge constructors to `AbstractInvocationEventHandler` and `LoggingInvocationEventHandler`