### PR TITLE
Treat warnings as compile errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ allprojects {
 
         tasks.withType(JavaCompile).configureEach {
             options.compilerArgs += [
-                // '-Werror', // disable due to https://github.com/immutables/immutables/issues/291 for now
+                '-Werror',
                 '-Xlint:deprecation',
                 '-Xlint:unchecked',
             ]

--- a/changelog/@unreleased/pr-354.v2.yml
+++ b/changelog/@unreleased/pr-354.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Treat warnings as compile errors
+  links:
+  - https://github.com/palantir/tritium/pull/354


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Warnings were not treated as compile time errors

## After this PR
==COMMIT_MSG==
Treat warnings as compile errors
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Previously this was blocked by Immutables annotations causing spurious warnings for generated JSON classes in https://github.com/immutables/immutables/issues/291 but these are no longer blocking.

