### PR TITLE
More error prone checks, cleanup, and improved test coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ allprojects {
             '-Xep:Slf4jLogsafeArgs:ERROR',
             '-Xep:SwitchStatementDefaultCase:ERROR',
             '-Xep:UnnecessaryParentheses:ERROR',
+            '-Xep:UnusedVariable:ERROR',
         ]
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ allprojects {
         options.errorprone.errorproneArgs += [
             '-Werror',
             '-Xlint:deprecation',
+            '-Xlint:unchecked',
             '-XepDisableWarningsInGeneratedCode',
             // skipping Immutable* explicitly due to https://github.com/google/error-prone/issues/1165
             '-XepExcludedPaths:.*(generated|Immutable).*',

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ allprojects {
             '-Xep:ClassCanBeStatic:ERROR',
             '-Xep:DefaultCharset:ERROR',
             '-Xep:FunctionalInterfaceClash:ERROR',
+            '-Xep:JavaTimeDefaultTimeZone:ERROR',
             '-Xep:MethodCanBeStatic:ERROR',
             '-Xep:NonCanonicalStaticMemberImport:ERROR',
             '-Xep:PreferSafeLoggableExceptions:ERROR',

--- a/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
@@ -81,6 +81,7 @@ public abstract class AbstractInvocationEventHandler<C extends InvocationContext
         return InstrumentationProperties.getSystemPropertySupplier(clazz.getName());
     }
 
+    @SuppressWarnings("WeakerAccess") // public API
     public static Object[] nullToEmpty(@Nullable Object[] args) {
         return (args == null) ? NO_ARGS : args;
     }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
@@ -107,7 +107,7 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
         try {
             return handler.preInvocation(instance, method, args);
         } catch (RuntimeException e) {
-            preInvocationFailed(handler, instance, method, args, e);
+            preInvocationFailed(handler, instance, method, e);
             return null;
         }
     }
@@ -117,9 +117,13 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
         return "CompositeInvocationEventHandler{" + "handlers=" + handlers + '}';
     }
 
-    private static void preInvocationFailed(InvocationEventHandler<? extends InvocationContext> handler,
-            Object instance, Method method, Object[] args, Exception exception) {
-        logger.warn("Exception handling preInvocation({}): invocation of {}.{} on {} threw",
+    private static void preInvocationFailed(
+            InvocationEventHandler<? extends InvocationContext> handler,
+            Object instance,
+            Method method,
+            Exception exception) {
+        logger.warn(
+                "Exception handling preInvocation({}): invocation of {}.{} on {} threw",
                 UnsafeArg.of("handler", handler),
                 SafeArg.of("class", method.getDeclaringClass().getCanonicalName()),
                 SafeArg.of("method", method.getName()),

--- a/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
@@ -51,7 +51,7 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
     }
 
     @Override
-    public InvocationContext preInvocation(Object instance, Method method, Object[] args) {
+    public InvocationContext preInvocation(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args) {
         InvocationContext[] contexts = new InvocationContext[handlers.size()];
 
         for (int i = 0; i < handlers.size(); i++) {

--- a/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
@@ -173,7 +173,7 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
             this.contexts = checkNotNull(contexts);
         }
 
-        public InvocationContext[] getContexts() {
+        InvocationContext[] getContexts() {
             return contexts;
         }
     }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationProperties.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationProperties.java
@@ -45,11 +45,13 @@ public final class InstrumentationProperties {
         return () -> instrumentationEnabled;
     }
 
+    @SuppressWarnings("WeakerAccess") // public API
     public static boolean isSpecificEnabled(String name) {
         String qualifiedValue = instrumentationProperties().get(INSTRUMENT_PREFIX + "." + name);
         return "true".equalsIgnoreCase(qualifiedValue) || qualifiedValue == null;
     }
 
+    @SuppressWarnings("WeakerAccess") // public API
     public static boolean isGloballyEnabled() {
         return !isGloballyDisabled();
     }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/NoOpInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/NoOpInvocationEventHandler.java
@@ -33,7 +33,7 @@ public enum NoOpInvocationEventHandler implements InvocationEventHandler<Invocat
     }
 
     @Override
-    public InvocationContext preInvocation(Object instance, Method method, Object[] args) {
+    public InvocationContext preInvocation(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args) {
         return DefaultInvocationContext.of(instance, method, args);
     }
 
@@ -46,5 +46,4 @@ public enum NoOpInvocationEventHandler implements InvocationEventHandler<Invocat
     public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause) {
         // no-op
     }
-
 }

--- a/tritium-core/src/test/java/com/palantir/tritium/event/CompositeInvocationEventHandlerTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/CompositeInvocationEventHandlerTest.java
@@ -50,7 +50,10 @@ public class CompositeInvocationEventHandlerTest {
         InvocationEventHandler<InvocationContext> compositeHandler = CompositeInvocationEventHandler.of(
                 Arrays.asList(NoOpInvocationEventHandler.INSTANCE, new ThrowingInvocationEventHandler(true) {
                     @Override
-                    public InvocationContext preInvocation(Object instance, Method method, Object[] args) {
+                    public InvocationContext preInvocation(
+                            @Nonnull Object instance,
+                            @Nonnull Method method,
+                            @Nonnull Object[] args) {
                         return DefaultInvocationContext.of(instance, method, args);
                     }
                 }));
@@ -66,7 +69,10 @@ public class CompositeInvocationEventHandlerTest {
         InvocationEventHandler<InvocationContext> compositeHandler = CompositeInvocationEventHandler.of(
                 Arrays.asList(NoOpInvocationEventHandler.INSTANCE, new ThrowingInvocationEventHandler(true) {
                     @Override
-                    public InvocationContext preInvocation(Object instance, Method method, Object[] args) {
+                    public InvocationContext preInvocation(
+                            @Nonnull Object instance,
+                            @Nonnull Method method,
+                            @Nonnull Object[] args) {
                         return DefaultInvocationContext.of(instance, method, args);
                     }
                 }));
@@ -162,7 +168,10 @@ public class CompositeInvocationEventHandlerTest {
 
     private static class SimpleInvocationEventHandler extends AbstractInvocationEventHandler<InvocationContext> {
         @Override
-        public InvocationContext preInvocation(Object instance, Method method, Object[] args) {
+        public InvocationContext preInvocation(
+                @Nonnull Object instance,
+                @Nonnull Method method,
+                @Nonnull Object[] args) {
             return DefaultInvocationContext.of(instance, method, args);
         }
 

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/ProxyBenchmark.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/ProxyBenchmark.java
@@ -122,7 +122,7 @@ public class ProxyBenchmark {
         return instrumentedWithPerformanceLogging.echo("test");
     }
 
-    // @Benchmark
+    @Benchmark
     public String instrumentedWithMetrics() {
         return instrumentedWithMetrics.echo("test");
     }
@@ -132,12 +132,12 @@ public class ProxyBenchmark {
         return instrumentedWithTracing.echo("test");
     }
 
-    @Benchmark
+    // @Benchmark
     public String instrumentedWithRemoting() {
         return instrumentedWithRemoting.echo("test");
     }
 
-    // @Benchmark
+    @Benchmark
     public String instrumentedWithEverything() {
         return instrumentedWithEverything.echo("test");
     }

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/InstrumentationProxy.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/InstrumentationProxy.java
@@ -21,7 +21,7 @@ import com.palantir.tritium.event.InvocationContext;
 import com.palantir.tritium.event.InvocationEventHandler;
 import java.util.List;
 
-class InstrumentationProxy<T> extends InvocationEventProxy<InvocationContext> {
+class InstrumentationProxy<T> extends InvocationEventProxy {
 
     private final T delegate;
 

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
@@ -37,8 +37,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-abstract class InvocationEventProxy<C extends InvocationContext>
-        extends AbstractInvocationHandler implements InvocationHandler {
+abstract class InvocationEventProxy extends AbstractInvocationHandler implements InvocationHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(InvocationEventProxy.class);
 
@@ -192,11 +191,11 @@ abstract class InvocationEventProxy<C extends InvocationContext>
 
     static void logInvocationWarning(String event, Object instance, Method method, Throwable cause) {
         if (logger.isWarnEnabled()) {
-            logger.warn("{} exception handling {} invocation of {}.{} on {}",
+            logger.warn("{} exception handling {} invocation of {} {} on {}",
                     safeSimpleClassName("throwable", cause),
                     SafeArg.of("event", event),
-                    SafeArg.of("class", method.getDeclaringClass()),
-                    SafeArg.of("method", method.getName()),
+                    SafeArg.of("class", method.getDeclaringClass().getName()),
+                    SafeArg.of("method", method),
                     UnsafeArg.of("instance", instance),
                     cause);
         }

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
@@ -18,6 +18,7 @@ package com.palantir.tritium.proxy;
 
 import static com.palantir.logsafe.Preconditions.checkNotNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.reflect.AbstractInvocationHandler;
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.SafeArg;
@@ -113,7 +114,8 @@ abstract class InvocationEventProxy<C extends InvocationContext>
      */
     @Nullable
     @SuppressWarnings("checkstyle:illegalthrows")
-    public final Object instrumentInvocation(Object instance, Method method, Object[] args) throws Throwable {
+    @VisibleForTesting
+    final Object instrumentInvocation(Object instance, Method method, Object[] args) throws Throwable {
         InvocationContext context = handlePreInvocation(instance, method, args);
         try {
             Object result = execute(method, args);
@@ -126,6 +128,7 @@ abstract class InvocationEventProxy<C extends InvocationContext>
     }
 
     @Nullable
+    @VisibleForTesting
     final InvocationContext handlePreInvocation(Object instance, Method method, Object[] args) {
         try {
             return eventHandler.preInvocation(instance, method, args);
@@ -137,6 +140,7 @@ abstract class InvocationEventProxy<C extends InvocationContext>
 
     @Nullable
     @SuppressWarnings("checkstyle:illegalthrows")
+    @VisibleForTesting
     final Object execute(Method method, Object[] args) throws Throwable {
         try {
             return method.invoke(getDelegate(), args);
@@ -146,6 +150,7 @@ abstract class InvocationEventProxy<C extends InvocationContext>
     }
 
     @Nullable
+    @VisibleForTesting
     final Object handleOnSuccess(@Nullable InvocationContext context, @Nullable Object result) {
         try {
             eventHandler.onSuccess(context, result);

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
@@ -39,7 +39,6 @@ abstract class InvocationEventProxy<C extends InvocationContext>
         extends AbstractInvocationHandler implements InvocationHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(InvocationEventProxy.class);
-    private static final Object[] NO_ARGS = {};
 
     private final InstrumentationFilter filter;
     private final InvocationEventHandler<?> eventHandler;

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
@@ -31,6 +31,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,11 +88,13 @@ abstract class InvocationEventProxy<C extends InvocationContext>
         }
     }
 
-
     @Override
     @Nullable
     @SuppressWarnings("checkstyle:illegalthrows")
-    protected final Object handleInvocation(Object proxy, Method method, Object[] args) throws Throwable {
+    protected final Object handleInvocation(
+            @Nonnull Object proxy,
+            @Nonnull Method method,
+            @Nonnull Object[] args) throws Throwable {
         if (isEnabled(proxy, method, args)) {
             return instrumentInvocation(proxy, method, args);
         } else {

--- a/tritium-lib/src/test/java/com/palantir/tritium/TritiumTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/TritiumTest.java
@@ -31,6 +31,8 @@ import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import com.palantir.tritium.test.TestImplementation;
 import com.palantir.tritium.test.TestInterface;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.SortedMap;
 import org.junit.After;
@@ -144,4 +146,15 @@ public class TritiumTest {
         assertThat(Tritium.instrument(TestInterface.class, instrumentedService, metricRegistry).toString())
                 .isEqualTo(TestImplementation.class.getName());
     }
+
+    @Test
+    public void testInaccessibleConstructor() throws NoSuchMethodException {
+        Constructor<Tritium> constructor = Tritium.class.getDeclaredConstructor();
+        assertThat(constructor.isAccessible()).isFalse();
+        constructor.setAccessible(true);
+        assertThatThrownBy(constructor::newInstance)
+                .isInstanceOf(InvocationTargetException.class)
+                .hasRootCauseExactlyInstanceOf(UnsupportedOperationException.class);
+    }
+
 }

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
@@ -353,6 +353,7 @@ public class InstrumentationTest {
     @Test
     public void testInaccessibleConstructor() throws NoSuchMethodException {
         Constructor<Instrumentation> constructor = Instrumentation.class.getDeclaredConstructor();
+        assertThat(constructor.isAccessible()).isFalse();
         constructor.setAccessible(true);
         assertThatThrownBy(constructor::newInstance)
                 .isInstanceOf(InvocationTargetException.class)

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
@@ -76,7 +76,10 @@ public class InvocationEventProxyTest {
     public void testInstrumentPreInvocationThrows() throws Throwable {
         InvocationEventHandler<InvocationContext> testHandler = new SimpleHandler() {
             @Override
-            public InvocationContext preInvocation(Object instance, Method method, Object[] args) {
+            public InvocationContext preInvocation(
+                    @Nonnull Object instance,
+                    @Nonnull Method method,
+                    @Nonnull Object[] args) {
                 throw new IllegalStateException("expected");
             }
         };
@@ -177,7 +180,10 @@ public class InvocationEventProxyTest {
         }
 
         @Override
-        public InvocationContext preInvocation(Object instance, Method method, Object[] args) {
+        public InvocationContext preInvocation(
+                @Nonnull Object instance,
+                @Nonnull Method method,
+                @Nonnull Object[] args) {
             return DefaultInvocationContext.of(instance, method, args);
         }
 

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
@@ -17,12 +17,22 @@
 package com.palantir.tritium.proxy;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.palantir.tritium.api.event.InstrumentationFilter;
 import com.palantir.tritium.event.DefaultInvocationContext;
 import com.palantir.tritium.event.InstrumentationFilters;
 import com.palantir.tritium.event.InvocationContext;
 import com.palantir.tritium.event.InvocationEventHandler;
+import com.palantir.tritium.test.TestImplementation;
+import com.palantir.tritium.test.TestInterface;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
@@ -30,15 +40,24 @@ import java.util.function.BooleanSupplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class InvocationEventProxyTest {
 
     private static final Object[] EMPTY_ARGS = {};
 
+    @Mock
+    private InstrumentationFilter mockFilter;
+    @Mock
+    private InvocationEventHandler mockHandler;
+
     @Test
     @SuppressWarnings("checkstyle:illegalthrows")
     public void testDisabled() throws Throwable {
-        InvocationEventProxy<InvocationContext> proxy = new InvocationEventProxy<InvocationContext>(
+        InvocationEventProxy proxy = new InvocationEventProxy(
                 Collections.emptyList(), InstrumentationFilters.from((BooleanSupplier) () -> false)) {
             @Override
             Object getDelegate() {
@@ -52,7 +71,7 @@ public class InvocationEventProxyTest {
     @SuppressWarnings("checkstyle:illegalthrows")
     public void testInstrumentPreInvocation() throws Throwable {
         InvocationEventHandler<InvocationContext> testHandler = new SimpleHandler();
-        InvocationEventProxy<InvocationContext> proxy = createTestProxy(ImmutableList.of(testHandler));
+        InvocationEventProxy proxy = createTestProxy(testHandler);
 
         Object result1 = proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS);
 
@@ -83,7 +102,7 @@ public class InvocationEventProxyTest {
                 throw new IllegalStateException("expected");
             }
         };
-        InvocationEventProxy<InvocationContext> proxy = createTestProxy(ImmutableList.of(testHandler));
+        InvocationEventProxy proxy = createTestProxy(testHandler);
 
         Object result = proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS);
 
@@ -101,7 +120,7 @@ public class InvocationEventProxyTest {
             }
         };
 
-        InvocationEventProxy<InvocationContext> proxy = createTestProxy(ImmutableList.of(testHandler));
+        InvocationEventProxy proxy = createTestProxy(testHandler);
 
         Object result = proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS);
 
@@ -127,7 +146,7 @@ public class InvocationEventProxyTest {
             }
         };
 
-        InvocationEventProxy<InvocationContext> proxy = createTestProxy(ImmutableList.of(testHandler));
+        InvocationEventProxy proxy = createTestProxy(testHandler);
 
         Object result = proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS);
 
@@ -149,7 +168,7 @@ public class InvocationEventProxyTest {
     @Test
     public void testInstrumentToString() {
         List<InvocationEventHandler<InvocationContext>> handlers = Collections.emptyList();
-        InvocationEventProxy<InvocationContext> proxy = new InvocationEventProxy<InvocationContext>(handlers) {
+        InvocationEventProxy proxy = new InvocationEventProxy(handlers) {
             @Override
             Object getDelegate() {
                 return "Hello, world";
@@ -159,18 +178,134 @@ public class InvocationEventProxyTest {
         assertThat(proxy.toString()).isEqualTo("Hello, world");
     }
 
-    private static InvocationEventProxy<InvocationContext> createTestProxy(
-            List<InvocationEventHandler<InvocationContext>> handlers) {
-        return new InvocationEventProxy<InvocationContext>(handlers) {
-            @Override
-            Object getDelegate() {
-                return "test";
-            }
-        };
+    @Test
+    @SuppressWarnings("checkstyle:illegalthrows")
+    public void testInstrumentInvocation() throws Throwable {
+        InvocationEventProxy proxy = createTestProxy(new SimpleHandler());
+
+        assertThat(proxy.instrumentInvocation("test", getToStringMethod(), null)).isEqualTo("test");
+        assertThat(proxy.instrumentInvocation("test", getToStringMethod(), EMPTY_ARGS)).isEqualTo("test");
+        assertThatThrownBy(() -> proxy.instrumentInvocation("test", getToStringMethod(), new Object[] {"Hello"}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("wrong number of arguments");
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:illegalthrows")
+    public void testInstrumentInvocationThrowsException() {
+        InvocationEventProxy proxy = createSimpleTestProxy();
+
+        assertThatThrownBy(() -> proxy.instrumentInvocation("test", getThrowsCheckedExceptionMethod(), null))
+                .isInstanceOf(TestImplementation.TestException.class)
+                .hasMessage("Testing checked Exception handling");
+
+        assertThatThrownBy(() -> proxy.instrumentInvocation("test", getThrowsThrowableMethod(), null))
+                .isInstanceOf(TestImplementation.TestThrowable.class)
+                .hasMessage("TestThrowable");
+
+        assertThatThrownBy(() -> proxy.instrumentInvocation("test", getThrowsOutOfMemoryErrorMethod(), null))
+                .isInstanceOf(OutOfMemoryError.class)
+                .hasMessage("Testing OOM");
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:illegalthrows")
+    public void testExecute() throws Throwable {
+        InvocationEventProxy proxy = createTestProxy(new SimpleHandler());
+
+        assertThat(proxy.execute(getToStringMethod(), null)).isEqualTo("test");
+        assertThat(proxy.execute(getToStringMethod(), EMPTY_ARGS)).isEqualTo("test");
+        assertThatThrownBy(() -> proxy.execute(getToStringMethod(), new Object[] {"Hello"}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("wrong number of arguments");
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:illegalthrows")
+    public void testExecuteThrowsExceptions() {
+        InvocationEventProxy proxy = createSimpleTestProxy();
+
+        assertThatThrownBy(() -> proxy.execute(getThrowsCheckedExceptionMethod(), null))
+                .isInstanceOf(TestImplementation.TestException.class)
+                .hasMessage("Testing checked Exception handling");
+
+        assertThatThrownBy(() -> proxy.execute(getThrowsThrowableMethod(), null))
+                .isInstanceOf(TestImplementation.TestThrowable.class)
+                .hasMessage("TestThrowable");
+
+        assertThatThrownBy(() -> proxy.execute(getThrowsOutOfMemoryErrorMethod(), null))
+                .isInstanceOf(OutOfMemoryError.class)
+                .hasMessage("Testing OOM");
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:illegalthrows")
+    public void testThrowingFilterAndHandler() throws Throwable {
+        doThrow(IllegalStateException.class).when(mockHandler).isEnabled();
+
+        InvocationEventProxy proxy = createTestProxy(mockHandler, mockFilter);
+        assertThat(proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS)).isEqualTo("test");
+
+        verify(mockHandler).isEnabled();
+        verifyNoMoreInteractions(mockFilter);
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:illegalthrows")
+    public void testThrowingFilter() throws Throwable {
+        doThrow(UnsupportedOperationException.class).when(mockFilter).shouldInstrument(any(), any(), any());
+        when(mockHandler.isEnabled()).thenReturn(true);
+
+        InvocationEventProxy proxy = createTestProxy(mockHandler, mockFilter);
+        assertThat(proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS)).isEqualTo("test");
+
+        verify(mockHandler).isEnabled();
+        verify(mockFilter).shouldInstrument(any(), any(), any());
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:illegalthrows")
+    public void testThrowingHandler() throws Throwable {
+        doThrow(IllegalStateException.class).when(mockHandler).isEnabled();
+
+        InvocationEventProxy proxy = createTestProxy(mockHandler);
+        assertThat(proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS)).isEqualTo("test");
+
+        verify(mockHandler).isEnabled();
+        verifyZeroInteractions(mockFilter);
+    }
+
+    private static InvocationEventProxy createSimpleTestProxy() {
+        return new TestProxy(
+                new TestImplementation(),
+                ImmutableList.of(new SimpleHandler()),
+                InstrumentationFilters.INSTRUMENT_ALL);
+    }
+
+    private static InvocationEventProxy createTestProxy(
+            InvocationEventHandler<InvocationContext> handler,
+            InstrumentationFilter filter) {
+        return new TestProxy("test", ImmutableList.of(handler), filter);
+    }
+
+    private static InvocationEventProxy createTestProxy(InvocationEventHandler<InvocationContext> handler) {
+        return createTestProxy(handler, InstrumentationFilters.INSTRUMENT_ALL);
     }
 
     private static Method getToStringMethod() throws NoSuchMethodException {
         return Object.class.getDeclaredMethod("toString");
+    }
+
+    private static Method getThrowsOutOfMemoryErrorMethod() throws NoSuchMethodException {
+        return TestInterface.class.getMethod("throwsOutOfMemoryError");
+    }
+
+    private static Method getThrowsThrowableMethod() throws NoSuchMethodException {
+        return TestInterface.class.getMethod("throwsThrowable");
+    }
+
+    private static Method getThrowsCheckedExceptionMethod() throws NoSuchMethodException {
+        return TestInterface.class.getMethod("throwsCheckedException");
     }
 
     private static class SimpleHandler implements InvocationEventHandler<InvocationContext> {
@@ -192,5 +327,22 @@ public class InvocationEventProxyTest {
 
         @Override
         public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause) {}
+    }
+
+    private static class TestProxy extends InvocationEventProxy {
+        private final Object delegate;
+
+        TestProxy(
+                Object delegate,
+                List<InvocationEventHandler<InvocationContext>> handlers,
+                InstrumentationFilter filter) {
+            super(handlers, filter);
+            this.delegate = delegate;
+        }
+
+        @Override
+        Object getDelegate() {
+            return delegate;
+        }
     }
 }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
@@ -101,7 +101,7 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
     }
 
     @Override
-    public InvocationContext preInvocation(Object instance, Method method, Object[] args) {
+    public InvocationContext preInvocation(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args) {
         return DefaultInvocationContext.of(instance, method, args);
     }
 

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 public final class MetricsInvocationEventHandler extends AbstractInvocationEventHandler<InvocationContext> {
 
     private static final Logger logger = LoggerFactory.getLogger(MetricsInvocationEventHandler.class);
+    private static final String FAILURES = "failures";
 
     private final MetricRegistry metricRegistry;
     private final String serviceName;
@@ -73,10 +74,6 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
     public MetricsInvocationEventHandler(
             MetricRegistry metricRegistry, Class serviceClass, @Nullable String globalGroupPrefix) {
         this(metricRegistry, serviceClass, checkNotNull(serviceClass.getName()), globalGroupPrefix);
-    }
-
-    private static String failuresMetricName() {
-        return "failures";
     }
 
     private static Map<AnnotationHelper.MethodSignature, String> createMethodGroupMapping(Class<?> serviceClass) {
@@ -140,7 +137,7 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
         }
 
         markGlobalFailure();
-        String failuresMetricName = MetricRegistry.name(getBaseMetricName(context), failuresMetricName());
+        String failuresMetricName = MetricRegistry.name(getBaseMetricName(context), FAILURES);
         metricRegistry.meter(failuresMetricName).mark();
         metricRegistry.meter(MetricRegistry.name(failuresMetricName, cause.getClass().getName())).mark();
 
@@ -148,11 +145,11 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
         String metricName = metricGroups.get(AnnotationHelper.MethodSignature.of(context.getMethod()));
 
         if (metricName != null) {
-            metricRegistry.timer(MetricRegistry.name(serviceName, metricName, failuresMetricName()))
+            metricRegistry.timer(MetricRegistry.name(serviceName, metricName, FAILURES))
                     .update(nanos, TimeUnit.NANOSECONDS);
 
             if (globalGroupPrefix != null) {
-                metricRegistry.timer(MetricRegistry.name(globalGroupPrefix, metricName, failuresMetricName()))
+                metricRegistry.timer(MetricRegistry.name(globalGroupPrefix, metricName, FAILURES))
                         .update(nanos, TimeUnit.NANOSECONDS);
             }
         }
@@ -163,7 +160,7 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
     }
 
     private void markGlobalFailure() {
-        metricRegistry.meter(failuresMetricName()).mark();
+        metricRegistry.meter(FAILURES).mark();
     }
 
 }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
@@ -51,6 +51,7 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
     private final Map<AnnotationHelper.MethodSignature, String> metricGroups;
     @Nullable private final String globalGroupPrefix;
 
+    @SuppressWarnings("WeakerAccess") // public API
     public MetricsInvocationEventHandler(MetricRegistry metricRegistry, String serviceName) {
         super(getEnabledSupplier(serviceName));
         this.metricRegistry = checkNotNull(metricRegistry, "metricRegistry");
@@ -68,6 +69,7 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
         this.globalGroupPrefix = Strings.emptyToNull(globalGroupPrefix);
     }
 
+    @SuppressWarnings("WeakerAccess") // public API
     public MetricsInvocationEventHandler(
             MetricRegistry metricRegistry, Class serviceClass, @Nullable String globalGroupPrefix) {
         this(metricRegistry, serviceClass, checkNotNull(serviceClass.getName()), globalGroupPrefix);

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandler.java
@@ -67,7 +67,10 @@ public class TaggedMetricsServiceInvocationEventHandler extends AbstractInvocati
     }
 
     @Override
-    public final InvocationContext preInvocation(Object instance, Method method, Object[] args) {
+    public final InvocationContext preInvocation(
+            @Nonnull Object instance,
+            @Nonnull Method method,
+            @Nonnull Object[] args) {
         return DefaultInvocationContext.of(instance, method, args);
     }
 

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/AbstractMetricBuilder.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/AbstractMetricBuilder.java
@@ -31,6 +31,7 @@ abstract class AbstractMetricBuilder<T extends Metric> implements MetricBuilder<
 
     @Override
     public boolean isInstance(@Nullable Metric metric) {
+        //noinspection PointlessNullCheck
         return metric != null && metricType.isInstance(metric);
     }
 

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -133,6 +133,7 @@ public final class MetricRegistries {
      * @param filter metric filter predicate
      * @return sorted map of metrics
      */
+    @SuppressWarnings("WeakerAccess") // public API
     public static SortedMap<String, Metric> metricsMatching(MetricRegistry metrics, MetricFilter filter) {
         SortedMap<String, Metric> matchingMetrics = new TreeMap<>();
         metrics.getMetrics().forEach((key, value) -> {
@@ -152,8 +153,8 @@ public final class MetricRegistries {
      *
      * @throws IllegalArgumentException if name is blank
      */
-    @SuppressWarnings("BanGuavaCaches") // this implementation is explicitly for Guava caches
-    public static <C extends Cache<?, ?>> void registerCache(MetricRegistry registry, Cache<?, ?> cache, String name) {
+    @SuppressWarnings({"BanGuavaCaches", "WeakerAccess"}) // this implementation is explicitly for Guava caches, API
+    public static void registerCache(MetricRegistry registry, Cache<?, ?> cache, String name) {
         registerCache(registry, cache, name, Clock.defaultClock());
     }
 

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -74,7 +74,7 @@ public final class MetricRegistries {
         return metrics;
     }
 
-    private static MetricRegistry registerDefaultMetrics(MetricRegistry metrics) {
+    private static void registerDefaultMetrics(MetricRegistry metrics) {
         registerSafe(metrics, MetricRegistry.name(MetricRegistries.class.getPackage().getName(), "snapshot", "begin"),
                 new Gauge<String>() {
                     private final String start = nowIsoTimestamp();
@@ -85,7 +85,6 @@ public final class MetricRegistries {
                 });
         registerSafe(metrics, MetricRegistry.name(MetricRegistries.class.getPackage().getName(), "snapshot", "now"),
                 (Gauge<String>) MetricRegistries::nowIsoTimestamp);
-        return metrics;
     }
 
     @VisibleForTesting

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -29,7 +29,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.logsafe.SafeArg;
-import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Set;
@@ -89,7 +90,7 @@ public final class MetricRegistries {
 
     @VisibleForTesting
     static String nowIsoTimestamp() {
-        return DateTimeFormatter.ISO_DATE_TIME.format(LocalDateTime.now());
+        return DateTimeFormatter.ISO_DATE_TIME.format(ZonedDateTime.now(ZoneOffset.UTC));
     }
 
     @SuppressWarnings("unchecked")

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Metric;
@@ -81,6 +82,23 @@ public class MetricRegistriesTest {
     @Test
     public void testHdrHistogram() {
         metrics = MetricRegistries.createWithHdrHistogramReservoirs();
+        assertThat(metrics).isNotNull();
+
+        Histogram histogram = metrics.histogram("histogram");
+        histogram.update(42L);
+        assertThat(histogram.getCount()).isEqualTo(1);
+        Snapshot histogramSnapshot = histogram.getSnapshot();
+        assertThat(histogram.getCount()).isEqualTo(1);
+        assertThat(histogramSnapshot.size()).isEqualTo(1);
+        assertThat(histogramSnapshot.getMax()).isEqualTo(42);
+
+        metrics.timer("timer").update(123, TimeUnit.MILLISECONDS);
+        assertThat(metrics.timer("timer").getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testDecayingHistogramReservoirs() {
+        metrics = MetricRegistries.createWithReservoirType(ExponentiallyDecayingReservoir::new);
         assertThat(metrics).isNotNull();
 
         Histogram histogram = metrics.histogram("histogram");

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
@@ -249,6 +249,7 @@ public class MetricRegistriesTest {
     @Test
     public void testInaccessibleConstructor() throws Exception {
         Constructor<?> constructor = MetricRegistries.class.getDeclaredConstructor();
+        assertThat(constructor.isAccessible()).isFalse();
         constructor.setAccessible(true);
         assertThatThrownBy(constructor::newInstance)
                 .isInstanceOf(InvocationTargetException.class)

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
@@ -38,6 +38,7 @@ import com.google.common.cache.LoadingCache;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
@@ -290,7 +291,10 @@ public class MetricRegistriesTest {
 
     @Test
     public void testTimestamp() throws Exception {
-        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").parse(MetricRegistries.nowIsoTimestamp());
+        Date now = new Date();
+        String isoTimestamp = MetricRegistries.nowIsoTimestamp();
+        Date date = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").parse(isoTimestamp);
+        assertThat(date).isAfterOrEqualsTo(now);
     }
 
     private static void report(MetricRegistry metrics) {

--- a/tritium-proxy/build.gradle
+++ b/tritium-proxy/build.gradle
@@ -8,5 +8,5 @@ dependencies {
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.slf4j:slf4j-simple'
-    
+
 }

--- a/tritium-proxy/src/test/java/com/palantir/tritium/proxy/ProxiesTest.java
+++ b/tritium-proxy/src/test/java/com/palantir/tritium/proxy/ProxiesTest.java
@@ -86,6 +86,7 @@ public class ProxiesTest {
     @Test
     public void testInaccessibleConstructor() throws NoSuchMethodException {
         Constructor<Proxies> constructor = Proxies.class.getDeclaredConstructor();
+        assertThat(constructor.isAccessible()).isFalse();
         constructor.setAccessible(true);
         assertThatThrownBy(constructor::newInstance)
                 .isInstanceOf(InvocationTargetException.class)

--- a/tritium-registry/build.gradle
+++ b/tritium-registry/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compileOnly 'com.google.auto.service:auto-service'
 
     implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'io.dropwizard.metrics:metrics-core'
 

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
@@ -59,7 +59,8 @@ public final class DefaultTaggedMetricRegistry implements TaggedMetricRegistry {
     }
 
     @Override
-    public Gauge gauge(MetricName metricName, Gauge gauge) {
+    @SuppressWarnings("unchecked")
+    public <T> Gauge<T> gauge(MetricName metricName, Gauge<T> gauge) {
         return getOrAdd(metricName, Gauge.class, () -> gauge);
     }
 

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
@@ -44,6 +44,7 @@ public final class DefaultTaggedMetricRegistry implements TaggedMetricRegistry {
     /**
      * Get the global default {@link TaggedMetricRegistry}.
      */
+    @SuppressWarnings("unused") // public API
     public static TaggedMetricRegistry getDefault() {
         return DefaultTaggedMetricRegistry.DEFAULT;
     }

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistryTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistryTest.java
@@ -136,7 +136,11 @@ public final class TaggedMetricRegistryTest {
 
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> registry.timer(METRIC_1))
-                .withMessage("'name' already used for a metric of type 'Counter' but wanted type 'Timer'. tags: {}");
+                .withMessageStartingWith("Metric name already used for different metric type: ")
+                .withMessageContaining("metricName=name")
+                .withMessageContaining("existingMetricType=Counter")
+                .withMessageContaining("newMetricType=Timer")
+                .withMessageContaining("safeTags={}");
     }
 
     @Test

--- a/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
+++ b/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
@@ -86,7 +86,10 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
     }
 
     @Override
-    public final InvocationContext preInvocation(Object instance, Method method, Object[] args) {
+    public final InvocationContext preInvocation(
+            @Nonnull Object instance,
+            @Nonnull Method method,
+            @Nonnull Object[] args) {
         return DefaultInvocationContext.of(instance, method, args);
     }
 

--- a/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
+++ b/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
@@ -19,7 +19,6 @@ package com.palantir.tritium.event.log;
 import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
-import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.tritium.api.functions.BooleanSupplier;
@@ -43,7 +42,7 @@ import org.slf4j.LoggerFactory;
 public class LoggingInvocationEventHandler extends AbstractInvocationEventHandler<InvocationContext> {
 
     private static final Logger CLASS_LOGGER = LoggerFactory.getLogger(LoggingInvocationEventHandler.class);
-    private static final List<String> MESSAGE_PATTERNS = generateMessagePatterns(10);
+    private static final List<String> MESSAGE_PATTERNS = generateMessagePatterns(20);
 
     public static final com.palantir.tritium.api.functions.LongPredicate LOG_ALL_DURATIONS =
             com.palantir.tritium.api.functions.LongPredicate.TRUE;
@@ -224,30 +223,10 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
                 }
             }
 
-            logParams[2 + i] = DynamicSafeArg.of("type", i, argMessage);
+            logParams[2 + i] = SafeArg.of("type" + i, argMessage);
         }
 
         return logParams;
     }
 
-    /**
-     * Like {@link SafeArg}, but works around strict {@link com.google.errorprone.annotations.CompileTimeConstant}
-     * argument name restrictions, as we guarantee safety.
-     */
-    private static final class DynamicSafeArg<T> extends Arg<T> {
-        private static final long serialVersionUID = 1L;
-
-        private DynamicSafeArg(String name, @Nullable T value) {
-            super(name, value);
-        }
-
-        static Arg<String> of(@CompileTimeConstant String name, int index, String message) {
-            return new DynamicSafeArg<>(name + index, message);
-        }
-
-        @Override
-        public boolean isSafeForLogging() {
-            return true;
-        }
-    }
 }

--- a/tritium-test/src/main/java/com/palantir/tritium/test/event/ThrowingInvocationEventHandler.java
+++ b/tritium-test/src/main/java/com/palantir/tritium/test/event/ThrowingInvocationEventHandler.java
@@ -33,14 +33,16 @@ public class ThrowingInvocationEventHandler implements InvocationEventHandler<In
     }
 
     @Override
-    public com.palantir.tritium.event.InvocationContext preInvocation(Object instance, Method method, Object[] args) {
+    public com.palantir.tritium.event.InvocationContext preInvocation(
+            @Nonnull Object instance,
+            @Nonnull Method method,
+            @Nonnull Object[] args) {
         throw new SafeIllegalStateException("preInvocation always throws");
     }
 
     @Override
     public void onSuccess(@Nullable InvocationContext context, @Nullable Object result) {
         throw new SafeIllegalStateException("onSuccess always throws");
-
     }
 
     @Override

--- a/tritium-tracing/src/main/java/com/palantir/tritium/tracing/RemotingCompatibleTracingInvocationEventHandler.java
+++ b/tritium-tracing/src/main/java/com/palantir/tritium/tracing/RemotingCompatibleTracingInvocationEventHandler.java
@@ -52,7 +52,7 @@ public final class RemotingCompatibleTracingInvocationEventHandler
     }
 
     @Override
-    public InvocationContext preInvocation(Object instance, Method method, Object[] args) {
+    public InvocationContext preInvocation(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args) {
         InvocationContext context = DefaultInvocationContext.of(instance, method, args);
         String operationName = getOperationName(method);
         tracer.startSpan(operationName);

--- a/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java
+++ b/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java
@@ -63,7 +63,7 @@ public final class TracingInvocationEventHandler extends AbstractInvocationEvent
     }
 
     @Override
-    public InvocationContext preInvocation(Object instance, Method method, Object[] args) {
+    public InvocationContext preInvocation(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args) {
         InvocationContext context = DefaultInvocationContext.of(instance, method, args);
         String operationName = getOperationName(method);
         Tracer.startSpan(operationName);

--- a/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java
+++ b/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java
@@ -44,6 +44,7 @@ public final class TracingInvocationEventHandler extends AbstractInvocationEvent
      * @deprecated use {@link #create(String)}
      */
     @Deprecated
+    @SuppressWarnings("DeprecatedIsStillUsed") // used by static factory
     public TracingInvocationEventHandler(String component) {
         super((java.util.function.BooleanSupplier) getEnabledSupplier(component));
         this.component = checkNotNull(component, "component");

--- a/tritium-tracing/src/test/java/com/palantir/tritium/tracing/JavaTracingTracerTest.java
+++ b/tritium-tracing/src/test/java/com/palantir/tritium/tracing/JavaTracingTracerTest.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.tracing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.tracing.api.Span;
+import java.util.Deque;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import org.junit.Test;
+
+public class JavaTracingTracerTest {
+
+    @Test
+    public void trace() {
+        Deque<Span> observedSpans = new ConcurrentLinkedDeque<>();
+        com.palantir.tracing.Tracer.subscribe("test", observedSpans::add);
+        JavaTracingTracer tracer = JavaTracingTracer.INSTANCE;
+        assertThat(observedSpans).isEmpty();
+        tracer.startSpan("test");
+        assertThat(observedSpans).isEmpty();
+        tracer.completeSpan();
+        assertThat(observedSpans)
+                .hasSize(1)
+                .first()
+                .extracting("operation")
+                .contains("test");
+    }
+
+}

--- a/tritium-tracing/src/test/java/com/palantir/tritium/tracing/TracingInvocationEventHandlerTest.java
+++ b/tritium-tracing/src/test/java/com/palantir/tritium/tracing/TracingInvocationEventHandlerTest.java
@@ -59,6 +59,7 @@ public class TracingInvocationEventHandlerTest {
     @Before
     public void before() throws Exception {
         Tracer.getAndClearTrace();
+        MDC.clear();
         executor = MoreExecutors.newDirectExecutorService();
         handler = TracingInvocationEventHandler.create("testComponent");
         assertThat(handler).isInstanceOf(TracingInvocationEventHandler.class);
@@ -78,6 +79,7 @@ public class TracingInvocationEventHandlerTest {
         Tracer.unsubscribe("slf4j");
         executor.shutdownNow();
         Tracer.getAndClearTrace();
+        MDC.clear();
     }
 
     @Test


### PR DESCRIPTION
* Enable `UnusedVariable:ERROR`
* Enable `JavaTimeDefaultTimeZone:ERROR`
* Add JavaTracingTracerTest
* Enable unchecked type linting
* Include `@Nonnull` annotations on handler implementations
* Clarify API and test method visibility
* Remove extraneous generics from InvocationEventProxy
* Improve `tritium-metrics` test coverage
* `DefaultTaggedMetricRegistry` uses safe-logging preconditions
* Update default included benchmarks