### PR TITLE
Register tagged gauge with replacement

### DIFF
--- a/changelog/@unreleased/pr-501.v2.yml
+++ b/changelog/@unreleased/pr-501.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Register tagged gauge with replacement
+  links:
+  - https://github.com/palantir/tritium/pull/501

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStats.java
@@ -65,10 +65,7 @@ public final class CaffeineCacheStats {
 
         CaffeineCacheTaggedMetrics.create(cache, name)
                 .getMetrics()
-                .forEach((metricName, gauge) -> {
-                    registry.remove(metricName);
-                    registry.gauge(metricName, gauge);
-                });
+                .forEach(registry::registerWithReplacement);
     }
 
     static <K> ImmutableMap<K, Gauge<?>> createCacheGauges(Cache<?, ?> cache, Function<String, K> metricNamer) {

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -265,10 +265,7 @@ public final class MetricRegistries {
 
         CacheTaggedMetrics.create(cache, name)
                 .getMetrics()
-                .forEach((metricName, gauge) -> {
-                    registry.remove(metricName);
-                    registry.gauge(metricName, gauge);
-                });
+                .forEach(registry::registerWithReplacement);
     }
 
     /**
@@ -467,7 +464,7 @@ public final class MetricRegistries {
             String safeName = MetricRegistry.name(prefix, name);
             MetricName metricName = MetricName.builder().safeName(safeName).build();
             if (metric instanceof Gauge) {
-                registry.gauge(metricName, (Gauge<?>) metric);
+                registry.registerWithReplacement(metricName, (Gauge<?>) metric);
             } else if (metric instanceof Counter) {
                 registry.counter(metricName, () -> (Counter) metric);
             } else if (metric instanceof Histogram) {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AbstractTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AbstractTaggedMetricRegistry.java
@@ -118,14 +118,14 @@ public abstract class AbstractTaggedMetricRegistry implements TaggedMetricRegist
     }
 
     @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "deprecation"})
     public final <T> Gauge<T> gauge(MetricName metricName, Gauge<T> gauge) {
         return getOrAdd(metricName, Gauge.class, () -> gauge);
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public final <T> void registerOrReplaceGauge(MetricName metricName, Gauge<T> gauge) {
+    public final void registerWithReplacement(MetricName metricName, Gauge<?> gauge) {
         Metric existing = registry.put(metricName, gauge);
         if (existing != null && !(existing instanceof Gauge)) {
             registry.replace(metricName, existing);

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
@@ -22,8 +22,10 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
+import com.palantir.logsafe.SafeArg;
 import java.util.Optional;
 import java.util.function.Supplier;
+import org.slf4j.LoggerFactory;
 
 /**
  * Similar to {@link com.codahale.metrics.MetricRegistry} but allows tagging of {@link Metric}s.
@@ -61,12 +63,12 @@ public interface TaggedMetricRegistry extends TaggedMetricSet {
     Histogram histogram(MetricName metricName, Supplier<Histogram> histogramSupplier);
 
     /**
-     * Returns existing gauge metric for the specified metric name or null if none has been registered.
+     * Returns existing gauge metric for the specified metric name or empty if none has been registered.
      *
      * @implNote Implementations should override this method with a more efficient mechanism.
      *
      * @param metricName metric name
-     * @return gauge metric or empty
+     * @return gauge metric or empty if none exists for this name
      */
     @SuppressWarnings("unchecked")
     default <T> Optional<Gauge<T>> gauge(MetricName metricName) {
@@ -83,8 +85,15 @@ public interface TaggedMetricRegistry extends TaggedMetricSet {
      * @param metricName metric name
      * @param gauge gauge
      * @return gauge metric
+     *
+     * In most cases, one typically wants {@link #registerWithReplacement(MetricName, Gauge)} as gauges may
+     * retain references to large backing data structures (e.g. queue or cache), and if a gauge is being registered
+     * with the same name, one is likely replacing that previous data structure and the registry should not retain
+     * references to the previous version. If lookup of an existing gauge is desired, one should use
+     * {@link #gauge(MetricName)}.
      */
     // This differs from MetricRegistry and takes the Gauge directly rather than a Supplier<Gauge>
+    // @Deprecated
     <T> Gauge<T> gauge(MetricName metricName, Gauge<T> gauge);
 
     /**
@@ -94,12 +103,14 @@ public interface TaggedMetricRegistry extends TaggedMetricSet {
      * @param gauge gauge
      */
     // This differs from MetricRegistry and takes the Gauge directly rather than a Supplier<Gauge>
-    default <T> void registerOrReplaceGauge(MetricName metricName, Gauge<T> gauge) {
-        Gauge<T> existing = gauge(metricName, gauge);
+    @SuppressWarnings("deprecation") // explicitly using as desired
+    default void registerWithReplacement(MetricName metricName, Gauge<?> gauge) {
+        Gauge<?> existing = gauge(metricName, gauge);
         if (existing == gauge) {
             return;
         }
-        remove(metricName);
+        remove(metricName).ifPresent(removed -> LoggerFactory.getLogger(getClass())
+                .debug("Removed previously registered gauge {}", SafeArg.of("metricName", metricName)));
         gauge(metricName, gauge);
     }
 

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistryTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistryTest.java
@@ -89,6 +89,7 @@ final class TaggedMetricRegistryTest {
 
     @ParameterizedTest
     @MethodSource(TestTaggedMetricRegistries.REGISTRIES)
+    @SuppressWarnings("deprecation") // explicitly testing
     void testGauge(TaggedMetricRegistry registry) {
         Gauge<Integer> gauge1 = registry.gauge(METRIC_1, intGauge(1));
         Gauge<Integer> gauge2 = registry.gauge(METRIC_2, intGauge(2));
@@ -103,15 +104,16 @@ final class TaggedMetricRegistryTest {
 
     @ParameterizedTest
     @MethodSource(TestTaggedMetricRegistries.REGISTRIES)
+    @SuppressWarnings("deprecation") // explicitly testing
     void testReplaceGauge(TaggedMetricRegistry registry) {
         assertThat(registry.getMetrics().get(METRIC_1)).isNull();
         Gauge<Integer> gauge1 = intGauge(1);
-        registry.registerOrReplaceGauge(METRIC_1, gauge1);
+        registry.registerWithReplacement(METRIC_1, gauge1);
         assertThat(registry.getMetrics().get(METRIC_1))
                 .isSameAs(registry.gauge(METRIC_1).get())
                 .isSameAs(gauge1);
         Gauge<Integer> gauge2 = intGauge(2);
-        registry.registerOrReplaceGauge(METRIC_2, gauge2);
+        registry.registerWithReplacement(METRIC_2, gauge2);
         assertThat(registry.getMetrics().get(METRIC_2))
                 .isSameAs(registry.gauge(METRIC_2).get())
                 .isSameAs(gauge2);
@@ -127,7 +129,7 @@ final class TaggedMetricRegistryTest {
                 .isSameAs(registry.gauge(METRIC_1).get())
                 .isSameAs(gauge1);
         Gauge<Integer> gauge3 = intGauge(3);
-        registry.registerOrReplaceGauge(METRIC_1, gauge3);
+        registry.registerWithReplacement(METRIC_1, gauge3);
         assertThat(registry.getMetrics().get(METRIC_1))
                 .isSameAs(registry.gauge(METRIC_1).get())
                 .isSameAs(gauge3);
@@ -139,7 +141,7 @@ final class TaggedMetricRegistryTest {
                 .isSameAs(registry.gauge(METRIC_2).get())
                 .isSameAs(gauge2);
         Gauge<Integer> gauge4 = intGauge(4);
-        registry.registerOrReplaceGauge(METRIC_2, gauge4);
+        registry.registerWithReplacement(METRIC_2, gauge4);
         assertThat(registry.getMetrics().get(METRIC_2))
                 .isSameAs(registry.gauge(METRIC_2).get())
                 .isSameAs(gauge4);
@@ -154,7 +156,7 @@ final class TaggedMetricRegistryTest {
 
             @Override
             public String toString() {
-                return "{gauge value=" + String.valueOf(value) + ", " + super.toString() + '}';
+                return "{gauge value=" + value + ", " + super.toString() + '}';
             }
         };
     }
@@ -213,6 +215,7 @@ final class TaggedMetricRegistryTest {
 
     @ParameterizedTest
     @MethodSource(TestTaggedMetricRegistries.REGISTRIES)
+    @SuppressWarnings("deprecation") // explicitly testing
     void testRemoveMetric(TaggedMetricRegistry registry) {
         Gauge<Integer> gauge = intGauge(42);
         Gauge<Integer> registeredGauge = registry.gauge(METRIC_1, gauge);


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Registering gauges with `TaggedMetricRegistry` may lead to memory leaks if one intended to actually replace a previously registered gauge under the same metric name.

## After this PR
==COMMIT_MSG==
Register tagged gauge with replacement
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

