### PR TITLE
Tritium instrumentation handles null InvocationContexts 

### DIFF
--- a/changelog/@unreleased/pr-508.v2.yml
+++ b/changelog/@unreleased/pr-508.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Instrumentation wrapper classes have their own loggers
+  links:
+  - https://github.com/palantir/tritium/pull/508

--- a/changelog/@unreleased/pr-510-2.v2.yml
+++ b/changelog/@unreleased/pr-510-2.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: When `InvocationEventHandler.preInvocation` throws an exception, `onSuccess` or `onFailure` will be properly invoked with a null context as expected.
+  links:
+  - https://github.com/palantir/tritium/pull/510

--- a/changelog/@unreleased/pr-510.v2.yml
+++ b/changelog/@unreleased/pr-510.v2.yml
@@ -1,0 +1,9 @@
+type: fix
+fix:
+  description: Tritium instrumentation handles null InvocationContexts.
+    A behavior change was introduced in #379 which resulted in handlers
+    which return a null InvocationContext being considered disabled,
+    which prevented the onSuccess and onFailure methods from
+    being invoked at all.
+  links:
+  - https://github.com/palantir/tritium/pull/510

--- a/changelog/@unreleased/pr-510.v2.yml
+++ b/changelog/@unreleased/pr-510.v2.yml
@@ -1,9 +1,9 @@
 type: fix
 fix:
   description: Tritium instrumentation handles null InvocationContexts.
-    A behavior change was introduced in #379 which resulted in handlers
-    which return a null InvocationContext being considered disabled,
-    which prevented the onSuccess and onFailure methods from
-    being invoked at all.
+    A behavior change was introduced in [379](https://github.com/palantir/tritium/pull/379)
+    which resulted in handlers which return a null InvocationContext being
+    considered disabled, which prevented the onSuccess and onFailure methods
+    from being invoked at all.
   links:
   - https://github.com/palantir/tritium/pull/510

--- a/tritium-api/src/main/java/com/palantir/tritium/event/InvocationEventHandler.java
+++ b/tritium-api/src/main/java/com/palantir/tritium/event/InvocationEventHandler.java
@@ -48,6 +48,9 @@ public interface InvocationEventHandler<C extends InvocationContext> {
      * interface method takes no arguments. Arguments of primitive types are
      * wrapped in instances of the appropriate primitive wrapper class, such as
      * {@code java.lang.Integer} or {@code java.lang.Boolean}.
+     *
+     * @return the current invocation context. Null values are not recommended but
+     * are supported.
      */
     C preInvocation(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args);
 

--- a/tritium-api/src/main/java/com/palantir/tritium/event/InvocationEventHandler.java
+++ b/tritium-api/src/main/java/com/palantir/tritium/event/InvocationEventHandler.java
@@ -54,7 +54,7 @@ public interface InvocationEventHandler<C extends InvocationContext> {
     /**
      * Invoked with the result of the invocation when it is successful.
      *
-     * @param context the current invocation context.
+     * @param context the current invocation context or null if preInvocation returned null, or threw an exception.
      * @param result the return value from invocation, or null if {@link Void}.
      */
     void onSuccess(@Nullable InvocationContext context, @Nullable Object result);
@@ -66,7 +66,7 @@ public interface InvocationEventHandler<C extends InvocationContext> {
      * If the invocation throws an {@link java.lang.reflect.InvocationTargetException}, then the cause is passed to this
      * method. Any other thrown object is passed unaltered.
      *
-     * @param context the current invocation context.
+     * @param context the current invocation context or null if preInvocation returned null, or threw an exception.
      * @param cause the throwable which caused the failure.
      */
     void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause);

--- a/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
@@ -111,10 +111,11 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
             if (handler != null) {
                 return handler.preInvocation(instance, method, args);
             }
+            return DisabledHandlerSentinel.INSTANCE;
         } catch (RuntimeException e) {
             preInvocationFailed(handler, instance, method, e);
+            return null;
         }
-        return DisabledHandlerSentinel.INSTANCE;
     }
 
     @Override

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/ByteBuddyInstrumentationAdvice.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/ByteBuddyInstrumentationAdvice.java
@@ -54,6 +54,7 @@ final class ByteBuddyInstrumentationAdvice {
             @Advice.FieldValue("invocationEventHandler") InvocationEventHandler<?> eventHandler,
             @Advice.FieldValue("methods") Method[] methods,
             @Advice.FieldValue("log") Logger logger,
+            @Advice.FieldValue("DISABLED_HANDLER_SENTINEL") InvocationContext disabledHandlerSentinel,
             @MethodIndex int index) {
         Method method = methods[index];
         try {
@@ -68,7 +69,7 @@ final class ByteBuddyInstrumentationAdvice {
                         t);
             }
         }
-        return null;
+        return disabledHandlerSentinel;
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, backupArguments = false)
@@ -77,8 +78,9 @@ final class ByteBuddyInstrumentationAdvice {
             @Advice.Thrown Throwable thrown,
             @Advice.FieldValue("invocationEventHandler") InvocationEventHandler<?> eventHandler,
             @Advice.FieldValue("log") Logger logger,
+            @Advice.FieldValue("DISABLED_HANDLER_SENTINEL") InvocationContext disabledHandlerSentinel,
             @Advice.Enter InvocationContext context) {
-        if (context != null) {
+        if (context != disabledHandlerSentinel) {
             try {
                 if (thrown == null) {
                     eventHandler.onSuccess(context, result);

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/ByteBuddyInstrumentationAdvice.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/ByteBuddyInstrumentationAdvice.java
@@ -31,11 +31,8 @@ import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class ByteBuddyInstrumentationAdvice {
-
-    private static final Logger logger = LoggerFactory.getLogger(ByteBuddyInstrumentationAdvice.class);
 
     private ByteBuddyInstrumentationAdvice() {}
 
@@ -56,6 +53,7 @@ final class ByteBuddyInstrumentationAdvice {
             @Advice.FieldValue("instrumentationFilter") InstrumentationFilter filter,
             @Advice.FieldValue("invocationEventHandler") InvocationEventHandler<?> eventHandler,
             @Advice.FieldValue("methods") Method[] methods,
+            @Advice.FieldValue("log") Logger logger,
             @MethodIndex int index) {
         Method method = methods[index];
         try {
@@ -78,6 +76,7 @@ final class ByteBuddyInstrumentationAdvice {
             @Advice.Return(typing = Assigner.Typing.DYNAMIC) Object result,
             @Advice.Thrown Throwable thrown,
             @Advice.FieldValue("invocationEventHandler") InvocationEventHandler<?> eventHandler,
+            @Advice.FieldValue("log") Logger logger,
             @Advice.Enter InvocationContext context) {
         if (context != null) {
             try {

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
@@ -643,7 +643,7 @@ public abstract class InstrumentationTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void testThrowingHandler() {
+    void testThrowingHandler_success_single() {
         InvocationEventHandler<InvocationContext> handler = Mockito.mock(InvocationEventHandler.class);
         when(handler.isEnabled()).thenReturn(true);
         when(handler.preInvocation(any(), any(), any())).thenThrow(new RuntimeException());
@@ -651,6 +651,64 @@ public abstract class InstrumentationTest {
                 .withHandler(handler)
                 .build();
         assertThatCode(wrapped::run).doesNotThrowAnyException();
+        verify(handler).isEnabled();
+        verify(handler).preInvocation(any(), any(), any());
+        verify(handler).onSuccess(isNull(), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testThrowingHandler_success_composite() {
+        InvocationEventHandler<InvocationContext> handler = Mockito.mock(InvocationEventHandler.class);
+        when(handler.isEnabled()).thenReturn(true);
+        when(handler.preInvocation(any(), any(), any())).thenThrow(new RuntimeException());
+        Runnable wrapped = Instrumentation.builder(Runnable.class, Runnables.doNothing())
+                .withHandler(handler)
+                .withTaggedMetrics(new DefaultTaggedMetricRegistry())
+                .build();
+        assertThatCode(wrapped::run).doesNotThrowAnyException();
+        verify(handler).isEnabled();
+        verify(handler).preInvocation(any(), any(), any());
+        verify(handler).onSuccess(isNull(), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testThrowingHandler_failure_single() {
+        InvocationEventHandler<InvocationContext> handler = Mockito.mock(InvocationEventHandler.class);
+        when(handler.isEnabled()).thenReturn(true);
+        when(handler.preInvocation(any(), any(), any())).thenThrow(new RuntimeException());
+        Runnable wrapped = Instrumentation.builder(Runnable.class, () -> {
+            throw new SafeRuntimeException("expected");
+        })
+                .withHandler(handler)
+                .build();
+        assertThatCode(wrapped::run)
+                .isExactlyInstanceOf(SafeRuntimeException.class)
+                .hasMessage("expected");
+        verify(handler).isEnabled();
+        verify(handler).preInvocation(any(), any(), any());
+        verify(handler).onFailure(isNull(), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testThrowingHandler_failure_composite() {
+        InvocationEventHandler<InvocationContext> handler = Mockito.mock(InvocationEventHandler.class);
+        when(handler.isEnabled()).thenReturn(true);
+        when(handler.preInvocation(any(), any(), any())).thenThrow(new RuntimeException());
+        Runnable wrapped = Instrumentation.builder(Runnable.class, () -> {
+            throw new SafeRuntimeException("expected");
+        })
+                .withHandler(handler)
+                .withTaggedMetrics(new DefaultTaggedMetricRegistry())
+                .build();
+        assertThatCode(wrapped::run)
+                .isExactlyInstanceOf(SafeRuntimeException.class)
+                .hasMessage("expected");
+        verify(handler).isEnabled();
+        verify(handler).preInvocation(any(), any(), any());
+        verify(handler).onFailure(isNull(), any());
     }
 
     @Test


### PR DESCRIPTION
==COMMIT_MSG==
Tritium instrumentation handles null InvocationContexts.
A behavior change was introduced in #379 which resulted in handlers
which return a null InvocationContext being considered disabled,
which prevented the `onSuccess` and `onFailure` methods from
being invoked at all.
==COMMIT_MSG==

