### PR TITLE
Specify JavaDoc for InstrumentationFilters enum

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.netflix.nebula:gradle-info-plugin:5.2.0'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:14.1.1'
-        classpath 'com.palantir.baseline:gradle-baseline-java:2.37.0'
+        classpath 'com.palantir.baseline:gradle-baseline-java:2.41.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:1.13.1'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.2'
         classpath 'com.palantir.metricschema:gradle-metric-schema:0.4.8'

--- a/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationFilters.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationFilters.java
@@ -22,6 +22,9 @@ import javax.annotation.Nonnull;
 
 public enum InstrumentationFilters implements InstrumentationFilter {
 
+    /**
+     * Instrument all invocations.
+     */
     INSTRUMENT_ALL {
         @Override
         public boolean shouldInstrument(
@@ -32,6 +35,9 @@ public enum InstrumentationFilters implements InstrumentationFilter {
         }
     },
 
+    /**
+     * Instrument no invocations.
+     */
     INSTRUMENT_NONE {
         @Override
         public boolean shouldInstrument(

--- a/tritium-tracing/src/main/java/com/palantir/tritium/tracing/ReflectiveTracer.java
+++ b/tritium-tracing/src/main/java/com/palantir/tritium/tracing/ReflectiveTracer.java
@@ -90,7 +90,7 @@ final class ReflectiveTracer implements Tracer {
     private static RuntimeException throwUnchecked(ReflectiveOperationException reflectionException) {
         Throwable cause = reflectionException.getCause() != null ? reflectionException.getCause() : reflectionException;
         Throwables.throwIfUnchecked(cause);
-        throw new RuntimeException(cause);
+        throw new IllegalStateException(cause);
     }
 
 }


### PR DESCRIPTION
## Before this PR
Error prone check `AlmostJavadoc` fails compilation seen in https://github.com/palantir/tritium/pull/536#issuecomment-563470526 . 

## After this PR
==COMMIT_MSG==
Specify JavaDoc for InstrumentationFilters enum.
==COMMIT_MSG==

## Possible downsides?
Temporary workaround for error-prone bug. Will file upstream.

