### PR TITLE
Use Byte Buddy for Instrumentation by default

### DIFF
--- a/changelog/@unreleased/pr-389.v2.yml
+++ b/changelog/@unreleased/pr-389.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: feature
+feature:
   description: Use Byte Buddy for Instrumentation by default, reducing excess stack
     frames from instrumentation.
   links:

--- a/changelog/@unreleased/pr-389.v2.yml
+++ b/changelog/@unreleased/pr-389.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Use Byte Buddy for Instrumentation by default, reducing excess stack
+    frames from instrumentation.
+  links:
+  - https://github.com/palantir/tritium/pull/389

--- a/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationProperties.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationProperties.java
@@ -26,6 +26,7 @@ import com.palantir.tritium.api.functions.BooleanSupplier;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,8 +47,22 @@ public final class InstrumentationProperties {
 
     @SuppressWarnings("WeakerAccess") // public API
     public static boolean isSpecificEnabled(String name) {
-        String qualifiedValue = instrumentationProperties().get(INSTRUMENT_PREFIX + "." + name);
-        return "true".equalsIgnoreCase(qualifiedValue) || qualifiedValue == null;
+        return isSpecificEnabled(name, true);
+    }
+
+    @SuppressWarnings("WeakerAccess") // public API
+    public static boolean isSpecificEnabled(String name, boolean defaultValue) {
+        String qualifiedValue = getSpecific(name);
+        if (qualifiedValue == null) {
+            return defaultValue;
+        }
+        return "true".equalsIgnoreCase(qualifiedValue);
+    }
+
+    /** Applies the {@link #INSTRUMENT_PREFIX} and returns the current value. */
+    @Nullable
+    private static String getSpecific(String name) {
+        return instrumentationProperties().get(INSTRUMENT_PREFIX + "." + name);
     }
 
     @SuppressWarnings("WeakerAccess") // public API
@@ -100,5 +115,4 @@ public final class InstrumentationProperties {
         log.debug("Reloaded instrumentation properties {}", map);
         return map;
     }
-
 }

--- a/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationPropertiesTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationPropertiesTest.java
@@ -173,4 +173,82 @@ final class InstrumentationPropertiesTest {
             assertThat(barrier.getNumberWaiting()).isZero();
         });
     }
+
+    @Test
+    void testIsSpecificEnabled_notSet() {
+        assertThat(InstrumentationProperties.isSpecificEnabled("not_set")).isTrue();
+    }
+
+    @Test
+    void testIsSpecificEnabled_notSet_defaultTrue() {
+        assertThat(InstrumentationProperties.isSpecificEnabled("not_set", true)).isTrue();
+    }
+
+    @Test
+    void testIsSpecificEnabled_notSet_defaultFalse() {
+        assertThat(InstrumentationProperties.isSpecificEnabled("not_set", false)).isFalse();
+    }
+
+    @Test
+    void testIsSpecificEnabled_setGarbage() {
+        System.setProperty("instrument.garbage", "garbage");
+        InstrumentationProperties.reload();
+        assertThat(InstrumentationProperties.isSpecificEnabled("garbage")).isFalse();
+    }
+
+    @Test
+    void testIsSpecificEnabled_setGarbage_defaultTrue() {
+        System.setProperty("instrument.garbage", "garbage");
+        InstrumentationProperties.reload();
+        assertThat(InstrumentationProperties.isSpecificEnabled("garbage", true)).isFalse();
+    }
+
+    @Test
+    void testIsSpecificEnabled_setGarbage_defaultFalse() {
+        System.setProperty("instrument.garbage", "garbage");
+        InstrumentationProperties.reload();
+        assertThat(InstrumentationProperties.isSpecificEnabled("garbage", false)).isFalse();
+    }
+
+    @Test
+    void testIsSpecificEnabled_setTrue() {
+        System.setProperty("instrument.true", "true");
+        InstrumentationProperties.reload();
+        assertThat(InstrumentationProperties.isSpecificEnabled("true")).isTrue();
+    }
+
+    @Test
+    void testIsSpecificEnabled_setTrue_defaultTrue() {
+        System.setProperty("instrument.true", "true");
+        InstrumentationProperties.reload();
+        assertThat(InstrumentationProperties.isSpecificEnabled("true", true)).isTrue();
+    }
+
+    @Test
+    void testIsSpecificEnabled_setTrue_defaultFalse() {
+        System.setProperty("instrument.true", "true");
+        InstrumentationProperties.reload();
+        assertThat(InstrumentationProperties.isSpecificEnabled("true", false)).isTrue();
+    }
+
+    @Test
+    void testIsSpecificEnabled_setFalse() {
+        System.setProperty("instrument.false", "false");
+        InstrumentationProperties.reload();
+        assertThat(InstrumentationProperties.isSpecificEnabled("false")).isFalse();
+    }
+
+    @Test
+    void testIsSpecificEnabled_setFalse_defaultTrue() {
+        System.setProperty("instrument.false", "false");
+        InstrumentationProperties.reload();
+        assertThat(InstrumentationProperties.isSpecificEnabled("false", true)).isFalse();
+    }
+
+    @Test
+    void testIsSpecificEnabled_setFalse_defaultFalse() {
+        System.setProperty("instrument.false", "false");
+        InstrumentationProperties.reload();
+        assertThat(InstrumentationProperties.isSpecificEnabled("false", false)).isFalse();
+    }
 }

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/Instrumentation.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/Instrumentation.java
@@ -59,7 +59,7 @@ public final class Instrumentation {
             return delegate;
         }
 
-        if (InstrumentationProperties.isSpecificEnabled("dynamic-proxy")) {
+        if (InstrumentationProperties.isSpecificEnabled("dynamic-proxy", false)) {
             return Proxies.newProxy(interfaceClass, delegate,
                     new InstrumentationProxy<>(instrumentationFilter, handlers, delegate));
         } else {


### PR DESCRIPTION
Previous behavior can be used by setting the
`instrument.dynamic-proxy` property to `true`.

## Before this PR
Dynamic proxies were used by default.

## After this PR
==COMMIT_MSG==
Use Byte Buddy for Instrumentation by default, reducing excess stack frames from instrumentation.
==COMMIT_MSG==

## Possible downsides?
There's always a risk in change, particularly for environments with complex class loader hierarchies and security managers. We've rolled this out to our largest project already without any issues.

