### PR TITLE
Change executor name tag

### DIFF
--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslEngine.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslEngine.java
@@ -284,7 +284,7 @@ class InstrumentedSslEngine extends SSLEngine {
                 if (session != null) {
                     metrics.meter(MetricName.builder()
                             .safeName("tls.handshake")
-                            .putSafeTags("name", name)
+                            .putSafeTags("context", name)
                             .putSafeTags("cipher", session.getCipherSuite())
                             .putSafeTags("protocol", session.getProtocol())
                             .build())

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslSocketFactory.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslSocketFactory.java
@@ -98,7 +98,7 @@ final class InstrumentedSslSocketFactory extends SSLSocketFactory {
     static HandshakeCompletedListener newHandshakeListener(TaggedMetricRegistry metrics, String name) {
         return event -> metrics.meter(MetricName.builder()
                 .safeName("tls.handshake")
-                .putSafeTags("name", name)
+                .putSafeTags("context", name)
                 .putSafeTags("cipher", event.getCipherSuite())
                 .putSafeTags("protocol", event.getSession().getProtocol())
                 .build())

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsExecutorService.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsExecutorService.java
@@ -192,7 +192,7 @@ final class TaggedMetricsExecutorService implements ExecutorService {
     private static MetricName createMetricName(String metricName, String name) {
         return MetricName.builder()
                 .safeName(MetricRegistry.name("executor", metricName))
-                .putSafeTags("executor-name", name)
+                .putSafeTags("executor", name)
                 .build();
     }
 }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsExecutorService.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsExecutorService.java
@@ -192,7 +192,7 @@ final class TaggedMetricsExecutorService implements ExecutorService {
     private static MetricName createMetricName(String metricName, String name) {
         return MetricName.builder()
                 .safeName(MetricRegistry.name("executor", metricName))
-                .putSafeTags("name", name)
+                .putSafeTags("executor-name", name)
                 .build();
     }
 }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsScheduledExecutorService.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsScheduledExecutorService.java
@@ -248,7 +248,7 @@ final class TaggedMetricsScheduledExecutorService implements ScheduledExecutorSe
     private static MetricName createMetricName(String metricName, String name) {
         return MetricName.builder()
                 .safeName(MetricRegistry.name("executor", metricName))
-                .putSafeTags("name", name)
+                .putSafeTags("executor-name", name)
                 .build();
     }
 }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsScheduledExecutorService.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsScheduledExecutorService.java
@@ -248,7 +248,7 @@ final class TaggedMetricsScheduledExecutorService implements ScheduledExecutorSe
     private static MetricName createMetricName(String metricName, String name) {
         return MetricName.builder()
                 .safeName(MetricRegistry.name("executor", metricName))
-                .putSafeTags("executor-name", name)
+                .putSafeTags("executor", name)
                 .build();
     }
 }

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/InstrumentedSslContextTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/InstrumentedSslContextTest.java
@@ -69,7 +69,7 @@ public class InstrumentedSslContextTest {
 
         MetricName name = MetricName.builder()
                 .safeName("tls.handshake")
-                .putSafeTags("name", "client-context")
+                .putSafeTags("context", "client-context")
                 .putSafeTags("cipher", ENABLED_CIPHER)
                 .putSafeTags("protocol", ENABLED_PROTOCOL)
                 .build();
@@ -96,7 +96,7 @@ public class InstrumentedSslContextTest {
 
         MetricName name = MetricName.builder()
                 .safeName("tls.handshake")
-                .putSafeTags("name", "okhttp-client")
+                .putSafeTags("context", "okhttp-client")
                 .putSafeTags("cipher", ENABLED_CIPHER)
                 .putSafeTags("protocol", ENABLED_PROTOCOL)
                 .build();
@@ -124,7 +124,7 @@ public class InstrumentedSslContextTest {
 
         MetricName name = MetricName.builder()
                 .safeName("tls.handshake")
-                .putSafeTags("name", "okhttp-client")
+                .putSafeTags("context", "okhttp-client")
                 .putSafeTags("cipher", ENABLED_CIPHER)
                 .putSafeTags("protocol", ENABLED_PROTOCOL)
                 .build();
@@ -150,7 +150,7 @@ public class InstrumentedSslContextTest {
 
         MetricName name = MetricName.builder()
                 .safeName("tls.handshake")
-                .putSafeTags("name", "h2-server")
+                .putSafeTags("context", "h2-server")
                 .putSafeTags("cipher", ENABLED_CIPHER)
                 .putSafeTags("protocol", ENABLED_PROTOCOL)
                 .build();
@@ -169,7 +169,7 @@ public class InstrumentedSslContextTest {
 
         MetricName name = MetricName.builder()
                 .safeName("tls.handshake")
-                .putSafeTags("name", "server-context")
+                .putSafeTags("context", "server-context")
                 .putSafeTags("cipher", ENABLED_CIPHER)
                 .putSafeTags("protocol", ENABLED_PROTOCOL)
                 .build();

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsExecutorServiceTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsExecutorServiceTest.java
@@ -107,7 +107,7 @@ public final class TaggedMetricsExecutorServiceTest {
     private static MetricName metricName(String metricName) {
         return MetricName.builder()
                 .safeName(MetricRegistry.name("executor", metricName))
-                .putSafeTags("name", NAME)
+                .putSafeTags("executor-name", NAME)
                 .build();
     }
 }

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsExecutorServiceTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsExecutorServiceTest.java
@@ -107,7 +107,7 @@ public final class TaggedMetricsExecutorServiceTest {
     private static MetricName metricName(String metricName) {
         return MetricName.builder()
                 .safeName(MetricRegistry.name("executor", metricName))
-                .putSafeTags("executor-name", NAME)
+                .putSafeTags("executor", NAME)
                 .build();
     }
 }

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsScheduledExecutorServiceTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsScheduledExecutorServiceTest.java
@@ -162,7 +162,7 @@ public final class TaggedMetricsScheduledExecutorServiceTest {
     private static MetricName metricName(String metricName) {
         return MetricName.builder()
                 .safeName(MetricRegistry.name("executor", metricName))
-                .putSafeTags("executor-name", NAME)
+                .putSafeTags("executor", NAME)
                 .build();
     }
 }

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsScheduledExecutorServiceTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsScheduledExecutorServiceTest.java
@@ -162,7 +162,7 @@ public final class TaggedMetricsScheduledExecutorServiceTest {
     private static MetricName metricName(String metricName) {
         return MetricName.builder()
                 .safeName(MetricRegistry.name("executor", metricName))
-                .putSafeTags("name", NAME)
+                .putSafeTags("executor-name", NAME)
                 .build();
     }
 }


### PR DESCRIPTION
This tag conflicts with another tag used internally to identify hosts. It's probably better to use something more specific here anyways.