### PR TITLE
Check unused dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,7 @@ allprojects {
     tasks.check.dependsOn(javadoc)
 
     tasks.check.dependsOn(checkImplicitDependencies)
+    tasks.check.dependsOn(checkUnusedDependencies)
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -67,9 +67,6 @@ allprojects {
             }
         }
 
-        // Work around https://github.com/immutables/immutables/issues/291
-        compileOnly 'org.immutables:value::annotations'
-        testCompileOnly 'org.immutables:value::annotations'
     }
 
     plugins.withId('com.palantir.baseline-error-prone', {

--- a/changelog/@unreleased/pr-337.v2.yml
+++ b/changelog/@unreleased/pr-337.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Check that all modules declare minimum dependencies
+  links:
+  - https://github.com/palantir/tritium/pull/337

--- a/tritium-caffeine/build.gradle
+++ b/tritium-caffeine/build.gradle
@@ -5,18 +5,14 @@ targetCompatibility = 1.8
 
 dependencies {
 
-    api project(':tritium-api')
-    api project(':tritium-core')
     api project(':tritium-metrics')
     api project(':tritium-registry')
     api 'com.github.ben-manes.caffeine:caffeine'
     api 'io.dropwizard.metrics:metrics-core'
 
-    implementation 'com.google.code.findbugs:jsr305'
     implementation 'com.google.guava:guava'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
-    implementation 'org.slf4j:slf4j-api'
 
     testImplementation project(':tritium-test')
     testImplementation 'ch.qos.logback:logback-classic'

--- a/tritium-caffeine/build.gradle
+++ b/tritium-caffeine/build.gradle
@@ -27,5 +27,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.slf4j:slf4j-simple'
 
+    // Work around https://github.com/immutables/immutables/issues/291
+    compileOnly 'org.immutables:value::annotations'
+    testCompileOnly 'org.immutables:value::annotations'
 }
 

--- a/tritium-jmh/build.gradle
+++ b/tritium-jmh/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     jmh project(':tritium-test')
     jmh 'ch.qos.logback:logback-classic'
     jmh 'com.palantir.remoting3:tracing'
-    jmh 'org.immutables:value::annotations'
 
+    // Work around https://github.com/immutables/immutables/issues/291
+    compileOnly 'org.immutables:value::annotations'
+    jmhCompileOnly 'org.immutables:value::annotations'
+    testCompileOnly 'org.immutables:value::annotations'
 }

--- a/tritium-lib/build.gradle
+++ b/tritium-lib/build.gradle
@@ -26,4 +26,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.slf4j:slf4j-simple'
 
+    // Work around https://github.com/immutables/immutables/issues/291
+    compileOnly 'org.immutables:value::annotations'
+    testCompileOnly 'org.immutables:value::annotations'
 }
+

--- a/tritium-metrics-jvm/build.gradle
+++ b/tritium-metrics-jvm/build.gradle
@@ -1,6 +1,7 @@
 apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
+
     api project(':tritium-registry')
     implementation project(':tritium-metrics')
 
@@ -17,5 +18,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'
 
+    // Work around https://github.com/immutables/immutables/issues/291
+    compileOnly 'org.immutables:value::annotations'
+    testCompileOnly 'org.immutables:value::annotations'
 }
 

--- a/tritium-metrics/build.gradle
+++ b/tritium-metrics/build.gradle
@@ -3,7 +3,6 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 dependencies {
 
     annotationProcessor "org.immutables:value"
-    compileOnly 'org.immutables:value::annotations'
 
     api project(':tritium-api')
     api project(':tritium-core')
@@ -32,5 +31,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'
 
+    // Work around https://github.com/immutables/immutables/issues/291
+    compileOnly 'org.immutables:value::annotations'
+    testCompileOnly 'org.immutables:value::annotations'
 }
 

--- a/tritium-registry/build.gradle
+++ b/tritium-registry/build.gradle
@@ -5,7 +5,6 @@ dependencies {
     annotationProcessor 'com.google.auto.service:auto-service'
     annotationProcessor 'org.immutables:value'
     compileOnly 'com.google.auto.service:auto-service'
-    compileOnly 'org.immutables:value::annotations'
 
     api 'io.dropwizard.metrics:metrics-core'
 
@@ -21,5 +20,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'
 
+    // Work around https://github.com/immutables/immutables/issues/291
+    compileOnly 'org.immutables:value::annotations'
+    testCompileOnly 'org.immutables:value::annotations'
 }
 

--- a/tritium-slf4j/build.gradle
+++ b/tritium-slf4j/build.gradle
@@ -19,5 +19,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.slf4j:slf4j-simple'
 
+    // Work around https://github.com/immutables/immutables/issues/291
+    compileOnly 'org.immutables:value::annotations'
+    testCompileOnly 'org.immutables:value::annotations'
 }
 

--- a/tritium-slf4j/build.gradle
+++ b/tritium-slf4j/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     api project(':tritium-core')
 
     implementation 'com.google.code.findbugs:jsr305'
-    implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.google.guava:guava'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'

--- a/tritium-test/build.gradle
+++ b/tritium-test/build.gradle
@@ -1,11 +1,7 @@
 dependencies {
 
-    api 'org.slf4j:slf4j-api'
-
     implementation project(':tritium-api')
-    implementation project(':tritium-core')
     implementation 'com.google.code.findbugs:jsr305'
-    implementation 'com.google.guava:guava'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'io.dropwizard.metrics:metrics-core'

--- a/tritium-tracing/build.gradle
+++ b/tritium-tracing/build.gradle
@@ -19,4 +19,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'
 
+    // Work around https://github.com/immutables/immutables/issues/291
+    compileOnly 'org.immutables:value::annotations'
+    testCompileOnly 'org.immutables:value::annotations'
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

We were not checking that modules declared minimum possible dependencies.

## After this PR
==COMMIT_MSG==
Check that all modules declare minimum dependencies
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

Currently blocked by https://github.com/palantir/gradle-baseline/issues/747 
