### PR TITLE
Support Removing tagged metrics

### DIFF
--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
@@ -25,6 +25,7 @@ import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
 import com.google.auto.service.AutoService;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
@@ -73,6 +74,11 @@ public final class DefaultTaggedMetricRegistry implements TaggedMetricRegistry {
     @Override
     public Map<MetricName, Metric> getMetrics() {
         return Collections.unmodifiableMap(registry);
+    }
+
+    @Override
+    public void removeMetrics(List<MetricName> metricNameList) {
+        metricNameList.forEach(registry::remove);
     }
 
     private <T extends Metric> T getOrAdd(MetricName metricName, Class<T> metricClass, Supplier<T> metricSupplier) {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
@@ -25,8 +25,8 @@ import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
 import com.google.auto.service.AutoService;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
@@ -77,8 +77,8 @@ public final class DefaultTaggedMetricRegistry implements TaggedMetricRegistry {
     }
 
     @Override
-    public void removeMetrics(List<MetricName> metricNameList) {
-        metricNameList.forEach(registry::remove);
+    public Optional<Metric> remove(MetricName metricName) {
+        return Optional.ofNullable(registry.remove(metricName));
     }
 
     private <T extends Metric> T getOrAdd(MetricName metricName, Class<T> metricClass, Supplier<T> metricSupplier) {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
@@ -22,6 +22,7 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -41,4 +42,6 @@ public interface TaggedMetricRegistry {
     Counter counter(MetricName metric);
 
     Map<MetricName, Metric> getMetrics();
+
+    void removeMetrics(List<MetricName> metricNameList);
 }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
@@ -22,8 +22,8 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
-import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Similar to {@link com.codahale.metrics.MetricRegistry} but allows tagging of {@link Metric}s.
@@ -43,5 +43,12 @@ public interface TaggedMetricRegistry {
 
     Map<MetricName, Metric> getMetrics();
 
-    void removeMetrics(List<MetricName> metricNameList);
+    /**
+     * Removes the tagged metric with the specified metric name.
+     *
+     * @param metricName metric name
+     * @return the removed metric
+     */
+    Optional<Metric> remove(MetricName metricName);
+
 }

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistryTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistryTest.java
@@ -23,7 +23,9 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -113,5 +115,18 @@ public final class TaggedMetricRegistryTest {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> registry.timer(METRIC_1))
                 .withMessage("'name' already used for a metric of type 'Counter' but wanted type 'Timer'. tags: {}");
+    }
+
+    @Test
+    public void testRemoveMetric() {
+        Gauge<Integer> gauge = () -> 42;
+        Gauge registeredGauge = registry.gauge(METRIC_1, gauge);
+        assertThat(registeredGauge).isSameAs(gauge);
+
+        Optional<Metric> removedGauge = registry.remove(METRIC_1);
+        assertThat(removedGauge.isPresent()).isTrue();
+        assertThat(removedGauge.get()).isSameAs(gauge);
+
+        assertThat(registry.remove(METRIC_1).isPresent()).isFalse();
     }
 }


### PR DESCRIPTION
Fixes #59. This unblocks adding tag metrics for cassandra-hosts and timelock for AtlasDB.

@tboam for SA.

We should add tests but the class is generally untested :(.