### PR TITLE
Declare metrics-core as gradle `api` dependency

### DIFF
--- a/tritium-caffeine/build.gradle
+++ b/tritium-caffeine/build.gradle
@@ -9,11 +9,11 @@ dependencies {
     api project(':tritium-core')
     api project(':tritium-metrics')
     api 'com.github.ben-manes.caffeine:caffeine'
+    api 'io.dropwizard.metrics:metrics-core'
 
     implementation 'com.google.guava:guava'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
-    implementation 'io.dropwizard.metrics:metrics-core'
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation project(':tritium-test')

--- a/tritium-lib/build.gradle
+++ b/tritium-lib/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api project(':tritium-proxy')
     api project(':tritium-slf4j')
     api project(':tritium-tracing')
+    api 'io.dropwizard.metrics:metrics-core'
 
     implementation 'com.google.guava:guava'
     implementation 'com.palantir.safe-logging:preconditions'

--- a/tritium-registry/build.gradle
+++ b/tritium-registry/build.gradle
@@ -4,14 +4,14 @@ dependencies {
 
     annotationProcessor 'com.google.auto.service:auto-service'
     annotationProcessor 'org.immutables:value'
+    compileOnly 'com.google.auto.service:auto-service'
     compileOnly 'org.immutables:value::annotations'
 
-    compileOnly 'com.google.auto.service:auto-service'
+    api 'io.dropwizard.metrics:metrics-core'
 
     implementation 'com.google.guava:guava'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
-    implementation 'io.dropwizard.metrics:metrics-core'
 
     testImplementation 'junit:junit'
     testImplementation 'org.assertj:assertj-core'


### PR DESCRIPTION
Tritium requires io.dropwizard.metrics:metrics-core as an API dependency for the common user consumed modules:

  * tritium-lib
  * tritium-caffeine
  * tritium-metrics
  * tritium-registry

closes #274 