### PR TITLE
[0.12.x] Improved remoting3 tracing fallback handling (#468)

### DIFF
--- a/changelog/@unreleased/pr-468.v2.yml
+++ b/changelog/@unreleased/pr-468.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    When remoting3 tracing is detected and fallback is required:
+      * Memoize fallback determination and tracer to reduce overhead
+      * Only log the first time fallback is required to reduce noise
+  links:
+  - https://github.com/palantir/tritium/pull/468


### PR DESCRIPTION
0.12.x backport of #468 

## Before this PR
When remoting3 tracing is detected and fallback is required we would noisily log error messages each time a tracer is created.

Ideally all folks would have upgraded off of remoting3 to conjure, but that has not happened everywhere yet, so we should improve our handling of fallback scenarios.

## After this PR
==COMMIT_MSG==
When remoting3 tracing is detected and fallback is required:
  * Memoize fallback determination and tracer to reduce overhead
  * Only log the first time fallback is required to reduce noise
==COMMIT_MSG==

## Possible downsides?
Maintenance burden of remoting3 back-compat and its older, less optimal tracing library.