### PR TITLE
Migrate `jvm.attribute` metrics to metric-schema

### DIFF
--- a/changelog/@unreleased/pr-512.v2.yml
+++ b/changelog/@unreleased/pr-512.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Include `jvm.attribute` metrics in metric-schema
+  links:
+  - https://github.com/palantir/tritium/pull/512

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -16,16 +16,21 @@
 
 package com.palantir.tritium.metrics.jvm;
 
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.JvmAttributeGaugeSet;
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.jvm.BufferPoolMetricSet;
 import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 import com.google.common.collect.Maps;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.lang.management.ManagementFactory;
+import java.util.Map;
 
 /**
  * {@link JvmMetrics} provides a standard set of metrics for debugging java services.
@@ -47,7 +52,8 @@ public final class JvmMetrics {
         Jdk9CompatibleFileDescriptorRatioGauge.register(registry);
         OperatingSystemMetrics.register(registry);
         SafepointMetrics.register(registry);
-        MetricRegistries.registerAll(registry, "jvm.attribute", new JvmAttributeGaugeSet());
+        InternalJvmMetrics metrics = InternalJvmMetrics.of(registry);
+        registerAttributes(metrics);
         MetricRegistries.registerAll(registry, "jvm.buffers",
                 new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
         MetricRegistries.registerAll(registry, "jvm.classloader", new ClassLoadingGaugeSet());
@@ -55,6 +61,22 @@ public final class JvmMetrics {
                 // Memory pool metrics are already provided by MetricRegistries.registerMemoryPools
                 new MemoryUsageGaugeSet().getMetrics(), name -> !name.startsWith("pools")));
         MetricRegistries.registerAll(registry, "jvm.threads", new ThreadStatesGaugeSet());
+    }
+
+    private static void registerAttributes(InternalJvmMetrics metrics) {
+        Map<String, Metric> jvmAttributes = new JvmAttributeGaugeSet().getMetrics();
+        metrics.attributeName(gauge(jvmAttributes, "name"));
+        metrics.attributeVendor(gauge(jvmAttributes, "vendor"));
+        metrics.attributeUptime(gauge(jvmAttributes, "uptime"));
+    }
+
+    private static Gauge<?> gauge(Map<String, Metric> metrics, String name) {
+        Metric metric = Preconditions.checkNotNull(metrics.get(name),
+                "Failed to find metric", SafeArg.of("name", name));
+        if (metric instanceof Gauge) {
+            return (Gauge<?>) metric;
+        }
+        throw new SafeIllegalStateException("Expected a gauge", SafeArg.of("type", metric.getClass()));
     }
 
     private JvmMetrics() {

--- a/tritium-metrics-jvm/src/main/metrics/metrics.yml
+++ b/tritium-metrics-jvm/src/main/metrics/metrics.yml
@@ -28,3 +28,12 @@ namespaces:
       filedescriptor:
         type: gauge
         docs: Ratio of open file descriptors to the maximum allowed open file descriptors. When this value reaches 1, attempts to open files (including sockets) will fail.
+      attribute.name:
+        type: gauge
+        docs: Provides the string value of the name of the current processes JVM.
+      attribute.vendor:
+        type: gauge
+        docs: Provides a string value representing the vendor and version of the current processes JVM.
+      attribute.uptime:
+        type: gauge
+        docs: Provides the Java virtual machine uptime value in milliseconds.


### PR DESCRIPTION
==COMMIT_MSG==
Include `jvm.attribute` metrics in metric-schema
==COMMIT_MSG==

These are a bit gnarly because we don't define the gauges ourselves, but I think its worthwhile to provide documentation in our schema.