### PR TITLE
Enable error-prone for JMH benchmarks

### DIFF
--- a/tritium-jmh/build.gradle
+++ b/tritium-jmh/build.gradle
@@ -14,7 +14,14 @@ buildscript {
 
 apply plugin: 'me.champeau.gradle.jmh'
 
+tasks.jmhCompileGeneratedClasses {
+    options.annotationProcessorPath = configurations.errorprone
+    options.errorprone.enabled = true
+}
+
 dependencies {
+
+    annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
 
     jmh project(':tritium-lib')
     jmh 'ch.qos.logback:logback-classic'


### PR DESCRIPTION
Enables error-prone compatibility with the JMH gradle compile phase per https://github.com/tbroyer/gradle-errorprone-plugin/blob/master/README.md#usage