### PR TITLE
Add metric for JVM process cpu load

### DIFF
--- a/changelog/@unreleased/pr-309.v2.yml
+++ b/changelog/@unreleased/pr-309.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add `process.cpu.utilization` gauge for process cpu load.
+  links:
+  - https://github.com/palantir/tritium/pull/309

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/OperatingSystemMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/OperatingSystemMetrics.java
@@ -22,12 +22,19 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 
 final class OperatingSystemMetrics {
+    private static final MetricName OS_LOAD_NORM_1 = MetricName.builder().safeName("os.load.norm.1").build();
+    private static final MetricName OS_LOAD_1 = MetricName.builder().safeName("os.load.1").build();
+    private static final MetricName OS_PROCESS_CPU_UTILIZATION
+            = MetricName.builder().safeName("process.cpu.utilization").build();
 
     static void register(TaggedMetricRegistry registry) {
         OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();
-        registry.gauge(MetricName.builder().safeName("os.load.norm.1").build(),
-                () -> osMxBean.getSystemLoadAverage() / osMxBean.getAvailableProcessors());
-        registry.gauge(MetricName.builder().safeName("os.load.1").build(), osMxBean::getSystemLoadAverage);
+        registry.gauge(OS_LOAD_NORM_1, () -> osMxBean.getSystemLoadAverage() / osMxBean.getAvailableProcessors());
+        registry.gauge(OS_LOAD_1, osMxBean::getSystemLoadAverage);
+        if (osMxBean instanceof com.sun.management.OperatingSystemMXBean) {
+            com.sun.management.OperatingSystemMXBean sunBean = (com.sun.management.OperatingSystemMXBean) osMxBean;
+            registry.gauge(OS_PROCESS_CPU_UTILIZATION, sunBean::getProcessCpuLoad);
+        }
     }
 
     private OperatingSystemMetrics() {

--- a/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
+++ b/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
@@ -82,7 +82,9 @@ public class JvmMetricsTest {
             "jvm.threads.terminated.count",
             "jvm.threads.blocked.count",
             "os.load.1",
-            "os.load.norm.1");
+            "os.load.norm.1",
+            "process.cpu.utilization"
+    );
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -130,6 +132,17 @@ public class JvmMetricsTest {
                 .get(MetricName.builder().safeName("os.load.1").build());
         assertThat(systemLoad.getValue()).isPositive();
         assertThat(systemLoadNormalized.getValue()).isPositive();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCpuLoad() {
+        TaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+        JvmMetrics.register(registry);
+        Gauge<Double> processCpuLoad = (Gauge<Double>) registry.getMetrics()
+                .get(MetricName.builder().safeName("process.cpu.utilization").build());
+        double processLoad = processCpuLoad.getValue();
+        assertThat(processLoad).isGreaterThanOrEqualTo(0D).isLessThanOrEqualTo(1D);
     }
 
     @Test


### PR DESCRIPTION
==COMMIT_MSG==
Added `process.cpu.utilization` gauge for process cpu load.
==COMMIT_MSG==

