### PR TITLE
Implement toString for InvocationEventProxy

### DIFF
--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
@@ -73,6 +73,11 @@ abstract class InvocationEventProxy<C extends InvocationContext>
      */
     abstract Object getDelegate();
 
+    @Override
+    public String toString() {
+        return String.valueOf(getDelegate());
+    }
+
     /**
      * Returns true if instrumentation handling is enabled, otherwise false.
      *

--- a/tritium-lib/src/test/java/com/palantir/tritium/TritiumTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/TritiumTest.java
@@ -100,4 +100,12 @@ public class TritiumTest {
                 .getCount())
                 .isEqualTo(1);
     }
+
+    @Test
+    public void testToString() {
+        assertThat(instrumentedService.toString()).isEqualTo(TestImplementation.class.getName());
+
+        assertThat(Tritium.instrument(TestInterface.class, instrumentedService, metricRegistry).toString())
+                .isEqualTo(TestImplementation.class.getName());
+    }
 }

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
@@ -138,9 +138,21 @@ public class InvocationEventProxyTest {
 
     @Test
     public void testToInvocationDebugString() throws Exception {
-
         Throwable cause = new RuntimeException("cause");
         InvocationEventProxy.logInvocationWarning("test", this, getToStringMethod(), null, cause);
+    }
+
+    @Test
+    public void testInstrumentToString() {
+        List<InvocationEventHandler<InvocationContext>> handlers = Collections.emptyList();
+        InvocationEventProxy<InvocationContext> proxy = new InvocationEventProxy<InvocationContext>(handlers) {
+            @Override
+            Object getDelegate() {
+                return "Hello, world";
+            }
+        };
+
+        assertThat(proxy.toString()).isEqualTo("Hello, world");
     }
 
     private InvocationEventProxy<InvocationContext> createTestProxy(

--- a/tritium-test/src/main/java/com/palantir/tritium/test/TestImplementation.java
+++ b/tritium-test/src/main/java/com/palantir/tritium/test/TestImplementation.java
@@ -73,4 +73,9 @@ public class TestImplementation implements TestInterface, Runnable {
             super(message);
         }
     }
+
+    @Override
+    public String toString() {
+        return TestImplementation.class.getName();
+    }
 }


### PR DESCRIPTION
Route InvocationEventProxy.toString() to delegate toString()

Closes #86 