### PR TITLE
Enforce additional error-prone checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,22 @@ allprojects {
     }
 
     tasks.withType(JavaCompile).configureEach {
-        options.errorprone.errorproneArgs += ['-Xep:Slf4jLogsafeArgs:ERROR']
+        options.errorprone.errorproneArgs += [
+            '-Werror',
+            '-Xlint:deprecation',
+            '-XepDisableWarningsInGeneratedCode',
+            '-XepExcludedPaths:.*/build/.*generated.*',
+            '-Xep:AmbiguousMethodReference:ERROR',
+            '-Xep:BoxedPrimitiveConstructor:ERROR',
+            '-Xep:CatchFail:ERROR',
+            '-Xep:ClassCanBeStatic:ERROR',
+            '-Xep:DefaultCharset:ERROR',
+            '-Xep:FunctionalInterfaceClash:ERROR',
+            '-Xep:MethodCanBeStatic:ERROR',
+            '-Xep:NonCanonicalStaticMemberImport:ERROR',
+            '-Xep:ReturnMissingNullable:ERROR',
+            '-Xep:Slf4jLogsafeArgs:ERROR',
+        ]
     }
 
     tasks.withType(Test) {

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheMetricSet.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheMetricSet.java
@@ -54,7 +54,7 @@ final class CaffeineCacheMetricSet implements MetricSet {
                 createCachedCacheStats(cache, clock, 5, TimeUnit.SECONDS));
     }
 
-    private <T> Gauge<T> derivedGauge(final Function<CacheStats, T> gauge) {
+    private <T> Gauge<T> derivedGauge(Function<CacheStats, T> gauge) {
         return transformingGauge(statsGauge, gauge);
     }
 

--- a/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheMetricSetTest.java
+++ b/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheMetricSetTest.java
@@ -95,7 +95,7 @@ public class CaffeineCacheMetricSetTest {
                 "test1.cache.weighted.size"
         );
 
-        when(cache.stats()).thenReturn(new CacheStats(1L, 2L, 3L, 4L, 5L, 6L));
+        when(cache.stats()).thenReturn(new CacheStats(1L, 2L, 3L, 4L, 5L, 6L, 7L));
         when(cache.estimatedSize()).thenReturn(42L);
 
         SortedMap<String, Gauge> gauges = metrics.getGauges();
@@ -114,7 +114,7 @@ public class CaffeineCacheMetricSetTest {
         verify(cache, times(1)).stats();
 
         clock.advance(1, TimeUnit.MINUTES); // let stats snapshot cache expire
-        when(cache.stats()).thenReturn(new CacheStats(11L, 12L, 13L, 14L, 15L, 16L));
+        when(cache.stats()).thenReturn(new CacheStats(11L, 12L, 13L, 14L, 15L, 16L, 17L));
         when(cache.estimatedSize()).thenReturn(37L);
 
         gauges = metrics.getGauges();
@@ -147,7 +147,7 @@ public class CaffeineCacheMetricSetTest {
                 "test2.cache.weighted.size"
         );
 
-        when(cache.stats()).thenReturn(new CacheStats(0L, 0L, 0L, 0L, 0L, 0L));
+        when(cache.stats()).thenReturn(new CacheStats(0L, 0L, 0L, 0L, 0L, 0L, 0L));
         assertThat(metrics.getGauges().get("test2.cache.request.count").getValue()).isEqualTo(0L);
         assertThat(metrics.getGauges().get("test2.cache.hit.count").getValue()).isEqualTo(0L);
         assertThat(metrics.getGauges().get("test2.cache.hit.ratio").getValue()).isEqualTo(Double.NaN);
@@ -161,7 +161,7 @@ public class CaffeineCacheMetricSetTest {
 
     @Test
     public void testDerivedGauge() {
-        when(cache.stats()).thenReturn(new CacheStats(1L, 2L, 3L, 4L, 5L, 6L));
+        when(cache.stats()).thenReturn(new CacheStats(1L, 2L, 3L, 4L, 5L, 6L, 7L));
         Gauge<CacheStats> cachedCacheStats = CaffeineCacheMetricSet.createCachedCacheStats(cache, clock,
                 15, TimeUnit.SECONDS);
         CacheStats value1 = cachedCacheStats.getValue();

--- a/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
@@ -36,16 +36,24 @@ public abstract class AbstractInvocationEventHandler<C extends InvocationContext
      * Always enabled instrumentation handler.
      */
     protected AbstractInvocationEventHandler() {
-        this(com.palantir.tritium.api.functions.BooleanSupplier.TRUE);
+        this((java.util.function.BooleanSupplier) () -> true);
     }
 
     /**
      * Bridge for backward compatibility.
+     * @deprecated Use {@link #AbstractInvocationEventHandler(java.util.function.BooleanSupplier)}
      */
+    @Deprecated
+    @SuppressWarnings("FunctionalInterfaceClash") // back compat
     protected AbstractInvocationEventHandler(com.palantir.tritium.api.functions.BooleanSupplier isEnabledSupplier) {
         this((java.util.function.BooleanSupplier) isEnabledSupplier);
     }
 
+    /**
+     * Constructs {@link AbstractInvocationEventHandler} with specified enabled supplier.
+     * @param isEnabledSupplier enabled supplier
+     */
+    @SuppressWarnings("FunctionalInterfaceClash")
     protected AbstractInvocationEventHandler(java.util.function.BooleanSupplier isEnabledSupplier) {
         this.isEnabledSupplier = checkNotNull(isEnabledSupplier, "isEnabledSupplier");
     }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
@@ -131,7 +131,7 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
                 exception);
     }
 
-    private void handleSuccess(InvocationEventHandler<?> handler,
+    private static void handleSuccess(InvocationEventHandler<?> handler,
             @Nullable InvocationContext context,
             @Nullable Object result) {
 
@@ -146,7 +146,7 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
         }
     }
 
-    private void handleFailure(InvocationEventHandler<?> handler,
+    private static void handleFailure(InvocationEventHandler<?> handler,
             @Nullable InvocationContext context,
             Throwable cause) {
 

--- a/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationFilters.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationFilters.java
@@ -17,7 +17,6 @@
 package com.palantir.tritium.event;
 
 import com.palantir.tritium.api.event.InstrumentationFilter;
-import com.palantir.tritium.api.functions.BooleanSupplier;
 import java.lang.reflect.Method;
 import javax.annotation.Nonnull;
 
@@ -37,8 +36,20 @@ public enum InstrumentationFilters implements InstrumentationFilter {
         }
     };
 
-    public static InstrumentationFilter from(final BooleanSupplier isEnabledSupplier) {
+    @SuppressWarnings("FunctionalInterfaceClash")
+    public static InstrumentationFilter from(java.util.function.BooleanSupplier isEnabledSupplier) {
         return (instance, method, args) ->
-                isEnabledSupplier.asBoolean();
+                isEnabledSupplier.getAsBoolean();
     }
+
+    /**
+     * Bridge for backward compatibility.
+     * @deprecated use {@link #from(java.util.function.BooleanSupplier)}
+     */
+    @Deprecated
+    @SuppressWarnings("FunctionalInterfaceClash") // back compat
+    public static InstrumentationFilter from(com.palantir.tritium.api.functions.BooleanSupplier isEnabledSupplier) {
+        return from((java.util.function.BooleanSupplier) isEnabledSupplier);
+    }
+
 }

--- a/tritium-core/src/test/java/com/palantir/tritium/event/CompositeInvocationEventHandlerTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/CompositeInvocationEventHandlerTest.java
@@ -156,7 +156,7 @@ public class CompositeInvocationEventHandlerTest {
         return Object.class.getDeclaredMethod("toString");
     }
 
-    private InvocationEventHandler<InvocationContext> createThrowingHandler(final boolean isEnabled) {
+    private static InvocationEventHandler<InvocationContext> createThrowingHandler(boolean isEnabled) {
         return new ThrowingInvocationEventHandler(isEnabled);
     }
 

--- a/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationFiltersTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationFiltersTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import com.palantir.tritium.api.event.InstrumentationFilter;
-import com.palantir.tritium.api.functions.BooleanSupplier;
 import com.palantir.tritium.test.TestImplementation;
 import com.palantir.tritium.test.TestInterface;
 import java.lang.reflect.Method;
@@ -28,9 +27,9 @@ import org.junit.Test;
 
 public class InstrumentationFiltersTest {
 
-    private TestInterface instance = mock(TestImplementation.class);
-    private Method method = testMethod();
-    private Object[] args = new Object[0];
+    private final TestInterface instance = mock(TestImplementation.class);
+    private final Method method = testMethod();
+    private final Object[] args = new Object[0];
 
     @Test
     public void testInstrumentAll() {
@@ -44,13 +43,13 @@ public class InstrumentationFiltersTest {
 
     @Test
     public void testFromTrueSupplier() {
-        InstrumentationFilter filter = InstrumentationFilters.from(BooleanSupplier.TRUE);
+        InstrumentationFilter filter = InstrumentationFilters.from((java.util.function.BooleanSupplier) () -> true);
         assertThat(filter.shouldInstrument(instance, method, args)).isTrue();
     }
 
     @Test
     public void testFromFalseSupplier() {
-        InstrumentationFilter filter = InstrumentationFilters.from(BooleanSupplier.FALSE);
+        InstrumentationFilter filter = InstrumentationFilters.from((java.util.function.BooleanSupplier) () -> false);
         assertThat(filter.shouldInstrument(instance, method, args)).isFalse();
     }
 

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/InstrumentationProxy.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/InstrumentationProxy.java
@@ -27,7 +27,7 @@ class InstrumentationProxy<T> extends InvocationEventProxy<InvocationContext> {
 
     InstrumentationProxy(InstrumentationFilter instrumentationFilter,
             List<InvocationEventHandler<InvocationContext>> handlers, T delegate) {
-        super(instrumentationFilter, handlers);
+        super(handlers, instrumentationFilter);
         this.delegate = delegate;
     }
 

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
@@ -22,7 +22,6 @@ import com.google.common.reflect.AbstractInvocationHandler;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.tritium.api.event.InstrumentationFilter;
-import com.palantir.tritium.api.functions.BooleanSupplier;
 import com.palantir.tritium.event.CompositeInvocationEventHandler;
 import com.palantir.tritium.event.InstrumentationFilters;
 import com.palantir.tritium.event.InvocationContext;
@@ -51,16 +50,11 @@ abstract class InvocationEventProxy<C extends InvocationContext>
      * @param handlers event handlers
      */
     protected InvocationEventProxy(List<InvocationEventHandler<InvocationContext>> handlers) {
-        this(InstrumentationFilters.INSTRUMENT_ALL, handlers);
+        this(handlers, InstrumentationFilters.INSTRUMENT_ALL);
     }
 
-    protected InvocationEventProxy(BooleanSupplier isEnabledSupplier,
-            List<InvocationEventHandler<InvocationContext>> handlers) {
-        this(InstrumentationFilters.from(isEnabledSupplier), handlers);
-    }
-
-    protected InvocationEventProxy(InstrumentationFilter filter,
-            List<InvocationEventHandler<InvocationContext>> handlers) {
+    protected InvocationEventProxy(List<InvocationEventHandler<InvocationContext>> handlers,
+                                   InstrumentationFilter filter) {
         checkNotNull(filter, "filter");
         checkNotNull(handlers, "handlers");
         this.eventHandler = CompositeInvocationEventHandler.of(handlers);

--- a/tritium-lib/src/test/java/com/palantir/tritium/TritiumTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/TritiumTest.java
@@ -35,9 +35,9 @@ public class TritiumTest {
 
     private static final String EXPECTED_METRIC_NAME = TestInterface.class.getName() + ".test";
 
-    private TestImplementation delegate = new TestImplementation();
-    private MetricRegistry metricRegistry = MetricRegistries.createWithHdrHistogramReservoirs();
-    private TestInterface instrumentedService = Tritium.instrument(TestInterface.class, delegate, metricRegistry);
+    private final TestImplementation delegate = new TestImplementation();
+    private final MetricRegistry metricRegistry = MetricRegistries.createWithHdrHistogramReservoirs();
+    private final TestInterface instrumentedService = Tritium.instrument(TestInterface.class, delegate, metricRegistry);
 
     @After
     public void after() {

--- a/tritium-lib/src/test/java/com/palantir/tritium/event/log/LoggingInstrumentationTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/event/log/LoggingInstrumentationTest.java
@@ -93,7 +93,7 @@ public class LoggingInstrumentationTest {
     }
 
 
-    private void testLoggingAtLevel(LoggingLevel level) {
+    private static void testLoggingAtLevel(LoggingLevel level) {
         TestImplementation delegate = new TestImplementation();
         enableLoggingForLevel(level);
         Logger logger = getLogger();

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
@@ -22,7 +22,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.logsafe.UnsafeArg;
-import com.palantir.tritium.api.functions.BooleanSupplier;
 import com.palantir.tritium.event.AbstractInvocationEventHandler;
 import com.palantir.tritium.event.DefaultInvocationContext;
 import com.palantir.tritium.event.InstrumentationProperties;
@@ -97,7 +96,7 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
         return builder.build();
     }
 
-    static BooleanSupplier getEnabledSupplier(final String serviceName) {
+    static java.util.function.BooleanSupplier getEnabledSupplier(String serviceName) {
         return InstrumentationProperties.getSystemPropertySupplier(serviceName);
     }
 

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/annotations/AnnotationHelper.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/annotations/AnnotationHelper.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 public final class AnnotationHelper {
 
@@ -38,6 +39,7 @@ public final class AnnotationHelper {
      * @param annotation - Annotation type to scan for
      * @return - First matching annotation found in depth first search, or null if not found
      */
+    @Nullable
     public static <T extends Annotation> T getSuperTypeAnnotation(Class<?> clazz, Class<T> annotation) {
         if (clazz.isAnnotationPresent(annotation)) {
             return clazz.getAnnotation(annotation);
@@ -62,6 +64,7 @@ public final class AnnotationHelper {
      * @param methodSignature - Method to search annotation for
      * @return - First found matching annotation or null
      */
+    @Nullable
     public static <T extends Annotation> T getMethodAnnotation(
             Class<T> annotation, Class<?> clazz, MethodSignature methodSignature) {
 

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/annotations/MetricGroup.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/annotations/MetricGroup.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
 public @interface MetricGroup {
     /**
      * String identifier grouped metrics.
-     * @return
+     * @return value
      */
     String value();
 }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/CacheMetricSet.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/CacheMetricSet.java
@@ -56,7 +56,7 @@ final class CacheMetricSet implements MetricSet {
                 createCachedCacheStats(cache, clock, 5, TimeUnit.SECONDS));
     }
 
-    private <T> Gauge<T> derivedGauge(final Function<CacheStats, T> gauge) {
+    private <T> Gauge<T> derivedGauge(Function<CacheStats, T> gauge) {
         return transformingGauge(statsGauge, gauge);
     }
 

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -67,7 +67,7 @@ public final class MetricRegistries {
     @VisibleForTesting
     static MetricRegistry createWithReservoirType(Supplier<Reservoir> reservoirSupplier) {
         MetricRegistry metrics = new MetricRegistryWithReservoirs(reservoirSupplier);
-        final String name = reservoirSupplier.get().getClass().getCanonicalName();
+        String name = reservoirSupplier.get().getClass().getCanonicalName();
         registerSafe(metrics, RESERVOIR_TYPE_METRIC_NAME, (Gauge<String>) () -> name);
         registerDefaultMetrics(metrics);
         return metrics;
@@ -98,12 +98,12 @@ public final class MetricRegistries {
         checkNotNull(name);
         checkNotNull(builder);
 
-        final Metric metric = metrics.getMetrics().get(name);
+        Metric metric = metrics.getMetrics().get(name);
         if (metric == null) {
             try {
                 return metrics.register(name, builder.newMetric());
             } catch (IllegalArgumentException e) {
-                final Metric added = metrics.getMetrics().get(name);
+                Metric added = metrics.getMetrics().get(name);
                 if (builder.isInstance(added)) {
                     return (T) added;
                 }
@@ -120,7 +120,7 @@ public final class MetricRegistries {
      * @param prefix metric name prefix
      * @return metric filter
      */
-    public static MetricFilter metricsPrefixedBy(final String prefix) {
+    public static MetricFilter metricsPrefixedBy(String prefix) {
         checkNotNull(prefix, "prefix");
         return (name, metric) -> name.startsWith(prefix);
     }
@@ -185,11 +185,11 @@ public final class MetricRegistries {
      *         interfaces as {@code metric}
      */
     public static <T extends Metric> T registerSafe(MetricRegistry registry, String name, T metric) {
-        return registerOrReplace(registry, name, metric, false);
+        return registerOrReplace(registry, name, metric, /* replace= */false);
     }
 
     public static <T extends Metric> T registerWithReplacement(MetricRegistry registry, String name, T metric) {
-        return registerOrReplace(registry, name, metric, true);
+        return registerOrReplace(registry, name, metric, /* replace= */true);
     }
 
     private static <T extends Metric> T registerOrReplace(MetricRegistry registry, String name, T metric,

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/Reservoirs.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/Reservoirs.java
@@ -47,7 +47,7 @@ final class Reservoirs {
         return hdrHistogramReservoirSupplier(twoSignificantDigits());
     }
 
-    static Supplier<Reservoir> hdrHistogramReservoirSupplier(final Supplier<Recorder> recorder) {
+    static Supplier<Reservoir> hdrHistogramReservoirSupplier(Supplier<Recorder> recorder) {
         checkNotNull(recorder, "recorder");
         return () -> new HdrHistogramReservoir(recorder.get());
     }

--- a/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/MetricsBooleanSupplierTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/MetricsBooleanSupplierTest.java
@@ -19,12 +19,12 @@ package com.palantir.tritium.event.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.palantir.tritium.api.functions.BooleanSupplier;
 import com.palantir.tritium.event.InstrumentationProperties;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -92,7 +92,7 @@ public class MetricsBooleanSupplierTest {
         System.setProperty("instrument.test", String.valueOf(service));
         InstrumentationProperties.reload();
         BooleanSupplier supplier = MetricsInvocationEventHandler.getEnabledSupplier("test");
-        assertThat(supplier.asBoolean()).isEqualTo(expected);
+        assertThat(supplier.getAsBoolean()).isEqualTo(expected);
     }
 
 }

--- a/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandlerTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandlerTest.java
@@ -89,7 +89,7 @@ public class MetricsInvocationEventHandlerTest {
 
     @Test
     public void testSystemPropertySupplier_Handler_Enabled() {
-        assertThat(MetricsInvocationEventHandler.getEnabledSupplier("test").asBoolean()).isTrue();
+        assertThat(MetricsInvocationEventHandler.getEnabledSupplier("test").getAsBoolean()).isTrue();
     }
 
     @Test
@@ -129,7 +129,7 @@ public class MetricsInvocationEventHandlerTest {
         assertThat(metricRegistry.timer(globalPrefix + ".ONE").getCount()).isEqualTo(2L);
     }
 
-    private void callVoidMethod(
+    private static void callVoidMethod(
             MetricsInvocationEventHandler handler, Object obj, String methodName, boolean success) throws Exception {
 
         InvocationContext context = DefaultInvocationContext.of(obj, obj.getClass().getMethod(methodName), null);

--- a/tritium-proxy/src/main/java/com/palantir/tritium/proxy/Proxies.java
+++ b/tritium-proxy/src/main/java/com/palantir/tritium/proxy/Proxies.java
@@ -56,14 +56,14 @@ public final class Proxies {
      * Determine the superset of interfaces for the specified arguments.
      *
      * @param iface primary interface class
-     * @param additionalInterfaces additional interfaces
      * @param delegateClass delegate class
+     * @param additionalInterfaces additional interfaces
      * @return the set of interfaces for the specified classes
      * @throws IllegalArgumentException if the specified interface class is not an interface
      */
     static Class<?>[] interfaces(Class<?> iface,
-                                 Collection<Class<?>> additionalInterfaces,
-                                 Class<?> delegateClass) {
+                                 Class<?> delegateClass,
+                                 Collection<Class<?>> additionalInterfaces) {
         checkIsInterface(iface);
         Objects.requireNonNull(additionalInterfaces, "additionalInterfaces");
         Objects.requireNonNull(delegateClass, "delegateClass");
@@ -89,7 +89,7 @@ public final class Proxies {
      * @throws IllegalArgumentException if the specified interface class is not an interface
      */
     static Class<?>[] interfaces(Class<?> iface, Class<?> delegateClass) {
-        return interfaces(iface, Collections.emptySet(), delegateClass);
+        return interfaces(iface, delegateClass, Collections.emptySet());
     }
 
     static void checkIsInterface(Class<?> iface) {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/MetricName.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/MetricName.java
@@ -16,6 +16,7 @@
 
 package com.palantir.tritium.metrics.registry;
 
+import com.palantir.logsafe.Safe;
 import java.util.Map;
 import org.immutables.value.Value;
 
@@ -30,14 +31,14 @@ public interface MetricName {
     /**
      * General/abstract measure (e.g. server.response-time).
      * <p>
-     * Names must be {@link com.palantir.logsafe.Safe} to log.
+     * Names must be {@link Safe} to log.
      */
     String safeName();
 
     /**
      * Metadata/coordinates for where a particular measure came from. Used for filtering & grouping.
      * <p>
-     * All tags and keys must be {@link com.palantir.logsafe.Safe} to log.
+     * All tags and keys must be {@link Safe} to log.
      */
     Map<String, String> safeTags();
 

--- a/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
+++ b/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
@@ -61,20 +61,24 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
     private final java.util.function.LongPredicate durationPredicate;
 
     public LoggingInvocationEventHandler(Logger logger, LoggingLevel level) {
-        this(logger, level, LOG_ALL_DURATIONS);
+        this(logger, level, (java.util.function.LongPredicate) LOG_ALL_DURATIONS);
     }
 
     /**
      * Bridge for backward compatibility.
+     * @deprecated uSe {@link #LoggingInvocationEventHandler(Logger, LoggingLevel, java.util.function.LongPredicate)}
      */
+    @Deprecated
+    @SuppressWarnings("FunctionalInterfaceClash") // back compat
     public LoggingInvocationEventHandler(Logger logger, LoggingLevel level,
             com.palantir.tritium.api.functions.LongPredicate durationPredicate) {
         this(logger, level, (java.util.function.LongPredicate) durationPredicate);
     }
 
+    @SuppressWarnings("FunctionalInterfaceClash") // back compat
     public LoggingInvocationEventHandler(Logger logger, LoggingLevel level,
             java.util.function.LongPredicate durationPredicate) {
-        super(createEnabledSupplier(logger, level));
+        super((java.util.function.BooleanSupplier) createEnabledSupplier(logger, level));
         this.logger = checkNotNull(logger, "logger");
         this.level = checkNotNull(level, "level");
         this.durationPredicate = checkNotNull(durationPredicate, "durationPredicate");
@@ -114,8 +118,8 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
         }
     }
 
-    @SuppressWarnings({"Slf4jConstantLogMessage", "Slf4jLogsafeArgs"})
-    // All message formats are generated with placeholders
+    // All message formats are generated with placeholders and safe args
+    @SuppressWarnings({"Slf4jConstantLogMessage", "Slf4jLogsafeArgs", "Var"})
     private void log(final String messageFormat, Object... args) {
         switch (level) {
             case TRACE:
@@ -159,7 +163,7 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
         return new IllegalArgumentException("Unsupported logging level " + level);
     }
 
-    private static BooleanSupplier createEnabledSupplier(final Logger logger, final LoggingLevel level) {
+    private static BooleanSupplier createEnabledSupplier(Logger logger, LoggingLevel level) {
         checkNotNull(logger, "logger");
         checkNotNull(level, "level");
         if (getSystemPropertySupplier(LoggingInvocationEventHandler.class).getAsBoolean()) {

--- a/tritium-slf4j/src/test/java/com/palantir/tritium/event/log/LoggingInvocationEventHandlerTest.java
+++ b/tritium-slf4j/src/test/java/com/palantir/tritium/event/log/LoggingInvocationEventHandlerTest.java
@@ -17,6 +17,7 @@
 package com.palantir.tritium.event.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -92,20 +93,22 @@ public class LoggingInvocationEventHandlerTest {
 
     }
 
-    private Logger getLogger() {
+    private static Logger getLogger() {
         return LoggerFactory.getLogger(LoggingInvocationEventHandlerTest.class);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testNullIsEnabled() {
-        //noinspection ConstantConditions
-        LoggingInvocationEventHandler.isEnabled(getLogger(), null);
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
+            //noinspection ConstantConditions
+            LoggingInvocationEventHandler.isEnabled(getLogger(), null);
+        });
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testNullLevel() {
-        //noinspection ConstantConditions
-        new LoggingInvocationEventHandler(getLogger(), null);
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() ->
+                new LoggingInvocationEventHandler(getLogger(), null));
     }
 
     @Test
@@ -162,7 +165,7 @@ public class LoggingInvocationEventHandlerTest {
         assertThat(LoggingInvocationEventHandler.LOG_DURATIONS_GREATER_THAN_1_MICROSECOND)
                 .isInstanceOf(com.palantir.tritium.api.functions.LongPredicate.class);
 
-        com.palantir.tritium.api.functions.LongPredicate legacyPredicate = input -> false;
+        java.util.function.LongPredicate legacyPredicate = input -> false;
         assertThat(new LoggingInvocationEventHandler(getLogger(), LoggingLevel.TRACE, legacyPredicate)).isNotNull();
     }
 

--- a/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java
+++ b/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java
@@ -36,7 +36,7 @@ public final class TracingInvocationEventHandler extends AbstractInvocationEvent
     private final String component;
 
     public TracingInvocationEventHandler(String component) {
-        super(getEnabledSupplier(component));
+        super((java.util.function.BooleanSupplier) getEnabledSupplier(component));
         this.component = component;
     }
 
@@ -65,7 +65,7 @@ public final class TracingInvocationEventHandler extends AbstractInvocationEvent
         Tracer.fastCompleteSpan();
     }
 
-    private void debugIfNullContext(@Nullable InvocationContext context) {
+    private static void debugIfNullContext(@Nullable InvocationContext context) {
         if (context == null) {
             logger.debug("Encountered null metric context likely due to exception in preInvocation");
         }


### PR DESCRIPTION
Skips generated code per:
-   DisableWarningsInGeneratedCode
-   ExcludedPaths:.*/build/.*generated.*

Fix deprecation warnings
Treats warnings as errors

Enables following checks as error:
-   AmbiguousMethodReference
-   BoxedPrimitiveConstructor
-   CatchFail
-   ClassCanBeStatic
-   DefaultCharset
-   FunctionalInterfaceClash
-   MethodCanBeStatic
-   NonCanonicalStaticMemberImport
-   ReturnMissingNullable
-   Slf4jLogsafeArgs