### PR TITLE
[fix] MetricRegistries.createWithSlidingTimeWindowReservoirs() counts are monotonic after window

### DIFF
--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/HistogramMetricBuilder.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/HistogramMetricBuilder.java
@@ -28,20 +28,6 @@ final class HistogramMetricBuilder extends AbstractReservoirMetricBuilder<Histog
 
     @Override
     public Histogram newMetric() {
-        return new ReservoirHistogram(getReservoirSupplier().get());
-    }
-
-    private static class ReservoirHistogram extends Histogram {
-        private final Reservoir reservoir;
-
-        ReservoirHistogram(Reservoir reservoir) {
-            super(reservoir);
-            this.reservoir = reservoir;
-        }
-
-        @Override
-        public long getCount() {
-            return reservoir.size();
-        }
+        return new Histogram(getReservoirSupplier().get());
     }
 }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TimerMetricBuilder.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TimerMetricBuilder.java
@@ -28,20 +28,6 @@ final class TimerMetricBuilder extends AbstractReservoirMetricBuilder<Timer> {
 
     @Override
     public Timer newMetric() {
-        return new ReservoirTimer(getReservoirSupplier().get());
-    }
-
-    private static class ReservoirTimer extends Timer {
-        private final Reservoir reservoir;
-
-        ReservoirTimer(Reservoir reservoir) {
-            super(reservoir);
-            this.reservoir = reservoir;
-        }
-
-        @Override
-        public long getCount() {
-            return reservoir.size();
-        }
+        return new Timer(getReservoirSupplier().get());
     }
 }

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
@@ -31,14 +31,11 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.SlidingTimeWindowArrayReservoir;
 import com.codahale.metrics.Snapshot;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheStats;
 import com.google.common.cache.LoadingCache;
-import com.palantir.tritium.metrics.registry.MetricName;
-import com.palantir.tritium.metrics.registry.SlidingWindowTaggedMetricRegistry;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.time.ZoneOffset;
@@ -394,42 +391,6 @@ public class MetricRegistriesTest {
         assertParsesTimestamp("2019-03-30T02:06:35.045Z");
         assertParsesTimestamp("2019-03-29T23:38:51.920Z");
         assertParsesTimestamp("2019-03-29T23:38:51.092Z");
-    }
-
-    @Test
-    public void codahale_registry_histogram_count_should_monotonically_increase_after_window()
-            throws InterruptedException {
-        MetricRegistry registry = new MetricRegistryWithReservoirs(
-                () -> new SlidingTimeWindowArrayReservoir(1, TimeUnit.MILLISECONDS));
-
-        Histogram histogram = registry.histogram("histogram");
-        histogram.update(20);
-        histogram.update(20);
-        histogram.update(20);
-        histogram.update(20);
-
-        assertThat(histogram.getCount()).isEqualTo(4);
-
-        Thread.sleep(1);
-
-        assertThat(histogram.getCount()).isEqualTo(4);
-    }
-
-    @Test
-    public void tagged_registry_histogram_count_should_monotonically_increase_after_window()
-            throws InterruptedException {
-        SlidingWindowTaggedMetricRegistry registry = new SlidingWindowTaggedMetricRegistry(1, TimeUnit.MILLISECONDS);
-        Histogram histogram = registry.histogram(MetricName.builder().safeName("histogram").build());
-        histogram.update(20);
-        histogram.update(20);
-        histogram.update(20);
-        histogram.update(20);
-
-        assertThat(histogram.getCount()).isEqualTo(4);
-
-        Thread.sleep(1);
-
-        assertThat(histogram.getCount()).isEqualTo(4);
     }
 
     private static void assertParsesTimestamp(String timestamp) {


### PR DESCRIPTION
## Before this PR

We started using the SlidingTimeWindowArrayReservoir in WC release candidates, expecting to see slightly different p99s, but someone reported that counts were different!

<img width="996" alt="Screenshot 2019-05-10 at 13 16 09" src="https://user-images.githubusercontent.com/3473798/57531345-1ab25f80-7331-11e9-94d5-36098817fead.png">

As you can see, the `.count` of a histogram was resetting to zero after the end of each time window, which is inconsistent with the tagged metric registry.

## After this PR

Histogram counts behave consistently whether they came from a tagged or untagged registry.

## Possible downsides
- I assume the ReservoirHistogram was intended as a performance optimization, so deleting it might cause a minor slowdown somewhere.  I consider this worth it because I'd prefer consistency!!