### PR TITLE
Use simple string concatenation over MetricRegistry.name

### DIFF
--- a/changelog/@unreleased/pr-407.v2.yml
+++ b/changelog/@unreleased/pr-407.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use simple string concatenation over MetricRegistry.name
+  links:
+  - https://github.com/palantir/tritium/pull/407

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/Instrumentation.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/Instrumentation.java
@@ -132,7 +132,7 @@ public final class Instrumentation {
             this.handlers.add(new MetricsInvocationEventHandler(
                     metricRegistry,
                     delegate.getClass(),
-                    MetricRegistry.name(interfaceClass.getName()),
+                    interfaceClass.getName(),
                     globalPrefix));
             return this;
         }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
@@ -116,9 +116,9 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
         markGlobalFailure();
         debugIfNullContext(context);
         if (context != null) {
-            String failuresMetricName = MetricRegistry.name(getBaseMetricName(context), FAILURES);
+            String failuresMetricName = getBaseMetricName(context) + '.' + FAILURES;
             metricRegistry.meter(failuresMetricName).mark();
-            metricRegistry.meter(MetricRegistry.name(failuresMetricName, cause.getClass().getName())).mark();
+            metricRegistry.meter(failuresMetricName + '.' + cause.getClass().getName()).mark();
             long nanos = updateTimer(context);
             handleFailureAnnotations(context, nanos);
         }
@@ -132,7 +132,7 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
     }
 
     private String getBaseMetricName(InvocationContext context) {
-        return MetricRegistry.name(serviceName, context.getMethod().getName());
+        return serviceName + '.' + context.getMethod().getName();
     }
 
     private void markGlobalFailure() {
@@ -142,11 +142,11 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
     private void handleSuccessAnnotations(InvocationContext context, long nanos) {
         String metricName = getAnnotatedMetricName(context);
         if (metricName != null) {
-            metricRegistry.timer(MetricRegistry.name(serviceName, metricName))
+            metricRegistry.timer(serviceName + '.' + metricName)
                     .update(nanos, TimeUnit.NANOSECONDS);
 
             if (globalGroupPrefix != null) {
-                metricRegistry.timer(MetricRegistry.name(globalGroupPrefix, metricName))
+                metricRegistry.timer(globalGroupPrefix + '.' + metricName)
                         .update(nanos, TimeUnit.NANOSECONDS);
             }
         }
@@ -155,11 +155,11 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
     private void handleFailureAnnotations(InvocationContext context, long nanos) {
         String metricName = getAnnotatedMetricName(context);
         if (metricName != null) {
-            metricRegistry.timer(MetricRegistry.name(serviceName, metricName, FAILURES))
+            metricRegistry.timer(serviceName + '.' + metricName + '.' + FAILURES)
                     .update(nanos, TimeUnit.NANOSECONDS);
 
             if (globalGroupPrefix != null) {
-                metricRegistry.timer(MetricRegistry.name(globalGroupPrefix, metricName, FAILURES))
+                metricRegistry.timer(globalGroupPrefix + '.' + metricName + '.' + FAILURES)
                         .update(nanos, TimeUnit.NANOSECONDS);
             }
         }


### PR DESCRIPTION
Avoid varargs method invocations by using simple string
concatenation, which javac (jdk8)  optimizes to use
a StringBuilder. Once we target JDK9+,
[JEP 280](https://openjdk.java.net/jeps/280) may result
in even better performance.

(disclaimer: benchmarks run on a laptop on battery!)

Before:
```
Benchmark                                         (mode)  Mode  Cnt    Score    Error  Units
ProxyBenchmark.instrumentedWithMetrics        BYTE_BUDDY  avgt    5  281.769 ±  9.058  ns/op
ProxyBenchmark.instrumentedWithTaggedMetrics  BYTE_BUDDY  avgt    5  204.400 ± 21.784  ns/op
```

After:
```
Benchmark                                         (mode)  Mode  Cnt    Score    Error  Units
ProxyBenchmark.instrumentedWithMetrics        BYTE_BUDDY  avgt    5  240.741 ±  4.348  ns/op
ProxyBenchmark.instrumentedWithTaggedMetrics  BYTE_BUDDY  avgt    5  202.567 ± 17.053  ns/op
```

## After this PR
==COMMIT_MSG==
Use simple string concatenation over MetricRegistry.name
==COMMIT_MSG==

