### PR TITLE
Lower logging level in MetricRegistries

### DIFF
--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -369,7 +369,7 @@ public final class MetricRegistries {
                 }
 
                 if (replace && registry.remove(name)) {
-                    logger.info("Removed existing registered metric with name {}: {}",
+                    logger.debug("Removed existing registered metric with name {}: {}",
                             SafeArg.of("name", name),
                             // #256: Metric implementations are necessarily json serializable
                             SafeArg.of("existingMetric", String.valueOf(existingMetric)));


### PR DESCRIPTION
The current `INFO` level seems too high when notifying about existing registered metrics being removed and `DEBUG` feels more appropriate.