### PR TITLE
TaggedMetricRegistry composability

### DIFF
--- a/tritium-registry/build.gradle
+++ b/tritium-registry/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     processor 'com.google.auto.service:auto-service'
     processor 'org.immutables:value'
 
+    compile 'com.google.guava:guava'
     compile 'com.palantir.safe-logging:safe-logging'
     compile 'io.dropwizard.metrics:metrics-core'
 

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
@@ -119,8 +119,8 @@ public final class DefaultTaggedMetricRegistry implements TaggedMetricRegistry {
     }
 
     @Override
-    public void removeMetrics(String safeTagName, String safeTagValue) {
-        taggedRegistries.remove(Maps.immutableEntry(safeTagName, safeTagValue));
+    public Optional<TaggedMetricSet> removeMetrics(String safeTagName, String safeTagValue) {
+        return Optional.ofNullable(taggedRegistries.remove(Maps.immutableEntry(safeTagName, safeTagValue)));
     }
 
     private <T extends Metric> T getOrAdd(MetricName metricName, Class<T> metricClass, Supplier<T> metricSupplier) {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 @AutoService(TaggedMetricRegistry.class)
 public final class DefaultTaggedMetricRegistry implements TaggedMetricRegistry {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
@@ -109,15 +109,6 @@ public final class DefaultTaggedMetricRegistry implements TaggedMetricRegistry {
         return result.build();
     }
 
-    private Stream<Map.Entry<MetricName, Metric>> addTag(
-            String tagKey, String tagValue, Stream<Map.Entry<MetricName, Metric>> untagged) {
-        return untagged.map(entry -> Maps.immutableEntry(
-                MetricName.builder().from(entry.getKey())
-                        .putSafeTags(tagKey, tagValue)
-                        .build(),
-                entry.getValue()));
-    }
-
     @Override
     public Optional<Metric> remove(MetricName metricName) {
         return Optional.ofNullable(registry.remove(metricName));

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DropwizardTaggedMetricSet.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DropwizardTaggedMetricSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DropwizardTaggedMetricSet.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DropwizardTaggedMetricSet.java
@@ -19,19 +19,19 @@ package com.palantir.tritium.metrics.registry;
 import static java.util.stream.Collectors.toMap;
 
 import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricSet;
 import java.util.Map;
 
 public final class DropwizardTaggedMetricSet implements TaggedMetricSet {
-    private final MetricRegistry metricRegistry;
+    private final MetricSet metricSet;
 
-    public DropwizardTaggedMetricSet(MetricRegistry metricRegistry) {
-        this.metricRegistry = metricRegistry;
+    public DropwizardTaggedMetricSet(MetricSet metricSet) {
+        this.metricSet = metricSet;
     }
 
     @Override
     public Map<MetricName, Metric> getMetrics() {
-        return metricRegistry.getMetrics().entrySet().stream()
+        return metricSet.getMetrics().entrySet().stream()
                 .collect(toMap(entry -> MetricName.builder().safeName(entry.getKey()).build(), Map.Entry::getValue));
     }
 }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DropwizardTaggedMetricSet.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DropwizardTaggedMetricSet.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.registry;
+
+import static java.util.stream.Collectors.toMap;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import java.util.Map;
+
+public final class DropwizardTaggedMetricSet implements TaggedMetricSet {
+    private final MetricRegistry metricRegistry;
+
+    public DropwizardTaggedMetricSet(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+    }
+
+    @Override
+    public Map<MetricName, Metric> getMetrics() {
+        return metricRegistry.getMetrics().entrySet().stream()
+                .collect(toMap(entry -> MetricName.builder().safeName(entry.getKey()).build(), Map.Entry::getValue));
+    }
+}

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
@@ -29,7 +29,7 @@ import java.util.function.Supplier;
 /**
  * Similar to {@link com.codahale.metrics.MetricRegistry} but allows tagging of {@link Metric}s.
  */
-public interface TaggedMetricRegistry {
+public interface TaggedMetricRegistry extends TaggedMetricSet {
 
     /**
      * Returns existing or new timer metric for the specified metric name.
@@ -82,13 +82,6 @@ public interface TaggedMetricRegistry {
     Counter counter(MetricName metricName, Supplier<Counter> counterSupplier);
 
     /**
-     * Returns a map of registered metrics.
-     *
-     * @return map of registered metrics
-     */
-    Map<MetricName, Metric> getMetrics();
-
-    /**
      * Removes the tagged metric with the specified metric name.
      *
      * @param metricName metric name
@@ -96,4 +89,20 @@ public interface TaggedMetricRegistry {
      */
     Optional<Metric> remove(MetricName metricName);
 
+    /**
+     * Adds a set of metrics to this TaggedMetricRegistry's metric set,
+     * which are to be uniquely identified by the tags provided.
+     * <p>
+     * So, if I have a metric registry with a single metric called 'foo', and I add it
+     * with tag (bar, baz), this registry will now contain 'foo', tagged with (bar, baz).
+     *
+     * @param tags the tags which will be added to all the metrics in the metric set
+     * @param metrics the metrics which should be added
+     */
+    void addMetrics(Map<String, String> tags, TaggedMetricSet metrics);
+
+    /**
+     * Removes a TaggedMetricsSet added via addMetrics from this metrics set.
+     */
+    void removeMetrics(Map<String, String> tags);
 }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
@@ -22,7 +22,6 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
@@ -99,10 +99,10 @@ public interface TaggedMetricRegistry extends TaggedMetricSet {
      * @param tags the tags which will be added to all the metrics in the metric set
      * @param metrics the metrics which should be added
      */
-    void addMetrics(Map<String, String> tags, TaggedMetricSet metrics);
+    void addMetrics(String safeTagName, String safeTagValue, TaggedMetricSet metrics);
 
     /**
      * Removes a TaggedMetricsSet added via addMetrics from this metrics set.
      */
-    void removeMetrics(Map<String, String> tags);
+    void removeMetrics(String safeTagName, String safeTagValue);
 }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
@@ -94,8 +94,11 @@ public interface TaggedMetricRegistry extends TaggedMetricSet {
      * <p>
      * So, if I have a metric registry with a single metric called 'foo', and I add it
      * with tag (bar, baz), this registry will now contain 'foo', tagged with (bar, baz).
+     * <p>
      *
-     * @param tags the tags which will be added to all the metrics in the metric set
+     *
+     * @param safeTagName a tag key which should be added to all metrics in the metrics set
+     * @param safeTagValue a tag value which should be added to all metrics in the metrics set
      * @param metrics the metrics which should be added
      */
     void addMetrics(String safeTagName, String safeTagValue, TaggedMetricSet metrics);
@@ -103,5 +106,5 @@ public interface TaggedMetricRegistry extends TaggedMetricSet {
     /**
      * Removes a TaggedMetricsSet added via addMetrics from this metrics set.
      */
-    void removeMetrics(String safeTagName, String safeTagValue);
+    Optional<TaggedMetricSet> removeMetrics(String safeTagName, String safeTagValue);
 }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
@@ -95,7 +95,8 @@ public interface TaggedMetricRegistry extends TaggedMetricSet {
      * So, if I have a metric registry with a single metric called 'foo', and I add it
      * with tag (bar, baz), this registry will now contain 'foo', tagged with (bar, baz).
      * <p>
-     *
+     * If a metric exists with duplicate tags, then calling {@link TaggedMetricSet#getMetrics}
+     * will be impossible.
      *
      * @param safeTagName a tag key which should be added to all metrics in the metrics set
      * @param safeTagValue a tag value which should be added to all metrics in the metrics set

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricSet.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricSet.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricSet.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.registry;
+
+import com.codahale.metrics.Metric;
+import java.util.Map;
+
+public interface TaggedMetricSet {
+    /**
+     * Returns a map of metrics.
+     *
+     * @return map of metrics
+     */
+    Map<MetricName, Metric> getMetrics();
+}

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistryTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistryTest.java
@@ -164,5 +164,7 @@ public final class TaggedMetricRegistryTest {
         registry.addMetrics(tagKey, tagValue, child);
         assertThat(registry.getMetrics())
                 .containsEntry(MetricName.builder().safeName(name).putSafeTags(tagKey, tagValue).build(), meter);
+        registry.removeMetrics(tagKey, tagValue);
+        assertThat(registry.getMetrics()).isEmpty();
     }
 }

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistryTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistryTest.java
@@ -153,4 +153,16 @@ public final class TaggedMetricRegistryTest {
 
         assertThat(registry.remove(METRIC_1).isPresent()).isFalse();
     }
+
+    @Test
+    public void testAddMetricRegistry() {
+        String name = "name";
+        String tagKey = "tagKey";
+        String tagValue = "tagValue";
+        TaggedMetricRegistry child = new DefaultTaggedMetricRegistry();
+        Meter meter = child.meter(MetricName.builder().safeName(name).build());
+        registry.addMetrics(tagKey, tagValue, child);
+        assertThat(registry.getMetrics())
+                .containsEntry(MetricName.builder().safeName(name).putSafeTags(tagKey, tagValue).build(), meter);
+    }
 }


### PR DESCRIPTION
Frequently libraries produce metrics, but the context of usage is not known (e.g. Atlas metrics are coupled to an Atlas client, Spark metrics are tied to a job). In this case, if a caller has multiple metric registries, they can add the child metrics to the parent with a tag, so that they can be distinguished.