### PR TITLE
 Cleanup java-library gradle dependency definitions

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'jacoco'
 apply plugin: 'org.inferred.processors'  // installs the "processor" configuration needed for baseline-error-prone
 apply plugin: 'com.palantir.baseline-error-prone'

--- a/tritium-api/build.gradle
+++ b/tritium-api/build.gradle
@@ -1,13 +1,8 @@
 apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
-    compile 'com.google.code.findbugs:jsr305'
 
-    testCompile 'com.google.guava:guava-testlib'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.hamcrest:hamcrest-all'
-    testCompile 'org.mockito:mockito-all'
-    testCompile 'org.slf4j:slf4j-simple'
+    api 'com.google.code.findbugs:jsr305'
+
 }
 

--- a/tritium-brave/build.gradle
+++ b/tritium-brave/build.gradle
@@ -1,18 +1,20 @@
 apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
-    compile project(':tritium-api')
-    compile project(':tritium-core')
+
+    api project(':tritium-api')
+    api project(':tritium-core')
+    api 'io.zipkin.brave:brave-core'
+
     compile 'com.palantir.safe-logging:safe-logging'
-    compile 'io.zipkin.brave:brave-core'
     compile 'org.slf4j:slf4j-api'
 
-    testCompile project(':tritium-test')
-    testCompile 'com.google.guava:guava-testlib'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.hamcrest:hamcrest-all'
-    testCompile 'org.mockito:mockito-all'
-    testCompile 'org.slf4j:slf4j-simple'
+    testImplementation project(':tritium-test')
+    testImplementation 'com.google.guava:guava-testlib'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-all'
+    testImplementation 'org.slf4j:slf4j-simple'
+
 }
 

--- a/tritium-caffeine/build.gradle
+++ b/tritium-caffeine/build.gradle
@@ -4,22 +4,24 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile project(':tritium-api')
-    compile project(':tritium-core')
-    compile project(':tritium-metrics')
-    compile 'com.github.ben-manes.caffeine:caffeine'
-    compile 'com.google.guava:guava'
-    compile 'com.palantir.safe-logging:safe-logging'
-    compile 'io.dropwizard.metrics:metrics-core'
-    compile 'org.slf4j:slf4j-api'
 
-    testCompile project(':tritium-test')
-    testCompile 'ch.qos.logback:logback-classic'
-    testCompile 'com.google.guava:guava-testlib'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.hamcrest:hamcrest-all'
-    testCompile 'org.mockito:mockito-all'
-    testCompile 'org.slf4j:slf4j-simple'
+    api project(':tritium-api')
+    api project(':tritium-core')
+    api project(':tritium-metrics')
+    api 'com.github.ben-manes.caffeine:caffeine'
+
+    implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:safe-logging'
+    implementation 'io.dropwizard.metrics:metrics-core'
+    implementation 'org.slf4j:slf4j-api'
+
+    testImplementation project(':tritium-test')
+    testImplementation 'ch.qos.logback:logback-classic'
+    testImplementation 'com.google.guava:guava-testlib'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-all'
+    testImplementation 'org.slf4j:slf4j-simple'
+
 }
 

--- a/tritium-core/build.gradle
+++ b/tritium-core/build.gradle
@@ -1,16 +1,18 @@
 apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
-    compile project(':tritium-api')
-    compile 'com.google.guava:guava'
-    compile 'com.palantir.safe-logging:safe-logging'
-    compile 'org.slf4j:slf4j-api'
 
-    testCompile project(':tritium-test')
-    testCompile 'com.google.guava:guava-testlib'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.hamcrest:hamcrest-all'
-    testCompile 'org.mockito:mockito-all'
-    testCompile 'org.slf4j:slf4j-simple'
+    api project(':tritium-api')
+
+    implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:safe-logging'
+    implementation 'org.slf4j:slf4j-api'
+
+    testImplementation project(':tritium-test')
+    testImplementation 'com.google.guava:guava-testlib'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-all'
+    testImplementation 'org.slf4j:slf4j-simple'
+
 }

--- a/tritium-jmh/build.gradle
+++ b/tritium-jmh/build.gradle
@@ -23,32 +23,32 @@ sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
 dependencies {
-    compile project(':tritium-api')
-    compile project(':tritium-brave')
-    compile project(':tritium-core')
-    compile project(':tritium-lib')
-    compile project(':tritium-metrics')
-    compile project(':tritium-slf4j')
-    compile project(':tritium-tracing')
 
-    compile 'com.google.guava:guava'
-    compile 'io.dropwizard.metrics:metrics-core'
-    compile ('org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir') {
+    implementation project(':tritium-api')
+    implementation project(':tritium-brave')
+    implementation project(':tritium-core')
+    implementation project(':tritium-lib')
+    implementation project(':tritium-metrics')
+    implementation project(':tritium-slf4j')
+    implementation project(':tritium-tracing')
+
+    implementation 'com.google.guava:guava'
+    implementation 'io.dropwizard.metrics:metrics-core'
+    implementation ('org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir') {
         exclude group: 'org.hdrhistogram', module: 'HdrHistogram'
     }
-    compile 'org.openjdk.jmh:jmh-core'
-    compile 'org.openjdk.jmh:jmh-generator-annprocess'
-    compile 'org.slf4j:slf4j-api'
+    implementation 'org.openjdk.jmh:jmh-core'
+    implementation 'org.openjdk.jmh:jmh-generator-annprocess'
+    implementation 'org.slf4j:slf4j-api'
 
-    testCompile project(':tritium-test')
-    testCompile 'io.zipkin.brave:brave-spancollector-http'
-    testCompile 'io.zipkin.java:zipkin-junit'
-    testCompile 'com.google.guava:guava-testlib'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.hamcrest:hamcrest-all'
-    testCompile 'org.mockito:mockito-all'
-    testCompile 'org.slf4j:slf4j-simple'
+    testImplementation project(':tritium-test')
+    testImplementation 'io.zipkin.brave:brave-spancollector-http'
+    testImplementation 'io.zipkin.java:zipkin-junit'
+    testImplementation 'com.google.guava:guava-testlib'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-all'
+    testImplementation 'org.slf4j:slf4j-simple'
 
     jmhCompile 'ch.qos.logback:logback-classic'
     jmhCompile 'io.zipkin.brave:brave-spancollector-http'

--- a/tritium-lib/build.gradle
+++ b/tritium-lib/build.gradle
@@ -2,21 +2,23 @@ apply from: "${rootDir}/gradle/publish.gradle"
 apply from: "${rootDir}/gradle/publish-bom.gradle"
 
 dependencies {
-    compile project(':tritium-api')
-    compile project(':tritium-core')
-    compile project(':tritium-metrics')
-    compile project(':tritium-proxy')
-    compile project(':tritium-slf4j')
-    compile project(':tritium-tracing')
-    compile 'com.google.guava:guava'
-    compile 'com.palantir.safe-logging:safe-logging'
-    compile 'org.slf4j:slf4j-api'
 
-    testCompile project(':tritium-test')
-    testCompile 'com.google.guava:guava-testlib'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.hamcrest:hamcrest-all'
-    testCompile 'org.mockito:mockito-all'
-    testCompile 'org.slf4j:slf4j-simple'
+    api project(':tritium-api')
+    api project(':tritium-core')
+    api project(':tritium-metrics')
+    api project(':tritium-proxy')
+    api project(':tritium-slf4j')
+    api project(':tritium-tracing')
+
+    implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:safe-logging'
+    implementation 'org.slf4j:slf4j-api'
+
+    testImplementation project(':tritium-test')
+    testImplementation 'com.google.guava:guava-testlib'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-all'
+    testImplementation 'org.slf4j:slf4j-simple'
+
 }

--- a/tritium-lib/src/test/java/com/palantir/tritium/TritiumTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/TritiumTest.java
@@ -17,7 +17,7 @@
 package com.palantir.tritium;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.MetricRegistry;
@@ -29,9 +29,7 @@ import com.palantir.tritium.test.TestImplementation;
 import com.palantir.tritium.test.TestInterface;
 import java.util.SortedMap;
 import org.junit.After;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class TritiumTest {
 
@@ -40,9 +38,6 @@ public class TritiumTest {
     private TestImplementation delegate = new TestImplementation();
     private MetricRegistry metricRegistry = MetricRegistries.createWithHdrHistogramReservoirs();
     private TestInterface instrumentedService = Tritium.instrument(TestInterface.class, delegate, metricRegistry);
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @After
     public void after() {
@@ -75,9 +70,9 @@ public class TritiumTest {
 
     @Test
     public void rethrowOutOfMemoryError() {
-        expectedException.expect(OutOfMemoryError.class);
-        expectedException.expectMessage("Testing OOM");
-        instrumentedService.throwsOutOfMemoryError();
+        assertThatThrownBy(() -> instrumentedService.throwsOutOfMemoryError())
+                .isInstanceOf(OutOfMemoryError.class)
+                .hasMessage("Testing OOM");
     }
 
     @Test
@@ -92,13 +87,9 @@ public class TritiumTest {
                 .getCount())
                 .isEqualTo(0);
 
-        try {
-            instrumentedService.throwsOutOfMemoryError();
-            fail("Should have thrown OutOfMemoryError");
-        } catch (OutOfMemoryError expected) {
-            assertThat(expected.getMessage()).isEqualTo("Testing OOM");
-
-        }
+        assertThatThrownBy(() -> instrumentedService.throwsOutOfMemoryError())
+                .isInstanceOf(OutOfMemoryError.class)
+                .hasMessage("Testing OOM");
 
         assertThat(metricRegistry.meter(
                 MetricRegistry.name(methodMetricName, "failures"))

--- a/tritium-lib/src/test/java/com/palantir/tritium/event/log/LoggingInstrumentationTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/event/log/LoggingInstrumentationTest.java
@@ -16,9 +16,8 @@
 
 package com.palantir.tritium.event.log;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import com.palantir.tritium.proxy.Instrumentation;
 import com.palantir.tritium.test.TestImplementation;
@@ -67,9 +66,9 @@ public class LoggingInstrumentationTest {
         Runnable instrumentedService = Instrumentation.builder(Runnable.class, delegate)
                 .withLogging(logger, LoggingLevel.TRACE, LoggingInvocationEventHandler.LOG_ALL_DURATIONS)
                 .build();
-        assertThat(delegate.invocationCount(), equalTo(0));
+        assertThat(delegate.invocationCount()).isEqualTo(0);
         instrumentedService.run();
-        assertThat(delegate.invocationCount(), equalTo(1));
+        assertThat(delegate.invocationCount()).isEqualTo(1);
     }
 
     @Test
@@ -85,13 +84,13 @@ public class LoggingInstrumentationTest {
         TestInterface instrumentedService = Instrumentation.builder(TestInterface.class, delegate)
                 .withLogging(logger, LoggingLevel.ERROR, LoggingInvocationEventHandler.NEVER_LOG)
                 .build();
-        assertThat(delegate.invocationCount(), equalTo(0));
+        assertThat(delegate.invocationCount()).isEqualTo(0);
         try {
             instrumentedService.test();
         } catch (RuntimeException expected) {
-            assertThat(expected.getMessage(), equalTo("expected"));
+            assertThat(expected.getMessage()).isEqualTo("expected");
         }
-        assertThat(delegate.invocationCount(), equalTo(1));
+        assertThat(delegate.invocationCount()).isEqualTo(1);
     }
 
 
@@ -105,34 +104,34 @@ public class LoggingInstrumentationTest {
                 .withHandler(handler)
                 .build();
 
-        assertThat(LoggingInvocationEventHandler.isEnabled(logger, level), equalTo(true));
+        assertThat(LoggingInvocationEventHandler.isEnabled(logger, level)).isTrue();
 
-        assertThat(delegate.invocationCount(), equalTo(0));
+        assertThat(delegate.invocationCount()).isEqualTo(0);
 
         instrumented.multiArgumentMethod("test", 1, Collections.singletonList("hello"));
 
         switch (level) {
             case ERROR:
-                assertThat(logger.isErrorEnabled(), equalTo(true));
+                assertThat(logger.isErrorEnabled()).isTrue();
                 break;
             case WARN:
-                assertThat(logger.isWarnEnabled(), equalTo(true));
+                assertThat(logger.isWarnEnabled()).isTrue();
                 break;
             case INFO:
-                assertThat(logger.isInfoEnabled(), equalTo(true));
+                assertThat(logger.isInfoEnabled()).isTrue();
                 break;
             case DEBUG:
-                assertThat(logger.isDebugEnabled(), equalTo(true));
+                assertThat(logger.isDebugEnabled()).isTrue();
                 break;
             case TRACE:
-                assertThat(logger.isTraceEnabled(), equalTo(true));
+                assertThat(logger.isTraceEnabled()).isTrue();
                 break;
 
             default:
                 fail("Invalid level: " + level);
                 break;
         }
-        assertThat(delegate.invocationCount(), equalTo(1));
+        assertThat(delegate.invocationCount()).isEqualTo(1);
     }
 
 

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
@@ -16,9 +16,7 @@
 
 package com.palantir.tritium.proxy;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.tritium.api.functions.BooleanSupplier;
@@ -41,10 +39,10 @@ public class InvocationEventProxyTest {
     public void testDisabled() throws Throwable {
         BooleanSupplier disabled = BooleanSupplier.FALSE;
         InvocationEventProxy<InvocationContext> proxy = new InvocationEventProxy<InvocationContext>(
-                disabled, Collections.<InvocationEventHandler<InvocationContext>>emptyList()) {
+                disabled, Collections.emptyList()) {
             @Override
             Object getDelegate() {
-                return this;
+                return "disabled";
             }
         };
         proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS);
@@ -54,23 +52,24 @@ public class InvocationEventProxyTest {
     @SuppressWarnings("checkstyle:illegalthrows")
     public void testInstrumentPreInvocation() throws Throwable {
         InvocationEventHandler<InvocationContext> testHandler = new SimpleHandler();
-        InvocationEventProxy<InvocationContext> proxy = createBasicProxy(ImmutableList.of(testHandler));
+        InvocationEventProxy<InvocationContext> proxy = createTestProxy(ImmutableList.of(testHandler));
 
         Object result = proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS);
 
-        assertNotNull(result);
-        assertThat(result.toString(), containsString(InvocationEventProxyTest.class.getName()));
+        assertThat(result).isNotNull();
+        assertThat(result.toString()).isEqualTo("test");
 
         result = proxy.handlePreInvocation(this, getToStringMethod(), EMPTY_ARGS);
-        assertNotNull(result);
-        assertThat(result.toString(), containsString(InvocationEventProxyTest.class.getName()));
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(DefaultInvocationContext.class);
+        assertThat(result.toString()).contains(InvocationEventProxyTest.class.getName());
 
         InvocationContext context = proxy.handlePreInvocation(this, getToStringMethod(), EMPTY_ARGS);
-        assertNotNull(context);
-        assertThat(context.toString(), containsString("startTimeNanos"));
-        assertThat(context.toString(), containsString("instance"));
-        assertThat(context.toString(), containsString("method"));
-        assertThat(context.toString(), containsString("args"));
+        assertThat(context).isNotNull();
+        assertThat(context.toString()).contains("startTimeNanos");
+        assertThat(context.toString()).contains("instance");
+        assertThat(context.toString()).contains("method");
+        assertThat(context.toString()).contains("args");
     }
 
     @Test
@@ -82,12 +81,12 @@ public class InvocationEventProxyTest {
                 throw new IllegalStateException("expected");
             }
         };
-        InvocationEventProxy<InvocationContext> proxy = createBasicProxy(ImmutableList.of(testHandler));
+        InvocationEventProxy<InvocationContext> proxy = createTestProxy(ImmutableList.of(testHandler));
 
         Object result = proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS);
 
-        assertNotNull(result);
-        assertThat(result.toString(), containsString(InvocationEventProxyTest.class.getName()));
+        assertThat(result).isNotNull();
+        assertThat(result.toString()).isEqualTo("test");
     }
 
     @Test
@@ -100,12 +99,12 @@ public class InvocationEventProxyTest {
             }
         };
 
-        InvocationEventProxy<InvocationContext> proxy = createBasicProxy(ImmutableList.of(testHandler));
+        InvocationEventProxy<InvocationContext> proxy = createTestProxy(ImmutableList.of(testHandler));
 
         Object result = proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS);
 
-        assertNotNull(result);
-        assertThat(result.toString(), containsString(InvocationEventProxyTest.class.getName()));
+        assertThat(result).isNotNull();
+        assertThat(result.toString()).isEqualTo("test");
 
         InvocationContext context = DefaultInvocationContext.of(this, getToStringMethod(), null);
         proxy.handleOnSuccess(context, result);
@@ -126,12 +125,12 @@ public class InvocationEventProxyTest {
             }
         };
 
-        InvocationEventProxy<InvocationContext> proxy = createBasicProxy(ImmutableList.of(testHandler));
+        InvocationEventProxy<InvocationContext> proxy = createTestProxy(ImmutableList.of(testHandler));
 
         Object result = proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS);
 
-        assertNotNull(result);
-        assertThat(result.toString(), containsString(InvocationEventProxyTest.class.getName()));
+        assertThat(result).isNotNull();
+        assertThat(result.toString()).isEqualTo("test");
 
         InvocationContext context = DefaultInvocationContext.of(this, getToStringMethod(), null);
         throw proxy.handleOnFailure(context, new RuntimeException("expected"));
@@ -139,19 +138,17 @@ public class InvocationEventProxyTest {
 
     @Test
     public void testToInvocationDebugString() throws Exception {
-        InvocationEventProxy<InvocationContext> proxy = createBasicProxy(
-                Collections.<InvocationEventHandler<InvocationContext>>emptyList());
 
         Throwable cause = new RuntimeException("cause");
-        proxy.logInvocationWarning("test", this, getToStringMethod(), null, cause);
+        InvocationEventProxy.logInvocationWarning("test", this, getToStringMethod(), null, cause);
     }
 
-    private InvocationEventProxy<InvocationContext> createBasicProxy(
+    private InvocationEventProxy<InvocationContext> createTestProxy(
             List<InvocationEventHandler<InvocationContext>> handlers) {
         return new InvocationEventProxy<InvocationContext>(handlers) {
             @Override
             Object getDelegate() {
-                return this;
+                return "test";
             }
         };
     }

--- a/tritium-metrics/build.gradle
+++ b/tritium-metrics/build.gradle
@@ -1,27 +1,28 @@
 apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
+
     processor "org.immutables:value"
 
-    compile project(':tritium-api')
-    compile project(':tritium-core')
+    api project(':tritium-api')
+    api project(':tritium-core')
+    api 'io.dropwizard.metrics:metrics-core'
 
-    compile 'com.google.guava:guava'
-    compile 'com.palantir.safe-logging:safe-logging'
-    compile 'io.dropwizard.metrics:metrics-core'
-    compile ('org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir') {
+    implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:safe-logging'
+    implementation ('org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir') {
         exclude group: 'io.dropwizard.metrics', module: 'metrics-core'
         exclude group: 'org.hdrhistogram', module: 'HdrHistogram'
     }
-    compile 'org.hdrhistogram:HdrHistogram'
-    compile 'org.slf4j:slf4j-api'
+    implementation 'org.hdrhistogram:HdrHistogram'
+    implementation 'org.slf4j:slf4j-api'
 
-    testCompile project(':tritium-test')
-    testCompile 'ch.qos.logback:logback-classic'
-    testCompile 'com.google.guava:guava-testlib'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.hamcrest:hamcrest-all'
-    testCompile 'org.mockito:mockito-all'
+    testImplementation project(':tritium-test')
+    testImplementation 'ch.qos.logback:logback-classic'
+    testImplementation 'com.google.guava:guava-testlib'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-all'
+
 }
 

--- a/tritium-proxy/build.gradle
+++ b/tritium-proxy/build.gradle
@@ -1,11 +1,12 @@
 apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
-    testCompile project(':tritium-test')
-    testCompile 'com.google.guava:guava-testlib'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.hamcrest:hamcrest-all'
-    testCompile 'org.mockito:mockito-all'
-    testCompile 'org.slf4j:slf4j-simple'
+
+    testImplementation project(':tritium-test')
+    testImplementation 'com.google.guava:guava-testlib'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-all'
+    testImplementation 'org.slf4j:slf4j-simple'
+    
 }

--- a/tritium-registry/build.gradle
+++ b/tritium-registry/build.gradle
@@ -1,15 +1,16 @@
 apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
+
     processor 'com.google.auto.service:auto-service'
     processor 'org.immutables:value'
 
-    compile 'com.google.guava:guava'
-    compile 'com.palantir.safe-logging:safe-logging'
-    compile 'io.dropwizard.metrics:metrics-core'
+    implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:safe-logging'
+    implementation 'io.dropwizard.metrics:metrics-core'
 
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.mockito:mockito-all'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-all'
 }
 

--- a/tritium-slf4j/build.gradle
+++ b/tritium-slf4j/build.gradle
@@ -1,17 +1,20 @@
 apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
-    compile project(':tritium-api')
-    compile project(':tritium-core')
-    compile 'com.palantir.safe-logging:safe-logging'
-    compile 'org.slf4j:slf4j-api'
 
-    testCompile project(':tritium-test')
-    testCompile 'com.google.guava:guava-testlib'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.hamcrest:hamcrest-all'
-    testCompile 'org.mockito:mockito-all'
-    testCompile 'org.slf4j:slf4j-simple'
+    api project(':tritium-api')
+    api project(':tritium-core')
+
+    implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:safe-logging'
+    implementation 'org.slf4j:slf4j-api'
+
+    testImplementation project(':tritium-test')
+    testImplementation 'com.google.guava:guava-testlib'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-all'
+    testImplementation 'org.slf4j:slf4j-simple'
+
 }
 

--- a/tritium-test/build.gradle
+++ b/tritium-test/build.gradle
@@ -1,14 +1,16 @@
 dependencies {
-    compile project(':tritium-core')
-    compile 'com.google.guava:guava'
-    compile 'com.palantir.safe-logging:safe-logging'
-    compile 'io.dropwizard.metrics:metrics-core'
-    compile 'org.slf4j:slf4j-api'
 
-    testCompile 'com.google.guava:guava-testlib'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.hamcrest:hamcrest-all'
-    testCompile 'org.mockito:mockito-all'
-    testCompile 'org.slf4j:slf4j-simple'
+    api 'org.slf4j:slf4j-api'
+
+    implementation project(':tritium-core')
+    implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:safe-logging'
+    implementation 'io.dropwizard.metrics:metrics-core'
+
+    testImplementation 'com.google.guava:guava-testlib'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-all'
+    testImplementation 'org.slf4j:slf4j-simple'
+
 }

--- a/tritium-tracing/build.gradle
+++ b/tritium-tracing/build.gradle
@@ -1,20 +1,20 @@
 apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
-    compile project(':tritium-api')
-    compile project(':tritium-core')
 
-    compile 'com.palantir.remoting3:tracing'
-    compile 'com.palantir.safe-logging:safe-logging'
-    compile 'org.slf4j:slf4j-api'
+    api project(':tritium-api')
+    api project(':tritium-core')
+    api 'com.palantir.remoting3:tracing'
 
-    testCompile project(':tritium-test')
+    implementation 'com.palantir.safe-logging:safe-logging'
+    implementation 'org.slf4j:slf4j-api'
 
-    testCompile 'ch.qos.logback:logback-classic'
-    testCompile 'com.google.guava:guava-testlib'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.hamcrest:hamcrest-all'
-    testCompile 'org.mockito:mockito-all'
+    testImplementation project(':tritium-test')
+
+    testImplementation 'ch.qos.logback:logback-classic'
+    testImplementation 'com.google.guava:guava-testlib'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-all'
+
 }
-

--- a/versions.props
+++ b/versions.props
@@ -12,7 +12,6 @@ io.zipkin.brave:* = 3.11.1
 io.zipkin.java:* = 1.12.1
 junit:junit = 4.12
 org.assertj:assertj-core = 3.8.0
-org.hamcrest:* = 1.3
 org.hdrhistogram:* = 2.1.10
 org.immutables:* = 2.5.6
 org.mockito:* = 1.10.19


### PR DESCRIPTION
Use api and implementation configurations of java-library per https://docs.gradle.org/current/userguide/java_library_plugin.html

Replace remaining uses of hamcrest with assertj