### PR TITLE
Allow access to wrapped SSLEngine delegate instances

### DIFF
--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslEngine.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslEngine.java
@@ -68,6 +68,15 @@ class InstrumentedSslEngine extends SSLEngine {
         return new InstrumentedSslEngine(engine, metrics, name);
     }
 
+    // Extracts a delegate SSLEngine instance if the input is wrapped.
+    static SSLEngine extractDelegate(SSLEngine maybeInstrumented) {
+        SSLEngine current = maybeInstrumented;
+        while (current instanceof InstrumentedSslEngine) {
+            current = ((InstrumentedSslEngine) current).engine;
+        }
+        return current;
+    }
+
     @Nullable
     private static Method getMethodNullable(Class<? extends SSLEngine> target, String name, Class<?>... paramTypes) {
         if (System.getSecurityManager() == null) {

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -324,7 +324,7 @@ public final class MetricRegistries {
      * @return The delegate instrumented engine, or the input if it is not instrumented
      */
     public static SSLEngine unwrap(SSLEngine engine) {
-        return InstrumentedSslEngine.extractDelegate(engine);
+        return InstrumentedSslEngine.extractDelegate(checkNotNull(engine, "engine"));
     }
 
     /**

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSocketFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -312,6 +313,18 @@ public final class MetricRegistries {
                 checkNotNull(factory, "factory"),
                 checkNotNull(registry, "registry"),
                 checkNotNull(name, "name"));
+    }
+
+    /**
+     * Extracts the wrapped delegate if the input {@link SSLEngine} is instrumented, otherwise returns the input.
+     * Some libraries (Conscrypt, for example) use <code>instanceof</code> checks and casts to configure specific
+     * {@link SSLEngine} implementations. In such cases, it may be necessary to unwrap the instrumented instance.
+     *
+     * @param engine Engine to unwrap
+     * @return The delegate instrumented engine, or the input if it is not instrumented
+     */
+    public static SSLEngine unwrap(SSLEngine engine) {
+        return InstrumentedSslEngine.extractDelegate(engine);
     }
 
     /**

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/InstrumentedSslContextTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/InstrumentedSslContextTest.java
@@ -191,7 +191,7 @@ public class InstrumentedSslContextTest {
                 metrics, MetricRegistries.instrument(metrics, context, "first"), "second");
         SSLEngine engine = wrapped.createSSLEngine();
         assertThat(engine).isInstanceOf(InstrumentedSslEngine.class);
-        assertThat(MetricRegistries.unwrap(engine)).isNotInstanceOf(InstrumentedSslEngine.class);
+        assertThat(MetricRegistries.unwrap(engine)).isNotNull().isNotInstanceOf(InstrumentedSslEngine.class);
     }
 
     private static Closeable server(SSLContext context) {


### PR DESCRIPTION
This is necessary for servers which provide Conscrypt-based ALPN
using Conscryp on java 8:
https://github.com/google/conscrypt/blob/d7d3ec873a50c733c9c4397d6718c04045b377b3/common/src/main/java/org/conscrypt/Conscrypt.java#L638-L649