### PR TITLE
Flatten the Tritium proxy to avoid excessive stack frames

### DIFF
--- a/changelog/@unreleased/pr-359.v2.yml
+++ b/changelog/@unreleased/pr-359.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Flatten the Tritium proxy to reduce proxy stack frames.
+  links:
+  - https://github.com/palantir/tritium/pull/359

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/BlackholeInvocationEventHandler.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/BlackholeInvocationEventHandler.java
@@ -56,12 +56,12 @@ final class BlackholeInvocationEventHandler implements InvocationEventHandler<In
     public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause) {
         consume(context, cause);
     }
-    private void consume(Object obj0, Object obj1, Object obj2) {
+    private void consume(@Nullable Object obj0, @Nullable Object obj1, @Nullable Object obj2) {
         consume(obj0, obj1);
         blackhole.consume(obj2);
     }
 
-    private void consume(Object obj0, Object obj1) {
+    private void consume(@Nullable Object obj0, @Nullable Object obj1) {
         blackhole.consume(obj0);
         blackhole.consume(obj1);
     }

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/BlackholeInvocationEventHandler.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/BlackholeInvocationEventHandler.java
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.microbenchmarks;
+
+import com.palantir.logsafe.Preconditions;
+import com.palantir.tritium.event.DefaultInvocationContext;
+import com.palantir.tritium.event.InvocationContext;
+import com.palantir.tritium.event.InvocationEventHandler;
+import java.lang.reflect.Method;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.openjdk.jmh.infra.Blackhole;
+
+final class BlackholeInvocationEventHandler implements InvocationEventHandler<InvocationContext> {
+
+    private static final InvocationContext SINGLETON_CONTEXT =
+            DefaultInvocationContext.of("stub", String.class.getMethods()[0], new Object[0]);
+
+    private final Blackhole blackhole;
+
+    BlackholeInvocationEventHandler(Blackhole blackhole) {
+        this.blackhole = Preconditions.checkNotNull(blackhole, "Blackhole is required");
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public InvocationContext preInvocation(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args) {
+        consume(instance, method, args);
+        return SINGLETON_CONTEXT;
+    }
+
+    @Override
+    public void onSuccess(@Nullable InvocationContext context, @Nullable Object result) {
+        consume(context, result);
+    }
+
+    @Override
+    public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause) {
+        consume(context, cause);
+    }
+    private void consume(Object obj0, Object obj1, Object obj2) {
+        consume(obj0, obj1);
+        blackhole.consume(obj2);
+    }
+
+    private void consume(Object obj0, Object obj1) {
+        blackhole.consume(obj0);
+        blackhole.consume(obj1);
+    }
+}

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/ProxyBenchmark.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/ProxyBenchmark.java
@@ -66,6 +66,7 @@ public class ProxyBenchmark {
 
     private Service raw;
     private Service instrumentedWithoutHandlers;
+    private Service instrumentedWithEnabledNopHandler;
     private Service instrumentedWithPerformanceLogging;
     private Service instrumentedWithMetrics;
     private Service instrumentedWithTaggedMetrics;
@@ -82,6 +83,10 @@ public class ProxyBenchmark {
 
         Class<Service> serviceInterface = Service.class;
         instrumentedWithoutHandlers = Instrumentation.builder(serviceInterface, raw).build();
+
+        instrumentedWithEnabledNopHandler = Instrumentation.builder(serviceInterface, raw)
+                .withHandler(new BlackholeInvocationEventHandler(blackhole))
+                .build();
 
         instrumentedWithPerformanceLogging = Instrumentation.builder(serviceInterface, raw)
                 // similar to .withPerformanceTraceLogging() but always log
@@ -147,6 +152,11 @@ public class ProxyBenchmark {
     // @Benchmark
     public String instrumentedWithoutHandlers() {
         return instrumentedWithoutHandlers.echo("test");
+    }
+
+    @Benchmark
+    public String instrumentedWithEnabledNopHandler() {
+        return instrumentedWithEnabledNopHandler.echo("test");
     }
 
     @Benchmark


### PR DESCRIPTION
Note that this pushes the invoke method above the 35 byte inline
threshold to 102 bytes, which is still below the 325 byte hot
method threshold.

Before:
```
java.lang.RuntimeException: Stack Trace
        at com.palantir.DemoMain.run(DemoMain.java:32)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at com.palantir.tritium.proxy.InvocationEventProxy.execute(InvocationEventProxy.java:149)
        at com.palantir.tritium.proxy.InvocationEventProxy.invoke(InvocationEventProxy.java:140)
        at com.palantir.tritium.proxy.InvocationEventProxy.instrumentInvocation(InvocationEventProxy.java:120)
        at com.palantir.tritium.proxy.InvocationEventProxy.handleInvocation(InvocationEventProxy.java:99)
        at com.google.common.reflect.AbstractInvocationHandler.invoke(AbstractInvocationHandler.java:86)
        at com.sun.proxy.$Proxy0.run(Unknown Source)
        at com.palantir.DemoMain.main(DemoMain.java:27)
```

After:
```
java.lang.RuntimeException: Stack Trace
        at com.palantir.DemoMain.run(DemoMain.java:32)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at com.palantir.tritium.proxy.InvocationEventProxy.invoke(InvocationEventProxy.java:102)
        at com.sun.proxy.$Proxy0.run(Unknown Source)
        at com.palantir.DemoMain.main(DemoMain.java:27)
```

## After this PR
==COMMIT_MSG==
Flatten the Tritium proxy to avoid excessive stack frames
==COMMIT_MSG==

