### PR TITLE
Unset `errorProneApply=true` in gradle.properties to enable validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ allprojects {
                 because "Spark still uses 3.X, which can't co-exist with 4.X"
             }
         }
+
+        // Work around https://github.com/immutables/immutables/issues/291
+        compileOnly 'org.immutables:value::annotations'
+        testCompileOnly 'org.immutables:value::annotations'
     }
 
     plugins.withId('com.palantir.baseline-error-prone', {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 javaVersion = 1.8
 org.gradle.parallel=true
 com.palantir.baseline-versions.disable=true
-errorProneApply=true

--- a/tritium-jmh/build.gradle
+++ b/tritium-jmh/build.gradle
@@ -33,5 +33,6 @@ dependencies {
     jmh project(':tritium-test')
     jmh 'ch.qos.logback:logback-classic'
     jmh 'com.palantir.remoting3:tracing'
+    jmh 'org.immutables:value::annotations'
 
 }

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/SharedTaggedMetricRegistriesTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/SharedTaggedMetricRegistriesTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 final class SharedTaggedMetricRegistriesTest {
     @Test
+    @SuppressWarnings("deprecation") // testing a deprecated registry
     void all_default_methods_return_the_same_thing() {
         TaggedMetricRegistry defaultRegistry = SharedTaggedMetricRegistries.getSingleton();
         assertThat(DefaultTaggedMetricRegistry.getDefault()).isSameAs(defaultRegistry);

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistryTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistryTest.java
@@ -236,7 +236,7 @@ final class TaggedMetricRegistryTest {
         assertThat(counter.getCount()).isEqualTo(1);
     }
 
-    private void assertMetric(
+    private static void assertMetric(
             TaggedMetricRegistry registry,
             String name,
             String tagKey,


### PR DESCRIPTION
The `errorProneApply` flag disables several warnings in order to
successfully migrate repos away from deprecated methods when
automated ifxes are present.

==COMMIT_MSG==
Unset `errorProneApply=true` in gradle.properties to enable validation
==COMMIT_MSG==

