### PR TITLE
Exclude method arguments from invocation context toString()

### DIFF
--- a/tritium-core/src/main/java/com/palantir/tritium/event/DefaultInvocationContext.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/DefaultInvocationContext.java
@@ -19,7 +19,6 @@ package com.palantir.tritium.event;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import javax.annotation.Nullable;
 
 public class DefaultInvocationContext implements InvocationContext {
@@ -73,8 +72,9 @@ public class DefaultInvocationContext implements InvocationContext {
     @Override
     @SuppressWarnings("DesignForExtension")
     public String toString() {
-        return "DefaultInvocationContext [startTimeNanos=" + startTimeNanos + ", instance=" + instance + ", method="
-                + method + ", args=" + Arrays.toString(args) + "]";
+        return "DefaultInvocationContext [startTimeNanos=" + startTimeNanos
+                + ", instance=" + instance
+                + ", method=" + method + ']';
     }
 
 }

--- a/tritium-core/src/test/java/com/palantir/tritium/event/DefaultInvocationContextTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/DefaultInvocationContextTest.java
@@ -24,17 +24,20 @@ public class DefaultInvocationContextTest {
 
     @Test
     public void testFactory() throws Exception {
-        InvocationContext context = DefaultInvocationContext.of(this, Object.class.getDeclaredMethod("toString"), null);
+        InvocationContext context =
+                DefaultInvocationContext.of(this, Object.class.getDeclaredMethod("equals", Object.class),
+                        new Object[] {"42"});
 
         assertThat(context.getInstance()).isEqualTo(this);
-        assertThat(context.getArgs()).isEqualTo(new Object[0]);
-        assertThat(context.getMethod()).isEqualTo(Object.class.getDeclaredMethod("toString"));
+        assertThat(context.getArgs()).isEqualTo(new Object[]{"42"});
+        assertThat(context.getMethod()).isEqualTo(Object.class.getDeclaredMethod("equals", Object.class));
 
         String toString = context.toString();
         assertThat(toString).contains("startTimeNanos");
         assertThat(toString).contains("instance");
         assertThat(toString).contains("method");
-        assertThat(toString).contains("args");
+        assertThat(toString).doesNotContain("args");
+        assertThat(toString).doesNotContain("42");
     }
 
 }

--- a/tritium-core/src/test/java/com/palantir/tritium/event/DefaultInvocationContextTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/DefaultInvocationContextTest.java
@@ -26,10 +26,10 @@ public class DefaultInvocationContextTest {
     public void testFactory() throws Exception {
         InvocationContext context =
                 DefaultInvocationContext.of(this, Object.class.getDeclaredMethod("equals", Object.class),
-                        new Object[] {"42"});
+                        new Object[] {"testArgument"});
 
         assertThat(context.getInstance()).isEqualTo(this);
-        assertThat(context.getArgs()).isEqualTo(new Object[]{"42"});
+        assertThat(context.getArgs()).isEqualTo(new Object[]{"testArgument"});
         assertThat(context.getMethod()).isEqualTo(Object.class.getDeclaredMethod("equals", Object.class));
 
         String toString = context.toString();
@@ -37,7 +37,7 @@ public class DefaultInvocationContextTest {
         assertThat(toString).contains("instance");
         assertThat(toString).contains("method");
         assertThat(toString).doesNotContain("args");
-        assertThat(toString).doesNotContain("42");
+        assertThat(toString).doesNotContain("testArgument");
     }
 
 }

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
@@ -69,7 +69,6 @@ public class InvocationEventProxyTest {
         assertThat(context.toString()).contains("startTimeNanos");
         assertThat(context.toString()).contains("instance");
         assertThat(context.toString()).contains("method");
-        assertThat(context.toString()).contains("args");
     }
 
     @Test


### PR DESCRIPTION
Method arguments may have expensive `toString()` implementation, so exclude them from `DefaultInvocationContext.toString()`