### PR TITLE
Use more specific exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.netflix.nebula:gradle-info-plugin:5.2.0'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:14.1.1'
-        classpath 'com.palantir.baseline:gradle-baseline-java:2.37.0'
+        classpath 'com.palantir.baseline:gradle-baseline-java:2.41.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:1.13.1'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.2'
         classpath 'com.palantir.metricschema:gradle-metric-schema:0.4.8'

--- a/tritium-tracing/src/main/java/com/palantir/tritium/tracing/ReflectiveTracer.java
+++ b/tritium-tracing/src/main/java/com/palantir/tritium/tracing/ReflectiveTracer.java
@@ -90,7 +90,7 @@ final class ReflectiveTracer implements Tracer {
     private static RuntimeException throwUnchecked(ReflectiveOperationException reflectionException) {
         Throwable cause = reflectionException.getCause() != null ? reflectionException.getCause() : reflectionException;
         Throwables.throwIfUnchecked(cause);
-        throw new RuntimeException(cause);
+        throw new IllegalStateException(cause);
     }
 
 }


### PR DESCRIPTION
## Before this PR
Error-prone identified location where we should use a more specific runtime exception type -- i.e. use `IllegalStateException` over more generic `IllegalStateException`.

## After this PR
==COMMIT_MSG==
Use more specific runtime exception where possible.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

