### PR TITLE
Replace usages of `assertThat(*.toString())` with `assertThat(*).asString()

### DIFF
--- a/tritium-core/src/test/java/com/palantir/tritium/event/CompositeInvocationEventHandlerTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/CompositeInvocationEventHandlerTest.java
@@ -153,7 +153,7 @@ public class CompositeInvocationEventHandlerTest {
     public void testToString() {
         InvocationEventHandler<InvocationContext> handler = CompositeInvocationEventHandler.of(
                 Arrays.asList(NoOpInvocationEventHandler.INSTANCE, new SimpleInvocationEventHandler()));
-        assertThat(handler.toString())
+        assertThat(handler).asString()
                 .startsWith("CompositeInvocationEventHandler{handlers=[INSTANCE, ")
                 .endsWith("]}");
     }

--- a/tritium-core/src/test/java/com/palantir/tritium/event/DefaultInvocationContextTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/DefaultInvocationContextTest.java
@@ -32,12 +32,12 @@ public class DefaultInvocationContextTest {
         assertThat(context.getArgs()).isEqualTo(new Object[]{"testArgument"});
         assertThat(context.getMethod()).isEqualTo(Object.class.getDeclaredMethod("equals", Object.class));
 
-        String toString = context.toString();
-        assertThat(toString).contains("startTimeNanos");
-        assertThat(toString).contains("instance");
-        assertThat(toString).contains("method");
-        assertThat(toString).doesNotContain("args");
-        assertThat(toString).doesNotContain("testArgument");
+        assertThat(context).asString()
+                .contains("startTimeNanos")
+                .contains("instance")
+                .contains("method")
+                .doesNotContain("args")
+                .doesNotContain("testArgument");
     }
 
 }

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
@@ -36,7 +36,6 @@ import com.palantir.tritium.test.TestInterface;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.BooleanSupplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -76,14 +75,14 @@ public class InvocationEventProxyTest {
         InvocationEventProxy proxy = createTestProxy(testHandler);
 
         assertThat(proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS))
-                .isNotNull().extracting(Object::toString).isEqualTo("test");
+                .asString().isEqualTo("test");
 
         Object result2 = proxy.handlePreInvocation(this, getToStringMethod(), EMPTY_ARGS);
-        assertThat(result2).isInstanceOf(DefaultInvocationContext.class);
-        assertThat(Objects.requireNonNull(result2).toString()).contains(InvocationEventProxyTest.class.getName());
+        assertThat(result2).isInstanceOf(DefaultInvocationContext.class)
+                .asString().contains(InvocationEventProxyTest.class.getName());
 
         InvocationContext context = proxy.handlePreInvocation(this, getToStringMethod(), EMPTY_ARGS);
-        assertThat(Objects.requireNonNull(context).toString())
+        assertThat(context).asString()
                 .contains("startTimeNanos")
                 .contains("instance")
                 .contains("method");
@@ -105,7 +104,7 @@ public class InvocationEventProxyTest {
 
         Object result = proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS);
 
-        assertThat(Objects.requireNonNull(result).toString()).isEqualTo("test");
+        assertThat(result).asString().isEqualTo("test");
     }
 
     @Test
@@ -122,7 +121,7 @@ public class InvocationEventProxyTest {
 
         Object result = proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS);
 
-        assertThat(Objects.requireNonNull(result).toString()).isEqualTo("test");
+        assertThat(result).asString().isEqualTo("test");
 
         InvocationContext context = DefaultInvocationContext.of(this, getToStringMethod(), null);
         proxy.handleOnSuccess(context, result);
@@ -146,7 +145,7 @@ public class InvocationEventProxyTest {
         InvocationEventProxy proxy = createTestProxy(testHandler);
 
         Object result = proxy.handleInvocation(this, getToStringMethod(), EMPTY_ARGS);
-        assertThat(Objects.requireNonNull(result).toString()).isEqualTo("test");
+        assertThat(result).asString().isEqualTo("test");
 
         InvocationContext context = DefaultInvocationContext.of(this, getToStringMethod(), null);
         RuntimeException expected = new RuntimeException("expected");
@@ -178,7 +177,7 @@ public class InvocationEventProxyTest {
             }
         };
 
-        assertThat(proxy.toString()).isEqualTo("Hello, world");
+        assertThat(proxy).asString().isEqualTo("Hello, world");
     }
 
     @Test


### PR DESCRIPTION
This provides cleaner null checks without writing the code ourselves.