### PR TITLE
Enable safe logging preconditions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ allprojects {
             '-Xep:MethodCanBeStatic:ERROR',
             '-Xep:NonCanonicalStaticMemberImport:ERROR',
             '-Xep:PreferSafeLoggableExceptions:ERROR',
+            '-Xep:PreferSafeLoggingPreconditions:ERROR',
             '-Xep:ReturnMissingNullable:ERROR',
             '-Xep:Slf4jLogsafeArgs:ERROR',
             '-Xep:SwitchStatementDefaultCase:ERROR',

--- a/tritium-caffeine/build.gradle
+++ b/tritium-caffeine/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     api 'com.github.ben-manes.caffeine:caffeine'
 
     implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'io.dropwizard.metrics:metrics-core'
     implementation 'org.slf4j:slf4j-api'

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheMetricSet.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheMetricSet.java
@@ -16,8 +16,8 @@
 
 package com.palantir.tritium.metrics.caffeine;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkArgument;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.codahale.metrics.CachedGauge;
 import com.codahale.metrics.Clock;

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStats.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.metrics.caffeine;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.codahale.metrics.Clock;
 import com.codahale.metrics.MetricRegistry;

--- a/tritium-core/build.gradle
+++ b/tritium-core/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     api project(':tritium-api')
 
     implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'org.slf4j:slf4j-api'
 

--- a/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.event;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import javax.annotation.Nullable;
 

--- a/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.event;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.logsafe.SafeArg;

--- a/tritium-core/src/main/java/com/palantir/tritium/event/DefaultInvocationContext.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/DefaultInvocationContext.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.event;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import java.lang.reflect.Method;
 import javax.annotation.Nullable;

--- a/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationProperties.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationProperties.java
@@ -16,11 +16,12 @@
 
 package com.palantir.tritium.event;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.palantir.logsafe.Preconditions.checkArgument;
 
 import com.google.common.base.Strings;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.tritium.api.functions.BooleanSupplier;
 import java.util.Map;
 import java.util.Properties;
@@ -39,7 +40,7 @@ public final class InstrumentationProperties {
     private static volatile Supplier<Map<String, String>> instrumentationProperties = createSupplier();
 
     public static BooleanSupplier getSystemPropertySupplier(String name) {
-        checkArgument(!Strings.isNullOrEmpty(name), "name cannot be null or empty, was '%s'", name);
+        checkArgument(!Strings.isNullOrEmpty(name), "name cannot be null or empty", SafeArg.of("name", name));
         boolean instrumentationEnabled = isGloballyEnabled() && isSpecificEnabled(name);
         return () -> instrumentationEnabled;
     }

--- a/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationPropertiesTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationPropertiesTest.java
@@ -76,9 +76,9 @@ public class InstrumentationPropertiesTest {
     public void invalid() {
         assertThatThrownBy(() -> InstrumentationProperties.getSystemPropertySupplier(null))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("name cannot be null or empty");
+                .hasMessage("name cannot be null or empty: {name=null}");
         assertThatThrownBy(() -> InstrumentationProperties.getSystemPropertySupplier(""))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("name cannot be null or empty");
+                .hasMessage("name cannot be null or empty: {name=}");
     }
 }

--- a/tritium-lib/build.gradle
+++ b/tritium-lib/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     api project(':tritium-tracing')
 
     implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'org.slf4j:slf4j-api'
 

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/Instrumentation.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/Instrumentation.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.proxy;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Strings;

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.proxy;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.google.common.reflect.AbstractInvocationHandler;
 import com.google.errorprone.annotations.CompileTimeConstant;

--- a/tritium-metrics/build.gradle
+++ b/tritium-metrics/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     api 'io.dropwizard.metrics:metrics-core'
 
     implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation ('org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir') {
         exclude group: 'io.dropwizard.metrics', module: 'metrics-core'

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.event.metrics;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Strings;

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandler.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.event.metrics;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.palantir.tritium.event.AbstractInvocationEventHandler;
 import com.palantir.tritium.event.DefaultInvocationContext;

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/annotations/AnnotationHelper.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/annotations/AnnotationHelper.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.event.metrics.annotations;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/AbstractMetricBuilder.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/AbstractMetricBuilder.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.metrics;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.codahale.metrics.Metric;
 import javax.annotation.Nullable;

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/AbstractReservoirMetricBuilder.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/AbstractReservoirMetricBuilder.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.metrics;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.Reservoir;

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/CacheMetricSet.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/CacheMetricSet.java
@@ -16,8 +16,8 @@
 
 package com.palantir.tritium.metrics;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkArgument;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.codahale.metrics.CachedGauge;
 import com.codahale.metrics.Clock;

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -16,8 +16,8 @@
 
 package com.palantir.tritium.metrics;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkArgument;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.codahale.metrics.Clock;
 import com.codahale.metrics.Gauge;

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistryWithReservoirs.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistryWithReservoirs.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.metrics;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/Reservoirs.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/Reservoirs.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.metrics;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.codahale.metrics.Reservoir;
 import java.util.function.Supplier;

--- a/tritium-proxy/src/main/java/com/palantir/tritium/proxy/Proxies.java
+++ b/tritium-proxy/src/main/java/com/palantir/tritium/proxy/Proxies.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
+@SuppressWarnings("PreferSafeLoggingPreconditions") // this module depends only on JDK
 public final class Proxies {
 
     private Proxies() {

--- a/tritium-slf4j/build.gradle
+++ b/tritium-slf4j/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     api project(':tritium-core')
 
     implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'org.slf4j:slf4j-api'
 

--- a/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
+++ b/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
@@ -16,9 +16,8 @@
 
 package com.palantir.tritium.event.log;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
@@ -192,9 +191,6 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
             message.append("{}");
         }
         message.append(") took {}ms");
-        Preconditions.checkState(estimatedSize == message.length(),
-                "Incorrect estimated size for %s arguments, expected %s, was %s",
-                argCount, estimatedSize, message.length());
         return message.toString();
     }
 

--- a/tritium-tracing/build.gradle
+++ b/tritium-tracing/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     api project(':tritium-api')
     api project(':tritium-core')
 
+    implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'com.palantir.tracing:tracing'
     implementation 'org.slf4j:slf4j-api'

--- a/tritium-tracing/src/main/java/com/palantir/tritium/tracing/RemotingCompatibleTracingInvocationEventHandler.java
+++ b/tritium-tracing/src/main/java/com/palantir/tritium/tracing/RemotingCompatibleTracingInvocationEventHandler.java
@@ -16,7 +16,8 @@
 
 package com.palantir.tritium.tracing;
 
-import com.google.common.base.Preconditions;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
+
 import com.google.common.base.Strings;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.tritium.event.AbstractInvocationEventHandler;
@@ -42,8 +43,8 @@ public final class RemotingCompatibleTracingInvocationEventHandler
 
     public RemotingCompatibleTracingInvocationEventHandler(String component, Tracer tracer) {
         super((java.util.function.BooleanSupplier) InstrumentationProperties.getSystemPropertySupplier(component));
-        this.component = Preconditions.checkNotNull(component, "component");
-        this.tracer = Preconditions.checkNotNull(tracer, "tracer");
+        this.component = checkNotNull(component, "component");
+        this.tracer = checkNotNull(tracer, "tracer");
     }
 
     static InvocationEventHandler<InvocationContext> create(String component) {

--- a/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java
+++ b/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java
@@ -16,7 +16,8 @@
 
 package com.palantir.tritium.tracing;
 
-import com.google.common.base.Preconditions;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
+
 import com.google.common.base.Strings;
 import com.palantir.tracing.Tracer;
 import com.palantir.tritium.api.functions.BooleanSupplier;
@@ -45,7 +46,7 @@ public final class TracingInvocationEventHandler extends AbstractInvocationEvent
     @Deprecated
     public TracingInvocationEventHandler(String component) {
         super((java.util.function.BooleanSupplier) getEnabledSupplier(component));
-        this.component = Preconditions.checkNotNull(component, "component");
+        this.component = checkNotNull(component, "component");
     }
 
     /**

--- a/tritium-tracing/src/test/java/com/palantir/tritium/tracing/ReflectiveTracerTest.java
+++ b/tritium-tracing/src/test/java/com/palantir/tritium/tracing/ReflectiveTracerTest.java
@@ -44,13 +44,22 @@ public class ReflectiveTracerTest {
 
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new ReflectiveTracer(invalidStartMethod, validCompleteMethod))
-                .withMessage("startSpan method should take 1 String argument, was [java.lang.Integer]");
+                .withMessageStartingWith("startSpan method should take 1 String argument:")
+                .withMessageContaining("method=public static void ")
+                .withMessageContaining("MockTracer.badStart(java.lang.Integer)")
+                .withMessageContaining("argumentTypes=[java.lang.Integer]");
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new ReflectiveTracer(validStartMethod, invalidCompleteMethod))
-                .withMessage("completeSpan method should take 0 arguments, was [java.lang.String]");
+                .withMessageStartingWith("completeSpan method should take 0 arguments: ")
+                .withMessageContaining("method=public static void ")
+                .withMessageContaining("MockTracer.badStop(java.lang.String)")
+                .withMessageContaining("argumentTypes=[java.lang.String]}");
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new ReflectiveTracer(invalidStartMethod, invalidCompleteMethod))
-                .withMessage("startSpan method should take 1 String argument, was [java.lang.Integer]");
+                .withMessageStartingWith("startSpan method should take 1 String argument: ")
+                .withMessageContaining("method=public static void ")
+                .withMessageContaining("MockTracer.badStart(java.lang.Integer)")
+                .withMessageContaining("argumentTypes=[java.lang.Integer]");
     }
 
     public static final class MockTracer {


### PR DESCRIPTION
Enables `PreferSafeLoggingPreconditions:ERROR` check and converts from Guava to log-safe preconditions checks