### PR TITLE
Avoid potential deadlock copying system properties

### DIFF
--- a/tritium-core/build.gradle
+++ b/tritium-core/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     testImplementation 'com.google.guava:guava-testlib'
     testImplementation 'junit:junit'
     testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.awaitility:awaitility'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.slf4j:slf4j-simple'
 

--- a/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationProperties.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationProperties.java
@@ -90,7 +90,9 @@ public final class InstrumentationProperties {
         @SuppressWarnings("unchecked")
         Map<Object, Object> clonedSystemProperties = (Map<Object, Object>) System.getProperties().clone();
         Map<String, String> map = clonedSystemProperties.entrySet().stream()
-                .filter(entry -> String.valueOf(entry.getKey()).startsWith(INSTRUMENT_PREFIX))
+                .filter(entry -> entry.getKey() instanceof String
+                        && entry.getValue() instanceof String
+                        && String.valueOf(entry.getKey()).startsWith(INSTRUMENT_PREFIX))
                 .collect(ImmutableMap.toImmutableMap(
                         entry -> String.valueOf(entry.getKey()),
                         entry -> String.valueOf(entry.getValue())));

--- a/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationPropertiesTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationPropertiesTest.java
@@ -18,12 +18,30 @@ package com.palantir.tritium.event;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.tritium.api.functions.BooleanSupplier;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.awaitility.Duration;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class InstrumentationPropertiesTest {
+
+    private ListeningExecutorService executorService =
+            MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
 
     @Before
     public void before() {
@@ -31,6 +49,11 @@ public class InstrumentationPropertiesTest {
         System.getProperties().entrySet().removeIf(entry ->
                 entry.getKey().toString().startsWith("instrument"));
         InstrumentationProperties.reload();
+    }
+
+    @After
+    public void after() {
+        executorService.shutdownNow();
     }
 
     @Test
@@ -81,5 +104,81 @@ public class InstrumentationPropertiesTest {
         assertThatThrownBy(() -> InstrumentationProperties.getSystemPropertySupplier(""))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("name cannot be null or empty: {name=}");
+    }
+
+    @Test
+    public void racingSystemProperties() throws Exception {
+        CountDownLatch latch = new CountDownLatch(8);
+        List<Callable<Object>> tasks = ImmutableList.of(
+                () -> {
+                    latch.countDown();
+                    latch.await();
+                    return "getSystemPropertySupplier: " + InstrumentationProperties.getSystemPropertySupplier("test")
+                            .asBoolean();
+                },
+                () -> {
+                    latch.countDown();
+                    latch.await();
+                    return "getProperty: " + System.getProperty("instrument.test");
+                },
+                () -> {
+                    latch.countDown();
+                    latch.await();
+                    return "setProperty: " + System.setProperty("instrument.test", "true");
+                },
+                () -> {
+                    latch.countDown();
+                    latch.await();
+                    for (int i = 0; i < 1000; i++) {
+                        System.setProperty("test" + i, "value" + i);
+                    }
+                    return "setProperties: " + System.getProperties();
+                },
+                () -> {
+                    latch.countDown();
+                    latch.await();
+                    InstrumentationProperties.reload();
+                    return "reload";
+                },
+                () -> {
+                    latch.countDown();
+                    latch.await();
+                    return "getSystemPropertySupplier: "
+                            + InstrumentationProperties.getSystemPropertySupplier("test").asBoolean();
+                },
+                () -> {
+                    latch.countDown();
+                    latch.await();
+                    return "isSpecificEnabled: " + InstrumentationProperties.isSpecificEnabled("test");
+                },
+                () -> {
+                    latch.countDown();
+                    latch.await();
+                    return "isGloballyEnabled: " + InstrumentationProperties.isGloballyEnabled();
+                });
+
+        List<ListenableFuture<Object>> futures = tasks.stream()
+                .map(task -> executorService.submit(task))
+                .map(task -> {
+                    Futures.addCallback(task, new FutureCallback<Object>() {
+                        @Override
+                        public void onSuccess(@Nullable Object result) {
+                            System.out.println("result: " + result);
+                        }
+
+                        @Override
+                        public void onFailure(Throwable throwable) {
+                            System.err.println("error: " + throwable);
+                            throwable.printStackTrace(System.err);
+                            assertThat(throwable).isNull();
+                        }
+                    }, MoreExecutors.directExecutor());
+                    return task;
+                })
+                .collect(Collectors.toList());
+
+        await().atMost(Duration.FIVE_SECONDS).untilAsserted(() -> {
+            assertThat(Futures.allAsList(futures).get()).hasSize(futures.size());
+        });
     }
 }

--- a/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationPropertiesTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationPropertiesTest.java
@@ -148,7 +148,8 @@ public class InstrumentationPropertiesTest {
                     return "isGloballyEnabled: " + InstrumentationProperties.isGloballyEnabled();
                 });
 
-        assertThat(barrier.getParties()).isEqualTo(tasks.size());
+        final int expectedTaskCount = tasks.size();
+        assertThat(barrier.getParties()).isEqualTo(expectedTaskCount);
         assertThat(barrier.getNumberWaiting()).isZero();
 
         @SuppressWarnings("unchecked") // guaranteed by ListenableExecutorService
@@ -158,7 +159,7 @@ public class InstrumentationPropertiesTest {
         Futures.addCallback(successfulAsList, new FutureCallback<List<Object>>() {
             @Override
             public void onSuccess(@Nullable List<Object> result) {
-                assertThat(result).isNotNull().hasSize(futures.size());
+                assertThat(result).isNotNull().hasSize(expectedTaskCount);
             }
 
             @Override
@@ -168,7 +169,7 @@ public class InstrumentationPropertiesTest {
         }, MoreExecutors.directExecutor());
 
         await().atMost(Duration.FIVE_SECONDS).untilAsserted(() -> {
-            assertThat(successfulAsList.get()).hasSize(futures.size());
+            assertThat(successfulAsList.get()).hasSize(expectedTaskCount);
             assertThat(barrier.getNumberWaiting()).isZero();
         });
     }

--- a/versions.props
+++ b/versions.props
@@ -16,6 +16,7 @@ com.uber.nullaway:nullaway = 0.6.4
 io.dropwizard.metrics:metrics-core = 3.2.5
 junit:junit = 4.12
 org.assertj:assertj-core = 3.12.2
+org.awaitility:awaitility = 3.1.6
 org.checkerframework:checker-qual = 2.5.0
 org.hdrhistogram:* = 2.1.11
 org.immutables:* = 2.7.5


### PR DESCRIPTION
Since system properties are backed by a `java.util.Hashtable`, they can be a point of contention as all access is synchronized. We therefore take an approach of cloning the entire `Hashtable` (which does its own locking), then copying only the entries we are interested in keeping.

See https://bugs.openjdk.java.net/browse/JDK-6977738 and https://bugs.openjdk.java.net/browse/JDK-8029891