### PR TITLE
Instrumentation wrapper classes have their own loggers

### DIFF
--- a/changelog/@unreleased/pr-508.v2.yml
+++ b/changelog/@unreleased/pr-508.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Instrumentation wrapper classes have their own loggers
+  links:
+  - https://github.com/palantir/tritium/pull/508

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/ByteBuddyInstrumentationAdvice.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/ByteBuddyInstrumentationAdvice.java
@@ -31,11 +31,8 @@ import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class ByteBuddyInstrumentationAdvice {
-
-    private static final Logger logger = LoggerFactory.getLogger(ByteBuddyInstrumentationAdvice.class);
 
     private ByteBuddyInstrumentationAdvice() {}
 
@@ -56,6 +53,7 @@ final class ByteBuddyInstrumentationAdvice {
             @Advice.FieldValue("instrumentationFilter") InstrumentationFilter filter,
             @Advice.FieldValue("invocationEventHandler") InvocationEventHandler<?> eventHandler,
             @Advice.FieldValue("methods") Method[] methods,
+            @Advice.FieldValue("log") Logger logger,
             @MethodIndex int index) {
         Method method = methods[index];
         try {
@@ -78,6 +76,7 @@ final class ByteBuddyInstrumentationAdvice {
             @Advice.Return(typing = Assigner.Typing.DYNAMIC) Object result,
             @Advice.Thrown Throwable thrown,
             @Advice.FieldValue("invocationEventHandler") InvocationEventHandler<?> eventHandler,
+            @Advice.FieldValue("log") Logger logger,
             @Advice.Enter InvocationContext context) {
         if (context != null) {
             try {


### PR DESCRIPTION
No longer have to reach into package-private
ByteBuddyInstrumentationAdvice, which can
result in access exceptions.

==COMMIT_MSG==
Instrumentation wrapper classes have their own loggers
==COMMIT_MSG==

```
[main] WARN com.palantir.tritium.proxy.InstrumentedRunnable$5 - Failure occurred handling 'preInvocation' invocation on: com.google.common.util.concurrent.Runnables$1@5829e4f4
java.lang.RuntimeException
	at com.palantir.tritium.proxy.InstrumentedRunnable$5.run(Unknown Source)
	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:62)
	at org.assertj.core.api.AssertionsForClassTypes.catchThrowable(AssertionsForClassTypes.java:739)
	at org.assertj.core.api.AssertionsForClassTypes.assertThatCode(AssertionsForClassTypes.java:710)
```
