### PR TITLE
CompositeInvocationEventHandler completes delegates when disabled in flight

### DIFF
--- a/changelog/@unreleased/pr-379.v2.yml
+++ b/changelog/@unreleased/pr-379.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: CompositeInvocationEventHandler correctly completes delegate handlers
+    when they are disabled in flight
+  links:
+  - https://github.com/palantir/tritium/pull/379

--- a/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
@@ -80,7 +80,10 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
 
     private void success(@Nonnull InvocationContext[] contexts, @Nullable Object result) {
         for (int i = contexts.length - 1; i > -1; i--) {
-            handleSuccess(tryGetEnabledHandler(i), contexts[i], result);
+            InvocationContext context = contexts[i];
+            if (context != null) {
+                handleSuccess(handlers.get(i), context, result);
+            }
         }
     }
 
@@ -94,7 +97,10 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
 
     private void failure(InvocationContext[] contexts, @Nonnull Throwable cause) {
         for (int i = contexts.length - 1; i > -1; i--) {
-            handleFailure(tryGetEnabledHandler(i), contexts[i], cause);
+            InvocationContext context = contexts[i];
+            if (context != null) {
+                handleFailure(handlers.get(i), context, cause);
+            }
         }
     }
 

--- a/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
@@ -47,7 +47,7 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
         if (handlers.isEmpty()) {
             return NoOpInvocationEventHandler.INSTANCE;
         } else if (handlers.size() == 1) {
-            return checkNotNull(handlers.iterator().next(), "Null handlers are not allowed");
+            return checkNotNull(handlers.get(0), "Null handlers are not allowed");
         } else {
             return new CompositeInvocationEventHandler(handlers);
         }

--- a/tritium-core/src/test/java/com/palantir/tritium/event/CompositeInvocationEventHandlerTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/CompositeInvocationEventHandlerTest.java
@@ -146,16 +146,16 @@ final class CompositeInvocationEventHandlerTest {
     void testNullHandler() {
         assertThatThrownBy(() -> CompositeInvocationEventHandler.of(Collections.singletonList(null)))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("at index 0");
+                .hasMessage("Null handlers are not allowed");
         assertThatThrownBy(
                 () -> CompositeInvocationEventHandler.of(Arrays.asList(NoOpInvocationEventHandler.INSTANCE, null)))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("at index 1");
+                .hasMessage("Null handlers are not allowed");
         assertThatThrownBy(
                 () -> CompositeInvocationEventHandler.of(
                         Arrays.asList(null, NoOpInvocationEventHandler.INSTANCE, null)))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("at index 0");
+                .hasMessage("Null handlers are not allowed");
     }
 
     @Test


### PR DESCRIPTION
InvocationEventHandler implementations are often responsible for
setting up and tearing down thread state. When a handler is
enabled at the beginning of a call, and disabled at the end, it
should still be executed to clean up what it started. This matches
expectations when only a single handler is used.

## Before this PR
preInvoke may be called without onSuccess/onFailure ever being executed.

## After this PR
==COMMIT_MSG==
CompositeInvocationEventHandler correctly completes delegate handlers when they are disabled in flight
==COMMIT_MSG==

