### PR TITLE
Avoid logging method arguments

### DIFF
--- a/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -120,12 +119,10 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
 
     private static void preInvocationFailed(InvocationEventHandler<? extends InvocationContext> handler,
             Object instance, Method method, Object[] args, Exception exception) {
-        logger.warn("Exception handling preInvocation({}): "
-                        + "invocation of {}.{} with arguments {} on {} threw: {}",
+        logger.warn("Exception handling preInvocation({}): invocation of {}.{} on {} threw: {}",
                 UnsafeArg.of("handler", handler),
                 SafeArg.of("class", method.getDeclaringClass().getCanonicalName()),
                 SafeArg.of("method", method.getName()),
-                UnsafeArg.of("args", Arrays.toString(args)),
                 UnsafeArg.of("instance", instance),
                 UnsafeArg.of("exception", exception),
                 exception);

--- a/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
@@ -119,12 +119,11 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
 
     private static void preInvocationFailed(InvocationEventHandler<? extends InvocationContext> handler,
             Object instance, Method method, Object[] args, Exception exception) {
-        logger.warn("Exception handling preInvocation({}): invocation of {}.{} on {} threw: {}",
+        logger.warn("Exception handling preInvocation({}): invocation of {}.{} on {} threw",
                 UnsafeArg.of("handler", handler),
                 SafeArg.of("class", method.getDeclaringClass().getCanonicalName()),
                 SafeArg.of("method", method.getName()),
                 UnsafeArg.of("instance", instance),
-                UnsafeArg.of("exception", exception),
                 exception);
     }
 
@@ -135,10 +134,9 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
         try {
             handler.onSuccess(context, result);
         } catch (RuntimeException exception) {
-            logger.warn("Exception handling onSuccess({}, {}): {}",
+            logger.warn("Exception handling onSuccess({}, {})",
                     UnsafeArg.of("context", context),
                     UnsafeArg.of("result", result),
-                    UnsafeArg.of("exception", exception),
                     exception);
         }
     }
@@ -150,10 +148,9 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
         try {
             handler.onFailure(context, cause);
         } catch (RuntimeException exception) {
-            logger.warn("Exception handling onFailure({}, {}): {}",
+            logger.warn("Exception handling onFailure({}, {})",
                     UnsafeArg.of("context", context),
                     UnsafeArg.of("cause", cause),
-                    UnsafeArg.of("exception", exception),
                     exception);
         }
     }

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
@@ -30,7 +30,6 @@ import com.palantir.tritium.event.InvocationEventHandler;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -84,7 +83,7 @@ abstract class InvocationEventProxy<C extends InvocationContext>
             return eventHandler.isEnabled()
                     && filter.shouldInstrument(instance, method, args);
         } catch (Throwable t) {
-            logInvocationWarning("isEnabled", instance, method, args, t);
+            logInvocationWarning("isEnabled", instance, method, t);
             return false;
         }
     }
@@ -129,7 +128,7 @@ abstract class InvocationEventProxy<C extends InvocationContext>
         try {
             return eventHandler.preInvocation(instance, method, args);
         } catch (RuntimeException e) {
-            logInvocationWarning("preInvocation", instance, method, args, e);
+            logInvocationWarning("preInvocation", instance, method, e);
         }
         return null;
     }
@@ -184,26 +183,16 @@ abstract class InvocationEventProxy<C extends InvocationContext>
         return SafeArg.of(name, (object == null) ? "null" : object.getClass().getSimpleName());
     }
 
-    static void logInvocationWarning(String event, Object instance, Method method, Object[] args,
-            Throwable cause) {
+    static void logInvocationWarning(String event, Object instance, Method method, Throwable cause) {
         if (logger.isWarnEnabled()) {
-            logger.warn("{} exception handling {} invocation of {}.{} with arguments {} on {}",
+            logger.warn("{} exception handling {} invocation of {}.{} on {}",
                     safeSimpleClassName("throwable", cause),
                     SafeArg.of("event", event),
                     SafeArg.of("class", method.getDeclaringClass()),
                     SafeArg.of("method", method.getName()),
-                    unsafeArgs(args),
                     UnsafeArg.of("instance", instance),
                     cause);
         }
-    }
-
-    private static UnsafeArg<List<Object>> unsafeArgs(Object[] args) {
-        return UnsafeArg.of("args", Arrays.asList(nullToEmpty(args)));
-    }
-
-    private static Object[] nullToEmpty(@Nullable Object[] args) {
-        return (args == null) ? NO_ARGS : args;
     }
 
 }

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
@@ -140,7 +140,7 @@ public class InvocationEventProxyTest {
     @Test
     public void testToInvocationDebugString() throws Exception {
         Throwable cause = new RuntimeException("cause");
-        InvocationEventProxy.logInvocationWarning("test", this, getToStringMethod(), null, cause);
+        InvocationEventProxy.logInvocationWarning("test", this, getToStringMethod(), cause);
     }
 
     @Test


### PR DESCRIPTION
Follow on to #209 to avoid potentially expensive arguments toString().