### PR TITLE
Optimize TaggedMetricsServiceInvocationEventHandler

### DIFF
--- a/changelog/@unreleased/pr-358.v2.yml
+++ b/changelog/@unreleased/pr-358.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Optimize TaggedMetricsServiceInvocationEventHandler
+  links:
+  - https://github.com/palantir/tritium/pull/358

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/ProxyBenchmark.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/ProxyBenchmark.java
@@ -21,6 +21,7 @@ import com.palantir.tracing.Tracer;
 import com.palantir.tritium.event.log.LoggingInvocationEventHandler;
 import com.palantir.tritium.event.log.LoggingLevel;
 import com.palantir.tritium.metrics.MetricRegistries;
+import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
 import com.palantir.tritium.proxy.Instrumentation;
 import com.palantir.tritium.tracing.RemotingCompatibleTracingInvocationEventHandler;
 import com.palantir.tritium.tracing.TracingInvocationEventHandler;
@@ -67,6 +68,7 @@ public class ProxyBenchmark {
     private Service instrumentedWithoutHandlers;
     private Service instrumentedWithPerformanceLogging;
     private Service instrumentedWithMetrics;
+    private Service instrumentedWithTaggedMetrics;
     private Service instrumentedWithEverything;
     private Service instrumentedWithTracing;
     private Service instrumentedWithTracingNested;
@@ -91,6 +93,10 @@ public class ProxyBenchmark {
 
         instrumentedWithMetrics = Instrumentation.builder(serviceInterface, raw)
                 .withMetrics(MetricRegistries.createWithHdrHistogramReservoirs())
+                .build();
+
+        instrumentedWithTaggedMetrics = Instrumentation.builder(serviceInterface, raw)
+                .withTaggedMetrics(SharedTaggedMetricRegistries.getSingleton(), serviceInterface.getName())
                 .build();
 
         instrumentedWithTracing = Instrumentation.builder(serviceInterface, raw)
@@ -151,6 +157,11 @@ public class ProxyBenchmark {
     @Benchmark
     public String instrumentedWithMetrics() {
         return instrumentedWithMetrics.echo("test");
+    }
+
+    @Benchmark
+    public String instrumentedWithTaggedMetrics() {
+        return instrumentedWithTaggedMetrics.echo("test");
     }
 
     @Benchmark

--- a/tritium-lib/src/test/java/com/palantir/tritium/TritiumTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/TritiumTest.java
@@ -113,13 +113,16 @@ public class TritiumTest {
     @Test
     public void testInstrumentWithTags() {
         assertThat(delegate.invocationCount()).isEqualTo(0);
-        assertThat(taggedMetricRegistry.getMetrics()).isEmpty();
+        assertThat(taggedMetricRegistry.getMetrics())
+                // The global failures metric is created eagerly
+                .containsOnlyKeys(MetricName.builder().safeName("failures").build());
 
         taggedInstrumentedService.test();
         assertThat(delegate.invocationCount()).isEqualTo(1);
 
         Map<MetricName, Metric> metrics = taggedMetricRegistry.getMetrics();
-        assertThat(metrics.keySet()).containsOnly(EXPECTED_TAGGED_METRIC_NAME);
+        assertThat(metrics.keySet())
+                .containsExactly(EXPECTED_TAGGED_METRIC_NAME, MetricName.builder().safeName("failures").build());
         Metric actual = metrics.get(EXPECTED_TAGGED_METRIC_NAME);
         assertThat(actual).isInstanceOf(Timer.class);
         Timer timer = (Timer) actual;

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
@@ -342,11 +342,16 @@ final class InstrumentationTest {
         runnable.test();
         assertThat(delegate.invocationCount()).isEqualTo(1);
         Map<MetricName, Metric> taggedMetrics = taggedMetricRegistry.getMetrics();
-        assertThat(taggedMetrics.keySet()).containsOnly(MetricName.builder()
-                .safeName("testPrefix")
-                .putSafeTags("service-name", "TestInterface")
-                .putSafeTags("endpoint", "test")
-                .build());
+        assertThat(taggedMetrics.keySet()).containsExactly(
+                MetricName.builder()
+                        .safeName("testPrefix")
+                        .putSafeTags("service-name", "TestInterface")
+                        .putSafeTags("endpoint", "test")
+                        .build(),
+                // The failures metric is created eagerly
+                MetricName.builder()
+                        .safeName("failures")
+                        .build());
 
         assertThat(taggedMetrics.values())
                 .first().isInstanceOf(Timer.class)


### PR DESCRIPTION
Create the global failure meter eagerly, cache timers by method
to avoid recreating metric name objects.

Before:
```
Benchmark                                     Mode  Cnt    Score     Error  Units
ProxyBenchmark.instrumentedWithTaggedMetrics  avgt    5  669.303 ± 108.389  ns/op
```

After:
```
Benchmark                                     Mode  Cnt    Score    Error  Units
ProxyBenchmark.instrumentedWithTaggedMetrics  avgt    5  233.019 ± 49.507  ns/op
```

## After this PR
==COMMIT_MSG==
Optimize TaggedMetricsServiceInvocationEventHandler
==COMMIT_MSG==

