### PR TITLE
Fix #393: Loosen InvocationEventHanndler context bound to object 

### DIFF
--- a/tritium-api/src/main/java/com/palantir/tritium/event/InvocationEventHandler.java
+++ b/tritium-api/src/main/java/com/palantir/tritium/event/InvocationEventHandler.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
  * @see java.lang.reflect.InvocationHandler
  * @param <C> invocation context
  */
-public interface InvocationEventHandler<C extends InvocationContext> {
+public interface InvocationEventHandler<C> {
 
     /**
      * Returns true if this event handler instance is enabled, otherwise false.
@@ -57,7 +57,7 @@ public interface InvocationEventHandler<C extends InvocationContext> {
      * @param context the current invocation context.
      * @param result the return value from invocation, or null if {@link Void}.
      */
-    void onSuccess(@Nullable InvocationContext context, @Nullable Object result);
+    void onSuccess(@Nullable C context, @Nullable Object result);
 
     /**
      * Invoked when an invocation fails.
@@ -69,6 +69,6 @@ public interface InvocationEventHandler<C extends InvocationContext> {
      * @param context the current invocation context.
      * @param cause the throwable which caused the failure.
      */
-    void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause);
+    void onFailure(@Nullable C context, @Nonnull Throwable cause);
 
 }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
@@ -28,8 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  * @param <C> invocation context
  */
-public abstract class AbstractInvocationEventHandler<C extends InvocationContext>
-        implements InvocationEventHandler<C> {
+public abstract class AbstractInvocationEventHandler<C> implements InvocationEventHandler<C> {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractInvocationEventHandler.class);
 
@@ -78,7 +77,7 @@ public abstract class AbstractInvocationEventHandler<C extends InvocationContext
      *
      * @param context invocation context
      */
-    protected final void debugIfNullContext(@Nullable InvocationContext context) {
+    protected final void debugIfNullContext(@Nullable C context) {
         if (context == null) {
             logger.debug(
                     "{} encountered null metric context, likely due to exception in preInvocation",
@@ -98,7 +97,7 @@ public abstract class AbstractInvocationEventHandler<C extends InvocationContext
      * @return false if "instrument.fully.qualified.class.Name" is set to "false", otherwise true
      */
     protected static com.palantir.tritium.api.functions.BooleanSupplier getSystemPropertySupplier(
-            Class<? extends InvocationEventHandler<InvocationContext>> clazz) {
+            Class<? extends InvocationEventHandler<?>> clazz) {
         checkNotNull(clazz, "clazz");
         return InstrumentationProperties.getSystemPropertySupplier(clazz.getName());
     }

--- a/tritium-core/src/test/java/com/palantir/tritium/event/CompositeInvocationEventHandlerTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/CompositeInvocationEventHandlerTest.java
@@ -38,30 +38,32 @@ final class CompositeInvocationEventHandlerTest {
     private static final Object[] EMPTY_ARGS = {};
 
     @Test
-    @SuppressWarnings("checkstyle:illegalthrows")
+    @SuppressWarnings({"checkstyle:illegalthrows", "unchecked"})
     void testSimpleFlow() throws Throwable {
-        InvocationEventHandler<InvocationContext> compositeHandler = CompositeInvocationEventHandler.of(
-                Arrays.asList(NoOpInvocationEventHandler.INSTANCE,
-                        new SimpleInvocationEventHandler()));
+        InvocationEventHandler<Object> compositeHandler =
+                (InvocationEventHandler<Object>) CompositeInvocationEventHandler.of(
+                        Arrays.asList(NoOpInvocationEventHandler.INSTANCE,
+                                new SimpleInvocationEventHandler()));
 
         assertThat(compositeHandler).isInstanceOf(CompositeInvocationEventHandler.class);
 
-        InvocationContext context = compositeHandler.preInvocation(this, getToStringMethod(), EMPTY_ARGS);
+        Object context = compositeHandler.preInvocation(this, getToStringMethod(), EMPTY_ARGS);
         compositeHandler.onSuccess(context, "test");
     }
 
     @Test
     @SuppressWarnings("unchecked")
     void testDisabledWhileRunning_success() throws NoSuchMethodException {
-        InvocationEventHandler<InvocationContext> handler = mock(InvocationEventHandler.class);
+        InvocationEventHandler<Object> handler = mock(InvocationEventHandler.class);
         when(handler.preInvocation(any(), any(), any())).thenReturn(mock(InvocationContext.class));
         when(handler.isEnabled()).thenReturn(true, false);
-        InvocationEventHandler<InvocationContext> compositeHandler = CompositeInvocationEventHandler.of(
-                Arrays.asList(NoOpInvocationEventHandler.INSTANCE, handler));
+        InvocationEventHandler<Object> compositeHandler =
+                (InvocationEventHandler<Object>) CompositeInvocationEventHandler.of(
+                        Arrays.asList(NoOpInvocationEventHandler.INSTANCE, handler));
 
         assertThat(compositeHandler).isInstanceOf(CompositeInvocationEventHandler.class);
 
-        InvocationContext context = compositeHandler.preInvocation(this, getToStringMethod(), EMPTY_ARGS);
+        Object context = compositeHandler.preInvocation(this, getToStringMethod(), EMPTY_ARGS);
         compositeHandler.onSuccess(context, "test");
 
         verify(handler).isEnabled();
@@ -73,15 +75,16 @@ final class CompositeInvocationEventHandlerTest {
     @Test
     @SuppressWarnings("unchecked")
     void testDisabledWhileRunning_failure() throws NoSuchMethodException {
-        InvocationEventHandler<InvocationContext> handler = mock(InvocationEventHandler.class);
+        InvocationEventHandler<Object> handler = mock(InvocationEventHandler.class);
         when(handler.preInvocation(any(), any(), any())).thenReturn(mock(InvocationContext.class));
         when(handler.isEnabled()).thenReturn(true, false);
-        InvocationEventHandler<InvocationContext> compositeHandler = CompositeInvocationEventHandler.of(
-                Arrays.asList(NoOpInvocationEventHandler.INSTANCE, handler));
+        InvocationEventHandler<Object> compositeHandler =
+                (InvocationEventHandler<Object>) CompositeInvocationEventHandler.of(
+                        Arrays.asList(NoOpInvocationEventHandler.INSTANCE, handler));
 
         assertThat(compositeHandler).isInstanceOf(CompositeInvocationEventHandler.class);
 
-        InvocationContext context = compositeHandler.preInvocation(this, getToStringMethod(), EMPTY_ARGS);
+        Object context = compositeHandler.preInvocation(this, getToStringMethod(), EMPTY_ARGS);
         compositeHandler.onFailure(context, new RuntimeException());
 
         verify(handler).isEnabled();
@@ -92,52 +95,53 @@ final class CompositeInvocationEventHandlerTest {
 
     @Test
     void testSuccessHandlerFailureShouldNotThrow() throws Exception {
-        InvocationEventHandler<InvocationContext> compositeHandler = CompositeInvocationEventHandler.of(
-                Arrays.asList(NoOpInvocationEventHandler.INSTANCE, new ThrowingInvocationEventHandler(true) {
-                    @Override
-                    public InvocationContext preInvocation(
-                            @Nonnull Object instance,
-                            @Nonnull Method method,
-                            @Nonnull Object[] args) {
-                        return DefaultInvocationContext.of(instance, method, args);
-                    }
-                }));
+        @SuppressWarnings("unchecked") InvocationEventHandler<Object> compositeHandler =
+                (InvocationEventHandler<Object>) CompositeInvocationEventHandler.of(
+                        Arrays.asList(NoOpInvocationEventHandler.INSTANCE, new ThrowingInvocationEventHandler(true) {
+                            @Override
+                            public InvocationContext preInvocation(
+                                    @Nonnull Object instance,
+                                    @Nonnull Method method,
+                                    @Nonnull Object[] args) {
+                                return DefaultInvocationContext.of(instance, method, args);
+                            }
+                        }));
 
         assertThat(compositeHandler).isInstanceOf(CompositeInvocationEventHandler.class);
 
-        InvocationContext context = compositeHandler.preInvocation(this, getToStringMethod(), EMPTY_ARGS);
+        Object context = compositeHandler.preInvocation(this, getToStringMethod(), EMPTY_ARGS);
         compositeHandler.onSuccess(context, "test");
     }
 
     @Test
     void testFailureHandlerFailureShouldNotThrow() throws Exception {
-        InvocationEventHandler<InvocationContext> compositeHandler = CompositeInvocationEventHandler.of(
-                Arrays.asList(NoOpInvocationEventHandler.INSTANCE, new ThrowingInvocationEventHandler(true) {
-                    @Override
-                    public InvocationContext preInvocation(
-                            @Nonnull Object instance,
-                            @Nonnull Method method,
-                            @Nonnull Object[] args) {
-                        return DefaultInvocationContext.of(instance, method, args);
-                    }
-                }));
+        @SuppressWarnings("unchecked") InvocationEventHandler<Object> compositeHandler =
+                (InvocationEventHandler<Object>) CompositeInvocationEventHandler.of(
+                        Arrays.asList(NoOpInvocationEventHandler.INSTANCE, new ThrowingInvocationEventHandler(true) {
+                            @Override
+                            public InvocationContext preInvocation(
+                                    @Nonnull Object instance,
+                                    @Nonnull Method method,
+                                    @Nonnull Object[] args) {
+                                return DefaultInvocationContext.of(instance, method, args);
+                            }
+                        }));
         assertThat(compositeHandler).isInstanceOf(CompositeInvocationEventHandler.class);
 
-        InvocationContext context = compositeHandler.preInvocation(this, getToStringMethod(), EMPTY_ARGS);
+        Object context = compositeHandler.preInvocation(this, getToStringMethod(), EMPTY_ARGS);
         compositeHandler.onFailure(context, new RuntimeException("simple failure"));
     }
 
     @Test
     void testEmpty() throws Exception {
-        InvocationEventHandler<InvocationContext> compositeHandler = CompositeInvocationEventHandler.of(
-                Collections.emptyList());
+        @SuppressWarnings("unchecked") InvocationEventHandler<Object> compositeHandler =
+                (InvocationEventHandler<Object>) CompositeInvocationEventHandler.of(Collections.emptyList());
         assertThat(compositeHandler).isInstanceOf(NoOpInvocationEventHandler.class);
         assertThat(compositeHandler).isSameAs(NoOpInvocationEventHandler.INSTANCE);
 
-        InvocationContext context = compositeHandler.preInvocation(this, getToStringMethod(), EMPTY_ARGS);
+        Object context = compositeHandler.preInvocation(this, getToStringMethod(), EMPTY_ARGS);
 
         assertThat(context).isNotNull();
-        assertThat(context.getMethod().getName()).isEqualTo("toString");
         compositeHandler.onSuccess(context, "Hello World");
         compositeHandler.onFailure(context, new RuntimeException());
     }
@@ -160,44 +164,42 @@ final class CompositeInvocationEventHandlerTest {
 
     @Test
     void testPreInvocationThrowingHandler() throws Exception {
-        @SuppressWarnings("unchecked") List<InvocationEventHandler<InvocationContext>> handlers =
+        List<InvocationEventHandler<?>> handlers =
                 Arrays.asList(NoOpInvocationEventHandler.INSTANCE, createThrowingHandler(true));
-        InvocationEventHandler<InvocationContext> compositeHandler = CompositeInvocationEventHandler.of(handlers);
+        InvocationEventHandler<?> compositeHandler = CompositeInvocationEventHandler.of(handlers);
         assertThat(compositeHandler).isInstanceOf(CompositeInvocationEventHandler.class);
 
-        InvocationContext context = compositeHandler.preInvocation(this, getToStringMethod(), EMPTY_ARGS);
-        assertThat(context).isInstanceOf(InvocationContext.class);
+        compositeHandler.preInvocation(this, getToStringMethod(), EMPTY_ARGS);
     }
 
     @Test
     void testThrowingOnSuccess() throws Exception {
-        @SuppressWarnings("unchecked") List<InvocationEventHandler<InvocationContext>> handlers =
+        List<InvocationEventHandler<?>> handlers =
                 Arrays.asList(NoOpInvocationEventHandler.INSTANCE, createThrowingHandler(true));
-        InvocationEventHandler<InvocationContext> compositeHandler = CompositeInvocationEventHandler.of(handlers);
+        @SuppressWarnings("unchecked") InvocationEventHandler<Object[]> compositeHandler =
+                (InvocationEventHandler<Object[]>) CompositeInvocationEventHandler.of(handlers);
         assertThat(compositeHandler).isInstanceOf(CompositeInvocationEventHandler.class);
 
-        InvocationContext context = new CompositeInvocationEventHandler.CompositeInvocationContext(this,
-                getToStringMethod(), null, new InvocationContext[] {null, null});
-        compositeHandler.onSuccess(context, "Hello World");
+        compositeHandler.onSuccess(new Object[] {null, null}, "Hello World");
     }
 
     @Test
     void testThrowingOnFailure() throws Exception {
-        InvocationEventHandler<InvocationContext> throwingHandler = createThrowingHandler(true);
-        @SuppressWarnings("unchecked") List<InvocationEventHandler<InvocationContext>> handlers =
+        InvocationEventHandler<?> throwingHandler = createThrowingHandler(true);
+        List<InvocationEventHandler<?>> handlers =
                 Arrays.asList(NoOpInvocationEventHandler.INSTANCE, throwingHandler);
-        InvocationEventHandler<InvocationContext> compositeHandler = CompositeInvocationEventHandler.of(handlers);
+        @SuppressWarnings("unchecked") InvocationEventHandler<Object[]> compositeHandler =
+                (InvocationEventHandler<Object[]>) CompositeInvocationEventHandler.of(handlers);
         assertThat(compositeHandler).isInstanceOf(CompositeInvocationEventHandler.class);
 
-        InvocationContext context = new CompositeInvocationEventHandler.CompositeInvocationContext(this,
-                getToStringMethod(), null, new InvocationContext[] {null, null});
-        compositeHandler.onFailure(context, new RuntimeException());
+        compositeHandler.onFailure(new Object[] {null, null}, new RuntimeException());
     }
 
     @Test
     void testToString() {
-        InvocationEventHandler<InvocationContext> handler = CompositeInvocationEventHandler.of(
-                Arrays.asList(NoOpInvocationEventHandler.INSTANCE, new SimpleInvocationEventHandler()));
+        @SuppressWarnings("unchecked") InvocationEventHandler<Object[]> handler =
+                (InvocationEventHandler<Object[]>) CompositeInvocationEventHandler.of(
+                        Arrays.asList(NoOpInvocationEventHandler.INSTANCE, new SimpleInvocationEventHandler()));
         assertThat(handler).asString()
                 .startsWith("CompositeInvocationEventHandler{handlers=[INSTANCE, ")
                 .endsWith("]}");

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/ByteBuddyInstrumentationAdvice.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/ByteBuddyInstrumentationAdvice.java
@@ -20,7 +20,6 @@ import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.tritium.api.event.InstrumentationFilter;
-import com.palantir.tritium.event.InvocationContext;
 import com.palantir.tritium.event.InvocationEventHandler;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -50,11 +49,11 @@ final class ByteBuddyInstrumentationAdvice {
 
     @Nullable
     @Advice.OnMethodEnter
-    static InvocationContext enter(
+    static Object enter(
             @Advice.This Object proxy,
             @Advice.AllArguments Object[] arguments,
             @Advice.FieldValue("instrumentationFilter") InstrumentationFilter filter,
-            @Advice.FieldValue("invocationEventHandler") InvocationEventHandler<?> eventHandler,
+            @Advice.FieldValue("invocationEventHandler") InvocationEventHandler<Object> eventHandler,
             @Advice.FieldValue("methods") Method[] methods,
             @MethodIndex int index) {
         Method method = methods[index];
@@ -77,8 +76,8 @@ final class ByteBuddyInstrumentationAdvice {
     static void exit(
             @Advice.Return(typing = Assigner.Typing.DYNAMIC) Object result,
             @Advice.Thrown Throwable thrown,
-            @Advice.FieldValue("invocationEventHandler") InvocationEventHandler<?> eventHandler,
-            @Advice.Enter InvocationContext context) {
+            @Advice.FieldValue("invocationEventHandler") InvocationEventHandler<Object> eventHandler,
+            @Advice.Enter Object context) {
         if (context != null) {
             try {
                 if (thrown == null) {

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/InstrumentationProxy.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/InstrumentationProxy.java
@@ -17,17 +17,14 @@
 package com.palantir.tritium.proxy;
 
 import com.palantir.tritium.api.event.InstrumentationFilter;
-import com.palantir.tritium.event.InvocationContext;
 import com.palantir.tritium.event.InvocationEventHandler;
-import java.util.List;
 
-class InstrumentationProxy<T> extends InvocationEventProxy {
+class InstrumentationProxy<T, U> extends InvocationEventProxy<U> {
 
     private final T delegate;
 
-    InstrumentationProxy(InstrumentationFilter instrumentationFilter,
-            List<InvocationEventHandler<InvocationContext>> handlers, T delegate) {
-        super(handlers, instrumentationFilter);
+    InstrumentationProxy(InstrumentationFilter instrumentationFilter, InvocationEventHandler<U> handler, T delegate) {
+        super(handler, instrumentationFilter);
         this.delegate = delegate;
     }
 

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
@@ -393,7 +393,7 @@ public abstract class InstrumentationTest {
     @Test
     void testEquals_separateInstanceWithSameArgs() {
         TestImplementation delegate = new TestImplementation();
-        InvocationEventHandler<InvocationContext> handler = TracingInvocationEventHandler.create("test");
+        InvocationEventHandler<?> handler = TracingInvocationEventHandler.create("test");
         TestInterface proxy0 = Instrumentation.builder(TestInterface.class, delegate).withHandler(handler).build();
         TestInterface proxy1 = Instrumentation.builder(TestInterface.class, delegate).withHandler(handler).build();
         assertThat(proxy0).isNotEqualTo(proxy1);

--- a/tritium-metrics/build.gradle
+++ b/tritium-metrics/build.gradle
@@ -5,7 +5,6 @@ dependencies {
 
     annotationProcessor "org.immutables:value"
 
-    api project(':tritium-api')
     api project(':tritium-core')
     api project(':tritium-registry')
     api 'io.dropwizard.metrics:metrics-core'

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationContext.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationContext.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.event.metrics;
+
+import static com.palantir.logsafe.Preconditions.checkNotNull;
+
+import java.lang.reflect.Method;
+
+final class MetricsInvocationContext {
+    private final Method method;
+    private final long startTimeNanos;
+
+    MetricsInvocationContext(Method method, long startTimeNanos) {
+        this.method = checkNotNull(method, "method");
+        this.startTimeNanos = checkNotNull(startTimeNanos, "startTimeNanos");
+    }
+
+    Method getMethod() {
+        return method;
+    }
+
+    long getStartTimeNanos() {
+        return startTimeNanos;
+    }
+
+    @Override
+    public String toString() {
+        return "MetricsInvocationContext{method='" + method + "', startTimeNanos=" + startTimeNanos + '}';
+    }
+}

--- a/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandlerTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandlerTest.java
@@ -21,8 +21,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.MetricRegistry;
-import com.palantir.tritium.event.DefaultInvocationContext;
-import com.palantir.tritium.event.InvocationContext;
 import com.palantir.tritium.event.metrics.annotations.MetricGroup;
 import org.junit.jupiter.api.Test;
 
@@ -55,8 +53,8 @@ final class MetricsInvocationEventHandlerTest {
         MetricRegistry metricRegistry = new MetricRegistry();
         MetricsInvocationEventHandler handler = new MetricsInvocationEventHandler(metricRegistry, "test");
 
-        InvocationContext context = mock(InvocationContext.class);
-        when(context.getMethod()).thenReturn(String.class.getDeclaredMethod("length"));
+        MetricsInvocationContext context = new MetricsInvocationContext(
+                 String.class.getDeclaredMethod("length"), 0L);
         assertThat(metricRegistry.getMeters().get("failures")).isNull();
 
         handler.onFailure(context, new RuntimeException("unexpected"));
@@ -132,7 +130,8 @@ final class MetricsInvocationEventHandlerTest {
 
     private static void callVoidMethod(
             MetricsInvocationEventHandler handler, Object obj, String methodName, boolean success) throws Exception {
-        InvocationContext context = DefaultInvocationContext.of(obj, obj.getClass().getMethod(methodName), null);
+        MetricsInvocationContext context = new MetricsInvocationContext(
+                obj.getClass().getMethod(methodName), System.nanoTime());
         if (success) {
             handler.onSuccess(context, null);
         } else {

--- a/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandlerTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandlerTest.java
@@ -20,9 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.codahale.metrics.Metric;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
-import com.palantir.tritium.event.AbstractInvocationEventHandler;
-import com.palantir.tritium.event.DefaultInvocationContext;
-import com.palantir.tritium.event.InvocationContext;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import com.palantir.tritium.metrics.test.TestTaggedMetricRegistries;
@@ -82,10 +79,11 @@ final class TaggedMetricsServiceInvocationEventHandlerTest {
 
     @SuppressWarnings("SameParameterValue")
     private static void invokeMethod(
-            AbstractInvocationEventHandler<InvocationContext> handler, Object obj, String methodName, Object result,
+            TaggedMetricsServiceInvocationEventHandler handler, Object obj, String methodName, Object result,
             boolean success)
             throws Exception {
-        InvocationContext context = DefaultInvocationContext.of(obj, obj.getClass().getMethod(methodName), null);
+        MetricsInvocationContext context = new MetricsInvocationContext(
+                obj.getClass().getMethod(methodName), System.nanoTime());
         if (success) {
             handler.onSuccess(context, result);
         } else {

--- a/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandlerTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandlerTest.java
@@ -82,7 +82,8 @@ final class TaggedMetricsServiceInvocationEventHandlerTest {
 
     @SuppressWarnings("SameParameterValue")
     private static void invokeMethod(
-            AbstractInvocationEventHandler handler, Object obj, String methodName, Object result, boolean success)
+            AbstractInvocationEventHandler<InvocationContext> handler, Object obj, String methodName, Object result,
+            boolean success)
             throws Exception {
         InvocationContext context = DefaultInvocationContext.of(obj, obj.getClass().getMethod(methodName), null);
         if (success) {


### PR DESCRIPTION
WIP: looking for feedback

General idea is that bounding to InvocationContext doesn't buy us much. We cannot add to it because that would break custom implementations, and contexts aren't read outside of the handler which created them. Most handlers don't use all the fields provided by InvocationContext, and some (composite, tracing) don't use any.

## Before this PR
Every handler created a full copy of the argument array, and accessed the precise system clock.

## After this PR
==COMMIT_MSG==
InvocationEventHandler context objects do not need to implement `InvocationContext`
==COMMIT_MSG==

## Possible downsides?
This is an API break, though type erasure should allow us to implement it in a way that doesn't break ABI for standard usage.

