### PR TITLE
jvm.attribute.uptime tags includes jvm vendor and version info

### DIFF
--- a/changelog/@unreleased/pr-516.v2.yml
+++ b/changelog/@unreleased/pr-516.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: The `jvm.attribute.uptime` metric now has several additional tags corresponding
+    to the JVM system properties `java.specification.version`, `java.version`, `java.version.date`,
+    `java.runtime.version`, `java.vendor.version`, `java.vm.vendor`, allowing observability
+    of how long a particular JVM version has been up for.
+  links:
+  - https://github.com/palantir/tritium/pull/516

--- a/changelog/@unreleased/pr-516.v2.yml
+++ b/changelog/@unreleased/pr-516.v2.yml
@@ -1,8 +1,14 @@
-type: improvement
-improvement:
-  description: The `jvm.attribute.uptime` metric now has several additional tags corresponding
-    to the JVM system properties `java.specification.version`, `java.version`, `java.version.date`,
-    `java.runtime.version`, `java.vendor.version`, `java.vm.vendor`, allowing observability
-    of how long a particular JVM version has been up for.
-  links:
-  - https://github.com/palantir/tritium/pull/516
+changes:
+- type: break
+  break:
+    description: |
+      The `jvm.attribute.name` and `jvm.attribute.vendor` gauges have been removed as their string values can't be represented in DataDog.
+      The information is now provided as tags on the `jvm.attribute.uptime` metric.
+- type: improvement
+  improvement:
+    description: The `jvm.attribute.uptime` metric now has several additional tags corresponding
+      to the JVM system properties `java.specification.version`, `java.version`, `java.version.date`,
+      `java.runtime.version`, `java.vendor.version`, `java.vm.vendor`, allowing observability
+      of how long a particular JVM version has been up for.
+    links:
+    - https://github.com/palantir/tritium/pull/516

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -68,12 +68,12 @@ public final class JvmMetrics {
         metrics.attributeName(gauge(jvmAttributes, "name"));
         metrics.attributeVendor(gauge(jvmAttributes, "vendor"));
         metrics.attributeUptime()
-                .javaSpecificationVersion(System.getProperty("java.specification.version", "null"))
-                .javaVersion(System.getProperty("java.version", "null"))
-                .javaVersionDate(System.getProperty("java.version.date", "null"))
-                .javaRuntimeVersion(System.getProperty("java.runtime.version", "null"))
-                .javaVendorVersion(System.getProperty("java.vendor.version", "null"))
-                .javaVmVendor(System.getProperty("java.vm.vendor", "null"))
+                .javaSpecificationVersion(System.getProperty("java.specification.version", "unknown"))
+                .javaVersion(System.getProperty("java.version", "unknown"))
+                .javaVersionDate(System.getProperty("java.version.date", "unknown"))
+                .javaRuntimeVersion(System.getProperty("java.runtime.version", "unknown"))
+                .javaVendorVersion(System.getProperty("java.vendor.version", "unknown"))
+                .javaVmVendor(System.getProperty("java.vm.vendor", "unknown"))
                 .build(gauge(jvmAttributes, "uptime"));
     }
 

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -65,8 +65,6 @@ public final class JvmMetrics {
 
     private static void registerAttributes(InternalJvmMetrics metrics) {
         Map<String, Metric> jvmAttributes = new JvmAttributeGaugeSet().getMetrics();
-        metrics.attributeName(gauge(jvmAttributes, "name"));
-        metrics.attributeVendor(gauge(jvmAttributes, "vendor"));
         metrics.attributeUptime()
                 .javaSpecificationVersion(System.getProperty("java.specification.version", "unknown"))
                 .javaVersion(System.getProperty("java.version", "unknown"))

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -67,7 +67,14 @@ public final class JvmMetrics {
         Map<String, Metric> jvmAttributes = new JvmAttributeGaugeSet().getMetrics();
         metrics.attributeName(gauge(jvmAttributes, "name"));
         metrics.attributeVendor(gauge(jvmAttributes, "vendor"));
-        metrics.attributeUptime(gauge(jvmAttributes, "uptime"));
+        metrics.attributeUptime()
+                .javaSpecificationVersion(System.getProperty("java.specification.version", "null"))
+                .javaVersion(System.getProperty("java.version", "null"))
+                .javaVersionDate(System.getProperty("java.version.date", "null"))
+                .javaRuntimeVersion(System.getProperty("java.runtime.version", "null"))
+                .javaVendorVersion(System.getProperty("java.vendor.version", "null"))
+                .javaVmVendor(System.getProperty("java.vm.vendor", "null"))
+                .build(gauge(jvmAttributes, "uptime"));
     }
 
     private static Gauge<?> gauge(Map<String, Metric> metrics, String name) {

--- a/tritium-metrics-jvm/src/main/metrics/metrics.yml
+++ b/tritium-metrics-jvm/src/main/metrics/metrics.yml
@@ -40,7 +40,7 @@ namespaces:
         tags:
         - javaSpecificationVersion # 11
         - javaVersion # 11.0.3
-        - javaVersionDate # 11.0.3
+        - javaVersionDate # 2019-04-16
         - javaRuntimeVersion # 11.0.3+7-LTS
         - javaVendorVersion # Zulu11.31+11-CA
         - javaVmVendor # Azul Systems, Inc.

--- a/tritium-metrics-jvm/src/main/metrics/metrics.yml
+++ b/tritium-metrics-jvm/src/main/metrics/metrics.yml
@@ -28,12 +28,6 @@ namespaces:
       filedescriptor:
         type: gauge
         docs: Ratio of open file descriptors to the maximum allowed open file descriptors. When this value reaches 1, attempts to open files (including sockets) will fail.
-      attribute.name:
-        type: gauge
-        docs: Provides the string value of the name of the current processes JVM.
-      attribute.vendor:
-        type: gauge
-        docs: Provides a string value representing the vendor and version of the current processes JVM.
       attribute.uptime:
         type: gauge
         docs: |

--- a/tritium-metrics-jvm/src/main/metrics/metrics.yml
+++ b/tritium-metrics-jvm/src/main/metrics/metrics.yml
@@ -37,3 +37,10 @@ namespaces:
       attribute.uptime:
         type: gauge
         docs: Provides the Java virtual machine uptime value in milliseconds.
+        tags:
+        - javaSpecificationVersion # 11
+        - javaVersion # 11.0.3
+        - javaVersionDate # 11.0.3
+        - javaRuntimeVersion # 11.0.3+7-LTS
+        - javaVendorVersion # Zulu11.31+11-CA
+        - javaVmVendor # Azul Systems, Inc.

--- a/tritium-metrics-jvm/src/main/metrics/metrics.yml
+++ b/tritium-metrics-jvm/src/main/metrics/metrics.yml
@@ -36,11 +36,14 @@ namespaces:
         docs: Provides a string value representing the vendor and version of the current processes JVM.
       attribute.uptime:
         type: gauge
-        docs: Provides the Java virtual machine uptime value in milliseconds.
+        docs: |
+          Provides the Java virtual machine uptime value in milliseconds. Example tags:
+          javaSpecificationVersion = 11, javaVersion = 11.0.3, javaVersionDate = 2019-04-16,
+          javaRuntimeVersion = 11.0.3+7-LTS, javaVendorVersion = Zulu11.31+11-CA, javaVmVendor = Azul Systems, Inc.
         tags:
-        - javaSpecificationVersion # 11
-        - javaVersion # 11.0.3
-        - javaVersionDate # 2019-04-16
-        - javaRuntimeVersion # 11.0.3+7-LTS
-        - javaVendorVersion # Zulu11.31+11-CA
-        - javaVmVendor # Azul Systems, Inc.
+        - javaSpecificationVersion
+        - javaVersion
+        - javaVersionDate
+        - javaRuntimeVersion
+        - javaVendorVersion
+        - javaVmVendor

--- a/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
+++ b/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
@@ -38,9 +38,7 @@ import org.junit.jupiter.api.io.TempDir;
 final class JvmMetricsTest {
 
     private static final ImmutableSet<String> EXPECTED_NAMES = ImmutableSet.of(
-            "jvm.attribute.name",
             "jvm.attribute.uptime",
-            "jvm.attribute.vendor",
             "jvm.buffers.direct.capacity",
             "jvm.buffers.direct.count",
             "jvm.buffers.direct.used",

--- a/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
+++ b/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
@@ -154,4 +154,20 @@ final class JvmMetricsTest {
                 .get(MetricName.builder().safeName("jvm.safepoint.time").build());
         assertThat(safepointTime).satisfies(gauge -> assertThat(gauge.getValue()).isNotNegative());
     }
+
+    @Test
+    void testUptimeHasExtraTags() {
+        TaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+        JvmMetrics.register(registry);
+        assertThat(registry.getMetrics().keySet()).anySatisfy(name -> {
+            assertThat(name.safeName()).isEqualTo("jvm.attribute.uptime");
+            assertThat(name.safeTags().keySet()).containsExactlyInAnyOrder(
+                    "javaRuntimeVersion",
+                    "javaSpecificationVersion",
+                    "javaVendorVersion",
+                    "javaVersion",
+                    "javaVersionDate",
+                    "javaVmVendor");
+        });
+    }
 }


### PR DESCRIPTION
## Before this PR

I'm currently rolling out a new JRE, adoptopenjdk 11.0.5. I've got it installed on a couple of canary deployments, but I currently don't have a good way of looking at a deployment and establishing how long services have actually been _running_ using my new JVM. 

Servers will pick up my new JVM when they restart, but I don't have the ability to just go and restart everything. Even if I did, I'd still like to look some kind of graph to figure out how much confidence I have in a particular jvm version.

cc @CRogers 

## After this PR
==COMMIT_MSG==
The `jvm.attribute.uptime` metric now has several additional tags corresponding to the JVM system properties `java.specification.version`, `java.version`, `java.version.date`, `java.runtime.version`, `java.vendor.version`, `java.vm.vendor`, allowing observability of how long a particular JVM version has been up for.
==COMMIT_MSG==

Obviously when a service restarts its uptime goes back to zero, but I actually want to add together its previous uptime with its current uptime... I think I do this by using the `per_second` and then `cum_sum` to get the graph I want.

These system properties are not expected to change for the lifetime of a service, so while this PR adds lots of tags, it shouldn't actually add any more unique _series_ in datadog (therefore I think the cost is $0).

Future work: I'm intending to slurp this stuff back from DD -> our internal foundry stack so that excavator can make decisions based on it

## Possible downsides?

- writing more bytes to disk
- there is now inconsistency between metrics `jvm` namespace, as most are untagged but `attribute.uptime` is super tagged.

## Alternatives

Could I just get this from skylab?

Not easily - skylab currently gives services both JAVA_8_HOME and JAVA_11_HOME environment variables and then lets them decide which one they want to use when they start up.