### PR TITLE
Deprecate SharedTaggedMetricRegistries#getSingleton

### DIFF
--- a/changelog/@unreleased/pr-519.v2.yml
+++ b/changelog/@unreleased/pr-519.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '`SharedTaggedMetricRegistries#getSingleton` is now deprecated. Using
+    the global singleton should be avoided.'
+  links:
+  - https://github.com/palantir/tritium/pull/519

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/ProxyBenchmark.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/ProxyBenchmark.java
@@ -25,7 +25,6 @@ import com.palantir.tritium.event.log.LoggingInvocationEventHandler;
 import com.palantir.tritium.event.log.LoggingLevel;
 import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
-import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
 import com.palantir.tritium.proxy.Instrumentation;
 import com.palantir.tritium.tracing.RemotingCompatibleTracingInvocationEventHandler;
 import com.palantir.tritium.tracing.TracingInvocationEventHandler;
@@ -123,7 +122,7 @@ public class ProxyBenchmark {
                 .build();
 
         instrumentedWithTaggedMetrics = Instrumentation.builder(serviceInterface, raw)
-                .withTaggedMetrics(SharedTaggedMetricRegistries.getSingleton(), serviceInterface.getName())
+                .withTaggedMetrics(new DefaultTaggedMetricRegistry(), serviceInterface.getName())
                 .build();
 
         instrumentedWithTracing = Instrumentation.builder(serviceInterface, raw)

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/SharedTaggedMetricRegistries.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/SharedTaggedMetricRegistries.java
@@ -37,8 +37,7 @@ public final class SharedTaggedMetricRegistries {
      * Single shared instance for use when it is infeasible to plumb through a user supplied instance.
      *
      * @deprecated avoid using the global singleton
-     *
-     * */
+     */
     @Deprecated
     public static TaggedMetricRegistry getSingleton() {
         return DEFAULT;

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/SharedTaggedMetricRegistries.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/SharedTaggedMetricRegistries.java
@@ -33,7 +33,13 @@ public final class SharedTaggedMetricRegistries {
      */
     private static final TaggedMetricRegistry DEFAULT = new SlidingWindowTaggedMetricRegistry(35, TimeUnit.SECONDS);
 
-    /** Single shared instance for use when it is infeasible to plumb through a user supplied instance. */
+    /**
+     * Single shared instance for use when it is infeasible to plumb through a user supplied instance.
+     *
+     * @deprecated avoid using the global singleton
+     *
+     * */
+    @Deprecated
     public static TaggedMetricRegistry getSingleton() {
         return DEFAULT;
     }


### PR DESCRIPTION
We'd like to encourage people not to use the global singleton. Marking the method as deprecated signals this intent to potential users.

It's relatively easy for callers to add `SuppressWarnings("deprecation")` if it is not currently feasible to migrate away from the global singleton.

