### PR TITLE
InstrumentationTest.executeManyTimes prints correct iterations

### DIFF
--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
@@ -182,11 +182,12 @@ final class InstrumentationTest {
         for (int i = 0; i < invocations; i++) {
             instrumentedService.test();
         }
-        System.out.printf("%s took %s for %d iterations %n", getClass(), timer, invocations );
+        timer.stop();
+        System.out.printf("%s took %s for %d iterations%n", getClass(), timer, invocations);
 
         timer.reset().start();
         instrumentedService.test();
-        System.out.printf("Single shot took %s", timer);
+        System.out.printf("Single shot took %s%n", timer);
     }
 
     @Test

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
@@ -182,7 +182,7 @@ final class InstrumentationTest {
         for (int i = 0; i < invocations; i++) {
             instrumentedService.test();
         }
-        System.out.printf("%s took %s for %d iterations %n", getClass(), timer, INVOCATION_ITERATIONS);
+        System.out.printf("%s took %s for %d iterations %n", getClass(), timer, invocations );
 
         timer.reset().start();
         instrumentedService.test();


### PR DESCRIPTION
Previously we printed 150000 iterations despite running 100
iterations in one case.

## After this PR
==COMMIT_MSG==
InstrumentationTest.executeManyTimes prints correct iterations
==COMMIT_MSG==

