### PR TITLE
Report Process CPU time as `process.cpu.time.nanoseconds`

### DIFF
--- a/changelog/@unreleased/pr-451.v2.yml
+++ b/changelog/@unreleased/pr-451.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Report Process CPU time as `process.cpu.time.nanoseconds`
+  links:
+  - https://github.com/palantir/tritium/pull/451

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/OperatingSystemMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/OperatingSystemMetrics.java
@@ -24,8 +24,10 @@ import java.lang.management.OperatingSystemMXBean;
 final class OperatingSystemMetrics {
     private static final MetricName OS_LOAD_NORM_1 = MetricName.builder().safeName("os.load.norm.1").build();
     private static final MetricName OS_LOAD_1 = MetricName.builder().safeName("os.load.1").build();
-    private static final MetricName OS_PROCESS_CPU_UTILIZATION
+    private static final MetricName PROCESS_CPU_UTILIZATION
             = MetricName.builder().safeName("process.cpu.utilization").build();
+    private static final MetricName PROCESS_CPU_TIME
+            = MetricName.builder().safeName("process.cpu.time.nanoseconds").build();
 
     static void register(TaggedMetricRegistry registry) {
         OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();
@@ -33,7 +35,8 @@ final class OperatingSystemMetrics {
         registry.gauge(OS_LOAD_1, osMxBean::getSystemLoadAverage);
         if (osMxBean instanceof com.sun.management.OperatingSystemMXBean) {
             com.sun.management.OperatingSystemMXBean sunBean = (com.sun.management.OperatingSystemMXBean) osMxBean;
-            registry.gauge(OS_PROCESS_CPU_UTILIZATION, sunBean::getProcessCpuLoad);
+            registry.gauge(PROCESS_CPU_UTILIZATION, sunBean::getProcessCpuLoad);
+            registry.gauge(PROCESS_CPU_TIME, sunBean::getProcessCpuTime);
         }
     }
 

--- a/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
+++ b/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
@@ -84,6 +84,7 @@ final class JvmMetricsTest {
             "jvm.threads.blocked.count",
             "os.load.1",
             "os.load.norm.1",
+            "process.cpu.time.nanoseconds",
             "process.cpu.utilization"
     );
 


### PR DESCRIPTION
==COMMIT_MSG==
Report Process CPU time as `process.cpu.time.nanoseconds`
==COMMIT_MSG==

