### PR TITLE
fix #256: Log the string value of Metric implementations

### DIFF
--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -370,13 +370,15 @@ public final class MetricRegistries {
                 if (replace && registry.remove(name)) {
                     logger.info("Removed existing registered metric with name {}: {}",
                             SafeArg.of("name", name),
-                            SafeArg.of("existingMetric", existingMetric));
+                            // #256: Metric implementations are necessarily json serializable
+                            SafeArg.of("existingMetric", String.valueOf(existingMetric)));
                     registry.register(name, metric);
                     return metric;
                 } else {
                     logger.warn("Metric already registered at this name. Name: {}, existing metric: {}",
                             SafeArg.of("name", name),
-                            SafeArg.of("existingMetric", existingMetric));
+                            // #256: Metric implementations are necessarily json serializable
+                            SafeArg.of("existingMetric", String.valueOf(existingMetric)));
                     @SuppressWarnings("unchecked")
                     T registeredMetric = (T) existingMetric;
                     return registeredMetric;

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -362,9 +362,10 @@ public final class MetricRegistries {
                 Set<Class<?>> existingMetricInterfaces = ImmutableSet.copyOf(existingMetric.getClass().getInterfaces());
                 Set<Class<?>> newMetricInterfaces = ImmutableSet.copyOf(metric.getClass().getInterfaces());
                 if (!existingMetricInterfaces.equals(newMetricInterfaces)) {
-                    throw new IllegalArgumentException(
-                            "Metric already registered at this name that implements a different set of interfaces."
-                                    + " Name: " + name + ", existing metric: " + existingMetric);
+                    throw new SafeIllegalArgumentException(
+                            "Metric already registered at this name that implements a different set of interfaces",
+                            SafeArg.of("name", name),
+                            SafeArg.of("existingMetric", String.valueOf(existingMetric)));
                 }
 
                 if (replace && registry.remove(name)) {

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
@@ -327,8 +327,8 @@ public class MetricRegistriesTest {
                 MetricRegistries.registerSafe(metrics, "test", metrics.histogram("histogram")))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageStartingWith(
-                        "Metric already registered at this name that implements a different set of interfaces. "
-                                + "Name: test, existing metric: com.codahale.metrics.Counter");
+                        "Metric already registered at this name that implements a different set of interfaces: "
+                                + "{name=test, existingMetric=com.codahale.metrics.Counter");
     }
 
     @Test


### PR DESCRIPTION
Logging layouts based on jackson serialization will fail to
serialize many metric implementations as JSON objects, it's not
clear what we expect the value to be if not `toString`.