### PR TITLE
Add metric for maximum size of cache

### DIFF
--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheMetricSet.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheMetricSet.java
@@ -95,6 +95,15 @@ final class CaffeineCacheMetricSet implements MetricSet {
                     }
                 });
 
+        cache.policy().eviction().ifPresent(eviction -> cacheMetrics.put(
+                cacheMetricName("maximum", "size"),
+                new CachedGauge<Long>(clock, 500, TimeUnit.MILLISECONDS) {
+                    @Override
+                    protected Long loadValue() {
+                        return eviction.getMaximum();
+                    }
+                }));
+
         cacheMetrics.put(cacheMetricName("request", "count"),
                 derivedGauge(CacheStats::requestCount));
 

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheMetricSet.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheMetricSet.java
@@ -95,14 +95,19 @@ final class CaffeineCacheMetricSet implements MetricSet {
                     }
                 });
 
-        cache.policy().eviction().ifPresent(eviction -> cacheMetrics.put(
-                cacheMetricName("maximum", "size"),
-                new CachedGauge<Long>(clock, 500, TimeUnit.MILLISECONDS) {
-                    @Override
-                    protected Long loadValue() {
-                        return eviction.getMaximum();
-                    }
-                }));
+        cache.policy().eviction().ifPresent(eviction -> {
+            eviction.weightedSize().ifPresent(weightedSize -> cacheMetrics.put(
+                    cacheMetricName("weighted", "size"),
+                    (Gauge<Long>) () -> weightedSize));
+            cacheMetrics.put(
+                    cacheMetricName("maximum", "size"),
+                    new CachedGauge<Long>(clock, 500, TimeUnit.MILLISECONDS) {
+                        @Override
+                        protected Long loadValue() {
+                            return eviction.getMaximum();
+                        }
+                    });
+        });
 
         cacheMetrics.put(cacheMetricName("request", "count"),
                 derivedGauge(CacheStats::requestCount));

--- a/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheMetricSetTest.java
+++ b/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheMetricSetTest.java
@@ -26,12 +26,15 @@ import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Policy;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.metrics.TestClock;
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -45,6 +48,19 @@ public class CaffeineCacheMetricSetTest {
 
     @Mock
     private LoadingCache<Integer, String> cache;
+
+    @Mock
+    private Policy<Integer, String> policy;
+
+    @Mock
+    private Policy.Eviction<Integer, String> evictionPolicy;
+
+    @Before
+    public void before() throws Exception {
+        when(cache.policy()).thenReturn(policy);
+        when(policy.eviction()).thenReturn(Optional.of(evictionPolicy));
+        when(evictionPolicy.getMaximum()).thenReturn(1234L);
+    }
 
     @After
     public void after() {
@@ -68,6 +84,7 @@ public class CaffeineCacheMetricSetTest {
                 "test1.cache.load.average.millis",
                 "test1.cache.load.failure.count",
                 "test1.cache.load.success.count",
+                "test1.cache.maximum.size",
                 "test1.cache.miss.count",
                 "test1.cache.miss.ratio",
                 "test1.cache.request.count"
@@ -116,6 +133,7 @@ public class CaffeineCacheMetricSetTest {
                 "test2.cache.load.average.millis",
                 "test2.cache.load.failure.count",
                 "test2.cache.load.success.count",
+                "test2.cache.maximum.size",
                 "test2.cache.miss.count",
                 "test2.cache.miss.ratio",
                 "test2.cache.request.count");


### PR DESCRIPTION
We use a Caffeine to cache all rows of a small view of our DB, since we have an endpoint which requires us to fetch such view regularly.

The size of the cache is also configurable in the configuration of the service. We're planning on adding alerts if the cache is close to being full (in order to evaluate if we can and should increase the cache). In order to add that alert, we need the metric of the maximum size that the cache was configured to use.

I could instrument this locally, on my service, but also think this might be useful in other services which have configurable caches thus I'm adding this here.