### PR TITLE
Mark unused public method arguments

### DIFF
--- a/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationFilters.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationFilters.java
@@ -24,14 +24,20 @@ public enum InstrumentationFilters implements InstrumentationFilter {
 
     INSTRUMENT_ALL {
         @Override
-        public boolean shouldInstrument(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args) {
+        public boolean shouldInstrument(
+                @Nonnull Object unusedInstance,
+                @Nonnull Method unusedMethod,
+                @Nonnull Object[] unusedArgs) {
             return true;
         }
     },
 
     INSTRUMENT_NONE {
         @Override
-        public boolean shouldInstrument(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args) {
+        public boolean shouldInstrument(
+                @Nonnull Object unusedInstance,
+                @Nonnull Method unusedMethod,
+                @Nonnull Object[] unusedArgs) {
             return false;
         }
     };

--- a/tritium-core/src/main/java/com/palantir/tritium/event/NoOpInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/NoOpInvocationEventHandler.java
@@ -38,12 +38,12 @@ public enum NoOpInvocationEventHandler implements InvocationEventHandler<Invocat
     }
 
     @Override
-    public void onSuccess(@Nullable InvocationContext context, @Nullable Object result) {
+    public void onSuccess(@Nullable InvocationContext unusedContext, @Nullable Object unusedResult) {
         // no-op
     }
 
     @Override
-    public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause) {
+    public void onFailure(@Nullable InvocationContext unusedContext, @Nonnull Throwable unusedCause) {
         // no-op
     }
 }

--- a/tritium-core/src/test/java/com/palantir/tritium/event/CompositeInvocationEventHandlerTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/CompositeInvocationEventHandlerTest.java
@@ -221,10 +221,10 @@ final class CompositeInvocationEventHandlerTest {
         }
 
         @Override
-        public void onSuccess(@Nullable InvocationContext context, @Nullable Object result) {}
+        public void onSuccess(@Nullable InvocationContext unusedContext, @Nullable Object unusedResult) {}
 
         @Override
-        public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause) {}
+        public void onFailure(@Nullable InvocationContext unusedContext, @Nonnull Throwable unusedCause) {}
     }
 
 }

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/ProxyBenchmark.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/ProxyBenchmark.java
@@ -243,7 +243,7 @@ public class ProxyBenchmark {
         }
     }
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] unusedArgs) throws Exception {
         Options options = new OptionsBuilder()
                 .include(ProxyBenchmark.class.getSimpleName())
                 .warmupTime(TimeValue.seconds(1))

--- a/tritium-lib/src/test/java/com/palantir/tritium/JitCompilationTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/JitCompilationTest.java
@@ -38,7 +38,7 @@ public final class JitCompilationTest {
         TestLogs.logTo("/dev/null");
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] unusedArgs) {
         JitCompilationTest test = new JitCompilationTest();
         test.jitAllSuccess();
         test.jitWithSomeExceptions();

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
@@ -94,9 +94,9 @@ public class InvocationEventProxyTest {
         InvocationEventHandler<InvocationContext> testHandler = new SimpleHandler() {
             @Override
             public InvocationContext preInvocation(
-                    @Nonnull Object instance,
-                    @Nonnull Method method,
-                    @Nonnull Object[] args) {
+                    @Nonnull Object unusedInstance,
+                    @Nonnull Method unusedMethod,
+                    @Nonnull Object[] unusedArgs) {
                 throw new IllegalStateException("expected");
             }
         };
@@ -112,7 +112,7 @@ public class InvocationEventProxyTest {
     public void testInstrumentOnSuccessThrows() throws Throwable {
         InvocationEventHandler<InvocationContext> testHandler = new SimpleHandler() {
             @Override
-            public void onSuccess(@Nullable InvocationContext context, @Nullable Object result) {
+            public void onSuccess(@Nullable InvocationContext unusedContext, @Nullable Object unusedResult) {
                 throw new IllegalStateException("expected");
             }
         };
@@ -132,12 +132,12 @@ public class InvocationEventProxyTest {
     public void testInstrumentOnFailureThrows() throws Throwable {
         InvocationEventHandler<InvocationContext> testHandler = new SimpleHandler() {
             @Override
-            public void onSuccess(@Nullable InvocationContext context, @Nullable Object result) {
+            public void onSuccess(@Nullable InvocationContext unusedContext, @Nullable Object unusedResult) {
                 throw new IllegalStateException("expected");
             }
 
             @Override
-            public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause) {
+            public void onFailure(@Nullable InvocationContext unusedContext, @Nonnull Throwable unusedCause) {
                 throw new IllegalStateException("expected");
             }
         };
@@ -331,10 +331,10 @@ public class InvocationEventProxyTest {
         }
 
         @Override
-        public void onSuccess(@Nullable InvocationContext context, @Nullable Object result) {}
+        public void onSuccess(@Nullable InvocationContext unusedContext, @Nullable Object unusedResult) {}
 
         @Override
-        public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause) {}
+        public void onFailure(@Nullable InvocationContext unusedContext, @Nonnull Throwable unusedCause) {}
     }
 
     private static class TestProxy extends InvocationEventProxy {

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
@@ -103,7 +103,7 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
     }
 
     @Override
-    public void onSuccess(@Nullable InvocationContext context, @Nullable Object result) {
+    public void onSuccess(@Nullable InvocationContext context, @Nullable Object unusedResult) {
         debugIfNullContext(context);
         if (context != null) {
             long nanos = updateTimer(context);

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandler.java
@@ -87,7 +87,7 @@ public class TaggedMetricsServiceInvocationEventHandler extends AbstractInvocati
     }
 
     @Override
-    public final void onSuccess(@Nullable InvocationContext context, @Nullable Object result) {
+    public final void onSuccess(@Nullable InvocationContext context, @Nullable Object unusedResult) {
         debugIfNullContext(context);
         if (context != null) {
             long nanos = System.nanoTime() - context.getStartTimeNanos();

--- a/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
+++ b/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
@@ -90,12 +90,12 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
     }
 
     @Override
-    public final void onSuccess(@Nullable InvocationContext context, @Nullable Object result) {
+    public final void onSuccess(@Nullable InvocationContext context, @Nullable Object unusedResult) {
         logInvocation(context);
     }
 
     @Override
-    public final void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause) {
+    public final void onFailure(@Nullable InvocationContext context, @Nonnull Throwable unusedCause) {
         logInvocation(context);
     }
 

--- a/tritium-test/src/main/java/com/palantir/tritium/test/TestImplementation.java
+++ b/tritium-test/src/main/java/com/palantir/tritium/test/TestImplementation.java
@@ -40,7 +40,7 @@ public class TestImplementation implements TestInterface, Runnable, MoreSpecific
     }
 
     @Override
-    public void multiArgumentMethod(String string, int count, Collection<String> foo) {
+    public void multiArgumentMethod(String unusedString, int unusedCount, Collection<String> unusedCollection) {
         test();
     }
 

--- a/tritium-test/src/main/java/com/palantir/tritium/test/event/ThrowingInvocationEventHandler.java
+++ b/tritium-test/src/main/java/com/palantir/tritium/test/event/ThrowingInvocationEventHandler.java
@@ -34,19 +34,19 @@ public class ThrowingInvocationEventHandler implements InvocationEventHandler<In
 
     @Override
     public com.palantir.tritium.event.InvocationContext preInvocation(
-            @Nonnull Object instance,
-            @Nonnull Method method,
-            @Nonnull Object[] args) {
+            @Nonnull Object unusedInstance,
+            @Nonnull Method unusedMethod,
+            @Nonnull Object[] unusedArgs) {
         throw new SafeIllegalStateException("preInvocation always throws");
     }
 
     @Override
-    public void onSuccess(@Nullable InvocationContext context, @Nullable Object result) {
+    public void onSuccess(@Nullable InvocationContext unusedContext, @Nullable Object unusedResult) {
         throw new SafeIllegalStateException("onSuccess always throws");
     }
 
     @Override
-    public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause) {
+    public void onFailure(@Nullable InvocationContext unusedContext, @Nonnull Throwable unusedCause) {
         throw new SafeIllegalStateException("onFailure always throws");
     }
 

--- a/tritium-tracing/src/main/java/com/palantir/tritium/tracing/RemotingCompatibleTracingInvocationEventHandler.java
+++ b/tritium-tracing/src/main/java/com/palantir/tritium/tracing/RemotingCompatibleTracingInvocationEventHandler.java
@@ -64,7 +64,7 @@ public final class RemotingCompatibleTracingInvocationEventHandler
     }
 
     @Override
-    public void onSuccess(@Nullable InvocationContext context, @Nullable Object result) {
+    public void onSuccess(@Nullable InvocationContext context, @Nullable Object unusedResult) {
         debugIfNullContext(context);
         if (context != null) {
             tracer.completeSpan();
@@ -72,7 +72,7 @@ public final class RemotingCompatibleTracingInvocationEventHandler
     }
 
     @Override
-    public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause) {
+    public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable unusedCause) {
         debugIfNullContext(context);
         if (context != null) {
             tracer.completeSpan();

--- a/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java
+++ b/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java
@@ -72,12 +72,12 @@ public final class TracingInvocationEventHandler extends AbstractInvocationEvent
     }
 
     @Override
-    public void onSuccess(@Nullable InvocationContext context, @Nullable Object result) {
+    public void onSuccess(@Nullable InvocationContext context, @Nullable Object unusedResult) {
         complete(context);
     }
 
     @Override
-    public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause) {
+    public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable unusedCause) {
         complete(context);
     }
 

--- a/tritium-tracing/src/test/java/com/palantir/tritium/tracing/ReflectiveTracerTest.java
+++ b/tritium-tracing/src/test/java/com/palantir/tritium/tracing/ReflectiveTracerTest.java
@@ -66,13 +66,13 @@ public class ReflectiveTracerTest {
     public static final class MockTracer {
         private MockTracer() {}
 
-        public static void start(String name) {}
+        public static void start(String unused) {}
 
         public static void stop() {}
 
-        public static void badStart(Integer id) {}
+        public static void badStart(Integer unused) {}
 
-        public static void badStop(String name) {}
+        public static void badStop(String unused) {}
     }
 
 }


### PR DESCRIPTION
## Before this PR
`StrictUnusedVariable` would flag errors in tritium

## After this PR
==COMMIT_MSG==
Tritium compiles cleanly with `StrictUnusedVariable` enabled
==COMMIT_MSG==


