### PR TITLE
Deduplicate interfaces for byte-buddy instrumentation

### DIFF
--- a/changelog/@unreleased/pr-547.v2.yml
+++ b/changelog/@unreleased/pr-547.v2.yml
@@ -1,0 +1,11 @@
+type: improvement
+improvement:
+  description: |-
+    Deduplicate interfaces for byte-buddy instrumentation
+
+    This leads to a sizable performance improvement creating
+    instrumented objects in scenarios where interfaces are declared
+    multiple times. This is particularly common when dynamic proxies
+    are instrumented, as many additional interfaces are discovered.
+  links:
+  - https://github.com/palantir/tritium/pull/547

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/InstrumentationCreationBenchmark.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/InstrumentationCreationBenchmark.java
@@ -1,0 +1,117 @@
+/*
+ * (c) Copyright 2016 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.microbenchmarks;
+
+import com.google.common.collect.Streams;
+import com.google.common.util.concurrent.Runnables;
+import com.palantir.tritium.Tritium;
+import com.palantir.tritium.event.InstrumentationProperties;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
+@Fork(1)
+@State(Scope.Benchmark)
+@SuppressWarnings({"designforextension", "NullAway"})
+public class InstrumentationCreationBenchmark {
+
+    @Param({"BYTE_BUDDY", "DYNAMIC_PROXY"})
+    private InstrumentationMode mode;
+
+    @SuppressWarnings("unused")
+    public enum InstrumentationMode {
+        BYTE_BUDDY,
+        DYNAMIC_PROXY;
+
+        void initialize() {
+            System.setProperty("instrument.dynamic-proxy", Boolean.toString(this.equals(DYNAMIC_PROXY)));
+            InstrumentationProperties.reload();
+        }
+    }
+
+    private TaggedMetricRegistry registry;
+    private Stubs.Iface99 largeStub;
+    private Stubs.Iface99 duplicateStub;
+
+    @Setup
+    public void before() {
+        mode.initialize();
+        this.registry = new DefaultTaggedMetricRegistry();
+        this.largeStub = (Stubs.Iface99) Proxy.newProxyInstance(getClass().getClassLoader(),
+                // Apply runnable to avoid benchmarks reusing the proxy class
+                new Class<?>[] {Runnable.class, Stubs.Iface99.class},
+                (proxy, method, args) -> null);
+        this.duplicateStub = (Stubs.Iface99) Proxy.newProxyInstance(getClass().getClassLoader(),
+                // Apply runnable to avoid benchmarks reusing the proxy class
+                Streams.concat(Stream.<Class<?>>of(Runnable.class), IntStream.range(0, 100)
+                        .<Class<?>>mapToObj(value -> {
+                            try {
+                                return Class.forName(Stubs.Iface99.class.getName().replace("99", "" + value));
+                            } catch (ClassNotFoundException e) {
+                                throw new IllegalStateException(e);
+                            }
+                        })).toArray(Class<?>[]::new),
+                (proxy, method, args) -> null);
+    }
+
+    @Benchmark
+    public void createInstrumentationLargeInterface() {
+        Tritium.instrument(Stubs.Iface99.class, largeStub, registry).iface50method5();
+    }
+
+    @Benchmark
+    public void createInstrumentationLargeComplexInterface() {
+        Tritium.instrument(Stubs.Iface99.class, duplicateStub, registry).iface50method5();
+    }
+
+    @Benchmark
+    public void createInstrumentationSimpleInterface() {
+        Tritium.instrument(Runnable.class, Runnables.doNothing(), registry).run();
+    }
+
+    public static void main(String[] _args) throws Exception {
+        Options options = new OptionsBuilder()
+                .include(InstrumentationCreationBenchmark.class.getName())
+                .warmupIterations(0)
+                .measurementIterations(1)
+                .mode(Mode.SingleShotTime)
+                .forks(1)
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/Stubs.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/Stubs.java
@@ -1,0 +1,1322 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.microbenchmarks;
+
+public final class Stubs {
+
+    private Stubs() {}
+
+    public interface Iface0 {
+        void iface0method0();
+        void iface0method1();
+        void iface0method2();
+        void iface0method3();
+        void iface0method4();
+        void iface0method5();
+        void iface0method6();
+        void iface0method7();
+        void iface0method8();
+        void iface0method9();
+    }
+
+    public interface Iface1 extends Iface0 {
+        void iface1method0();
+        void iface1method1();
+        void iface1method2();
+        void iface1method3();
+        void iface1method4();
+        void iface1method5();
+        void iface1method6();
+        void iface1method7();
+        void iface1method8();
+        void iface1method9();
+    }
+
+    public interface Iface2 extends Iface1 {
+        void iface2method0();
+        void iface2method1();
+        void iface2method2();
+        void iface2method3();
+        void iface2method4();
+        void iface2method5();
+        void iface2method6();
+        void iface2method7();
+        void iface2method8();
+        void iface2method9();
+    }
+
+    public interface Iface3 extends Iface2 {
+        void iface3method0();
+        void iface3method1();
+        void iface3method2();
+        void iface3method3();
+        void iface3method4();
+        void iface3method5();
+        void iface3method6();
+        void iface3method7();
+        void iface3method8();
+        void iface3method9();
+    }
+
+    public interface Iface4 extends Iface3 {
+        void iface4method0();
+        void iface4method1();
+        void iface4method2();
+        void iface4method3();
+        void iface4method4();
+        void iface4method5();
+        void iface4method6();
+        void iface4method7();
+        void iface4method8();
+        void iface4method9();
+    }
+
+    public interface Iface5 extends Iface4 {
+        void iface5method0();
+        void iface5method1();
+        void iface5method2();
+        void iface5method3();
+        void iface5method4();
+        void iface5method5();
+        void iface5method6();
+        void iface5method7();
+        void iface5method8();
+        void iface5method9();
+    }
+
+    public interface Iface6 extends Iface5 {
+        void iface6method0();
+        void iface6method1();
+        void iface6method2();
+        void iface6method3();
+        void iface6method4();
+        void iface6method5();
+        void iface6method6();
+        void iface6method7();
+        void iface6method8();
+        void iface6method9();
+    }
+
+    public interface Iface7 extends Iface6 {
+        void iface7method0();
+        void iface7method1();
+        void iface7method2();
+        void iface7method3();
+        void iface7method4();
+        void iface7method5();
+        void iface7method6();
+        void iface7method7();
+        void iface7method8();
+        void iface7method9();
+    }
+
+    public interface Iface8 extends Iface7 {
+        void iface8method0();
+        void iface8method1();
+        void iface8method2();
+        void iface8method3();
+        void iface8method4();
+        void iface8method5();
+        void iface8method6();
+        void iface8method7();
+        void iface8method8();
+        void iface8method9();
+    }
+
+    public interface Iface9 extends Iface8 {
+        void iface9method0();
+        void iface9method1();
+        void iface9method2();
+        void iface9method3();
+        void iface9method4();
+        void iface9method5();
+        void iface9method6();
+        void iface9method7();
+        void iface9method8();
+        void iface9method9();
+    }
+
+    public interface Iface10 extends Iface9 {
+        void iface10method0();
+        void iface10method1();
+        void iface10method2();
+        void iface10method3();
+        void iface10method4();
+        void iface10method5();
+        void iface10method6();
+        void iface10method7();
+        void iface10method8();
+        void iface10method9();
+    }
+
+    public interface Iface11 extends Iface10 {
+        void iface11method0();
+        void iface11method1();
+        void iface11method2();
+        void iface11method3();
+        void iface11method4();
+        void iface11method5();
+        void iface11method6();
+        void iface11method7();
+        void iface11method8();
+        void iface11method9();
+    }
+
+    public interface Iface12 extends Iface11 {
+        void iface12method0();
+        void iface12method1();
+        void iface12method2();
+        void iface12method3();
+        void iface12method4();
+        void iface12method5();
+        void iface12method6();
+        void iface12method7();
+        void iface12method8();
+        void iface12method9();
+    }
+
+    public interface Iface13 extends Iface12 {
+        void iface13method0();
+        void iface13method1();
+        void iface13method2();
+        void iface13method3();
+        void iface13method4();
+        void iface13method5();
+        void iface13method6();
+        void iface13method7();
+        void iface13method8();
+        void iface13method9();
+    }
+
+    public interface Iface14 extends Iface13 {
+        void iface14method0();
+        void iface14method1();
+        void iface14method2();
+        void iface14method3();
+        void iface14method4();
+        void iface14method5();
+        void iface14method6();
+        void iface14method7();
+        void iface14method8();
+        void iface14method9();
+    }
+
+    public interface Iface15 extends Iface14 {
+        void iface15method0();
+        void iface15method1();
+        void iface15method2();
+        void iface15method3();
+        void iface15method4();
+        void iface15method5();
+        void iface15method6();
+        void iface15method7();
+        void iface15method8();
+        void iface15method9();
+    }
+
+    public interface Iface16 extends Iface15 {
+        void iface16method0();
+        void iface16method1();
+        void iface16method2();
+        void iface16method3();
+        void iface16method4();
+        void iface16method5();
+        void iface16method6();
+        void iface16method7();
+        void iface16method8();
+        void iface16method9();
+    }
+
+    public interface Iface17 extends Iface16 {
+        void iface17method0();
+        void iface17method1();
+        void iface17method2();
+        void iface17method3();
+        void iface17method4();
+        void iface17method5();
+        void iface17method6();
+        void iface17method7();
+        void iface17method8();
+        void iface17method9();
+    }
+
+    public interface Iface18 extends Iface17 {
+        void iface18method0();
+        void iface18method1();
+        void iface18method2();
+        void iface18method3();
+        void iface18method4();
+        void iface18method5();
+        void iface18method6();
+        void iface18method7();
+        void iface18method8();
+        void iface18method9();
+    }
+
+    public interface Iface19 extends Iface18 {
+        void iface19method0();
+        void iface19method1();
+        void iface19method2();
+        void iface19method3();
+        void iface19method4();
+        void iface19method5();
+        void iface19method6();
+        void iface19method7();
+        void iface19method8();
+        void iface19method9();
+    }
+
+    public interface Iface20 extends Iface19 {
+        void iface20method0();
+        void iface20method1();
+        void iface20method2();
+        void iface20method3();
+        void iface20method4();
+        void iface20method5();
+        void iface20method6();
+        void iface20method7();
+        void iface20method8();
+        void iface20method9();
+    }
+
+    public interface Iface21 extends Iface20 {
+        void iface21method0();
+        void iface21method1();
+        void iface21method2();
+        void iface21method3();
+        void iface21method4();
+        void iface21method5();
+        void iface21method6();
+        void iface21method7();
+        void iface21method8();
+        void iface21method9();
+    }
+
+    public interface Iface22 extends Iface21 {
+        void iface22method0();
+        void iface22method1();
+        void iface22method2();
+        void iface22method3();
+        void iface22method4();
+        void iface22method5();
+        void iface22method6();
+        void iface22method7();
+        void iface22method8();
+        void iface22method9();
+    }
+
+    public interface Iface23 extends Iface22 {
+        void iface23method0();
+        void iface23method1();
+        void iface23method2();
+        void iface23method3();
+        void iface23method4();
+        void iface23method5();
+        void iface23method6();
+        void iface23method7();
+        void iface23method8();
+        void iface23method9();
+    }
+
+    public interface Iface24 extends Iface23 {
+        void iface24method0();
+        void iface24method1();
+        void iface24method2();
+        void iface24method3();
+        void iface24method4();
+        void iface24method5();
+        void iface24method6();
+        void iface24method7();
+        void iface24method8();
+        void iface24method9();
+    }
+
+    public interface Iface25 extends Iface24 {
+        void iface25method0();
+        void iface25method1();
+        void iface25method2();
+        void iface25method3();
+        void iface25method4();
+        void iface25method5();
+        void iface25method6();
+        void iface25method7();
+        void iface25method8();
+        void iface25method9();
+    }
+
+    public interface Iface26 extends Iface25 {
+        void iface26method0();
+        void iface26method1();
+        void iface26method2();
+        void iface26method3();
+        void iface26method4();
+        void iface26method5();
+        void iface26method6();
+        void iface26method7();
+        void iface26method8();
+        void iface26method9();
+    }
+
+    public interface Iface27 extends Iface26 {
+        void iface27method0();
+        void iface27method1();
+        void iface27method2();
+        void iface27method3();
+        void iface27method4();
+        void iface27method5();
+        void iface27method6();
+        void iface27method7();
+        void iface27method8();
+        void iface27method9();
+    }
+
+    public interface Iface28 extends Iface27 {
+        void iface28method0();
+        void iface28method1();
+        void iface28method2();
+        void iface28method3();
+        void iface28method4();
+        void iface28method5();
+        void iface28method6();
+        void iface28method7();
+        void iface28method8();
+        void iface28method9();
+    }
+
+    public interface Iface29 extends Iface28 {
+        void iface29method0();
+        void iface29method1();
+        void iface29method2();
+        void iface29method3();
+        void iface29method4();
+        void iface29method5();
+        void iface29method6();
+        void iface29method7();
+        void iface29method8();
+        void iface29method9();
+    }
+
+    public interface Iface30 extends Iface29 {
+        void iface30method0();
+        void iface30method1();
+        void iface30method2();
+        void iface30method3();
+        void iface30method4();
+        void iface30method5();
+        void iface30method6();
+        void iface30method7();
+        void iface30method8();
+        void iface30method9();
+    }
+
+    public interface Iface31 extends Iface30 {
+        void iface31method0();
+        void iface31method1();
+        void iface31method2();
+        void iface31method3();
+        void iface31method4();
+        void iface31method5();
+        void iface31method6();
+        void iface31method7();
+        void iface31method8();
+        void iface31method9();
+    }
+
+    public interface Iface32 extends Iface31 {
+        void iface32method0();
+        void iface32method1();
+        void iface32method2();
+        void iface32method3();
+        void iface32method4();
+        void iface32method5();
+        void iface32method6();
+        void iface32method7();
+        void iface32method8();
+        void iface32method9();
+    }
+
+    public interface Iface33 extends Iface32 {
+        void iface33method0();
+        void iface33method1();
+        void iface33method2();
+        void iface33method3();
+        void iface33method4();
+        void iface33method5();
+        void iface33method6();
+        void iface33method7();
+        void iface33method8();
+        void iface33method9();
+    }
+
+    public interface Iface34 extends Iface33 {
+        void iface34method0();
+        void iface34method1();
+        void iface34method2();
+        void iface34method3();
+        void iface34method4();
+        void iface34method5();
+        void iface34method6();
+        void iface34method7();
+        void iface34method8();
+        void iface34method9();
+    }
+
+    public interface Iface35 extends Iface34 {
+        void iface35method0();
+        void iface35method1();
+        void iface35method2();
+        void iface35method3();
+        void iface35method4();
+        void iface35method5();
+        void iface35method6();
+        void iface35method7();
+        void iface35method8();
+        void iface35method9();
+    }
+
+    public interface Iface36 extends Iface35 {
+        void iface36method0();
+        void iface36method1();
+        void iface36method2();
+        void iface36method3();
+        void iface36method4();
+        void iface36method5();
+        void iface36method6();
+        void iface36method7();
+        void iface36method8();
+        void iface36method9();
+    }
+
+    public interface Iface37 extends Iface36 {
+        void iface37method0();
+        void iface37method1();
+        void iface37method2();
+        void iface37method3();
+        void iface37method4();
+        void iface37method5();
+        void iface37method6();
+        void iface37method7();
+        void iface37method8();
+        void iface37method9();
+    }
+
+    public interface Iface38 extends Iface37 {
+        void iface38method0();
+        void iface38method1();
+        void iface38method2();
+        void iface38method3();
+        void iface38method4();
+        void iface38method5();
+        void iface38method6();
+        void iface38method7();
+        void iface38method8();
+        void iface38method9();
+    }
+
+    public interface Iface39 extends Iface38 {
+        void iface39method0();
+        void iface39method1();
+        void iface39method2();
+        void iface39method3();
+        void iface39method4();
+        void iface39method5();
+        void iface39method6();
+        void iface39method7();
+        void iface39method8();
+        void iface39method9();
+    }
+
+    public interface Iface40 extends Iface39 {
+        void iface40method0();
+        void iface40method1();
+        void iface40method2();
+        void iface40method3();
+        void iface40method4();
+        void iface40method5();
+        void iface40method6();
+        void iface40method7();
+        void iface40method8();
+        void iface40method9();
+    }
+
+    public interface Iface41 extends Iface40 {
+        void iface41method0();
+        void iface41method1();
+        void iface41method2();
+        void iface41method3();
+        void iface41method4();
+        void iface41method5();
+        void iface41method6();
+        void iface41method7();
+        void iface41method8();
+        void iface41method9();
+    }
+
+    public interface Iface42 extends Iface41 {
+        void iface42method0();
+        void iface42method1();
+        void iface42method2();
+        void iface42method3();
+        void iface42method4();
+        void iface42method5();
+        void iface42method6();
+        void iface42method7();
+        void iface42method8();
+        void iface42method9();
+    }
+
+    public interface Iface43 extends Iface42 {
+        void iface43method0();
+        void iface43method1();
+        void iface43method2();
+        void iface43method3();
+        void iface43method4();
+        void iface43method5();
+        void iface43method6();
+        void iface43method7();
+        void iface43method8();
+        void iface43method9();
+    }
+
+    public interface Iface44 extends Iface43 {
+        void iface44method0();
+        void iface44method1();
+        void iface44method2();
+        void iface44method3();
+        void iface44method4();
+        void iface44method5();
+        void iface44method6();
+        void iface44method7();
+        void iface44method8();
+        void iface44method9();
+    }
+
+    public interface Iface45 extends Iface44 {
+        void iface45method0();
+        void iface45method1();
+        void iface45method2();
+        void iface45method3();
+        void iface45method4();
+        void iface45method5();
+        void iface45method6();
+        void iface45method7();
+        void iface45method8();
+        void iface45method9();
+    }
+
+    public interface Iface46 extends Iface45 {
+        void iface46method0();
+        void iface46method1();
+        void iface46method2();
+        void iface46method3();
+        void iface46method4();
+        void iface46method5();
+        void iface46method6();
+        void iface46method7();
+        void iface46method8();
+        void iface46method9();
+    }
+
+    public interface Iface47 extends Iface46 {
+        void iface47method0();
+        void iface47method1();
+        void iface47method2();
+        void iface47method3();
+        void iface47method4();
+        void iface47method5();
+        void iface47method6();
+        void iface47method7();
+        void iface47method8();
+        void iface47method9();
+    }
+
+    public interface Iface48 extends Iface47 {
+        void iface48method0();
+        void iface48method1();
+        void iface48method2();
+        void iface48method3();
+        void iface48method4();
+        void iface48method5();
+        void iface48method6();
+        void iface48method7();
+        void iface48method8();
+        void iface48method9();
+    }
+
+    public interface Iface49 extends Iface48 {
+        void iface49method0();
+        void iface49method1();
+        void iface49method2();
+        void iface49method3();
+        void iface49method4();
+        void iface49method5();
+        void iface49method6();
+        void iface49method7();
+        void iface49method8();
+        void iface49method9();
+    }
+
+    public interface Iface50 extends Iface49 {
+        void iface50method0();
+        void iface50method1();
+        void iface50method2();
+        void iface50method3();
+        void iface50method4();
+        void iface50method5();
+        void iface50method6();
+        void iface50method7();
+        void iface50method8();
+        void iface50method9();
+    }
+
+    public interface Iface51 extends Iface50 {
+        void iface51method0();
+        void iface51method1();
+        void iface51method2();
+        void iface51method3();
+        void iface51method4();
+        void iface51method5();
+        void iface51method6();
+        void iface51method7();
+        void iface51method8();
+        void iface51method9();
+    }
+
+    public interface Iface52 extends Iface51 {
+        void iface52method0();
+        void iface52method1();
+        void iface52method2();
+        void iface52method3();
+        void iface52method4();
+        void iface52method5();
+        void iface52method6();
+        void iface52method7();
+        void iface52method8();
+        void iface52method9();
+    }
+
+    public interface Iface53 extends Iface52 {
+        void iface53method0();
+        void iface53method1();
+        void iface53method2();
+        void iface53method3();
+        void iface53method4();
+        void iface53method5();
+        void iface53method6();
+        void iface53method7();
+        void iface53method8();
+        void iface53method9();
+    }
+
+    public interface Iface54 extends Iface53 {
+        void iface54method0();
+        void iface54method1();
+        void iface54method2();
+        void iface54method3();
+        void iface54method4();
+        void iface54method5();
+        void iface54method6();
+        void iface54method7();
+        void iface54method8();
+        void iface54method9();
+    }
+
+    public interface Iface55 extends Iface54 {
+        void iface55method0();
+        void iface55method1();
+        void iface55method2();
+        void iface55method3();
+        void iface55method4();
+        void iface55method5();
+        void iface55method6();
+        void iface55method7();
+        void iface55method8();
+        void iface55method9();
+    }
+
+    public interface Iface56 extends Iface55 {
+        void iface56method0();
+        void iface56method1();
+        void iface56method2();
+        void iface56method3();
+        void iface56method4();
+        void iface56method5();
+        void iface56method6();
+        void iface56method7();
+        void iface56method8();
+        void iface56method9();
+    }
+
+    public interface Iface57 extends Iface56 {
+        void iface57method0();
+        void iface57method1();
+        void iface57method2();
+        void iface57method3();
+        void iface57method4();
+        void iface57method5();
+        void iface57method6();
+        void iface57method7();
+        void iface57method8();
+        void iface57method9();
+    }
+
+    public interface Iface58 extends Iface57 {
+        void iface58method0();
+        void iface58method1();
+        void iface58method2();
+        void iface58method3();
+        void iface58method4();
+        void iface58method5();
+        void iface58method6();
+        void iface58method7();
+        void iface58method8();
+        void iface58method9();
+    }
+
+    public interface Iface59 extends Iface58 {
+        void iface59method0();
+        void iface59method1();
+        void iface59method2();
+        void iface59method3();
+        void iface59method4();
+        void iface59method5();
+        void iface59method6();
+        void iface59method7();
+        void iface59method8();
+        void iface59method9();
+    }
+
+    public interface Iface60 extends Iface59 {
+        void iface60method0();
+        void iface60method1();
+        void iface60method2();
+        void iface60method3();
+        void iface60method4();
+        void iface60method5();
+        void iface60method6();
+        void iface60method7();
+        void iface60method8();
+        void iface60method9();
+    }
+
+    public interface Iface61 extends Iface60 {
+        void iface61method0();
+        void iface61method1();
+        void iface61method2();
+        void iface61method3();
+        void iface61method4();
+        void iface61method5();
+        void iface61method6();
+        void iface61method7();
+        void iface61method8();
+        void iface61method9();
+    }
+
+    public interface Iface62 extends Iface61 {
+        void iface62method0();
+        void iface62method1();
+        void iface62method2();
+        void iface62method3();
+        void iface62method4();
+        void iface62method5();
+        void iface62method6();
+        void iface62method7();
+        void iface62method8();
+        void iface62method9();
+    }
+
+    public interface Iface63 extends Iface62 {
+        void iface63method0();
+        void iface63method1();
+        void iface63method2();
+        void iface63method3();
+        void iface63method4();
+        void iface63method5();
+        void iface63method6();
+        void iface63method7();
+        void iface63method8();
+        void iface63method9();
+    }
+
+    public interface Iface64 extends Iface63 {
+        void iface64method0();
+        void iface64method1();
+        void iface64method2();
+        void iface64method3();
+        void iface64method4();
+        void iface64method5();
+        void iface64method6();
+        void iface64method7();
+        void iface64method8();
+        void iface64method9();
+    }
+
+    public interface Iface65 extends Iface64 {
+        void iface65method0();
+        void iface65method1();
+        void iface65method2();
+        void iface65method3();
+        void iface65method4();
+        void iface65method5();
+        void iface65method6();
+        void iface65method7();
+        void iface65method8();
+        void iface65method9();
+    }
+
+    public interface Iface66 extends Iface65 {
+        void iface66method0();
+        void iface66method1();
+        void iface66method2();
+        void iface66method3();
+        void iface66method4();
+        void iface66method5();
+        void iface66method6();
+        void iface66method7();
+        void iface66method8();
+        void iface66method9();
+    }
+
+    public interface Iface67 extends Iface66 {
+        void iface67method0();
+        void iface67method1();
+        void iface67method2();
+        void iface67method3();
+        void iface67method4();
+        void iface67method5();
+        void iface67method6();
+        void iface67method7();
+        void iface67method8();
+        void iface67method9();
+    }
+
+    public interface Iface68 extends Iface67 {
+        void iface68method0();
+        void iface68method1();
+        void iface68method2();
+        void iface68method3();
+        void iface68method4();
+        void iface68method5();
+        void iface68method6();
+        void iface68method7();
+        void iface68method8();
+        void iface68method9();
+    }
+
+    public interface Iface69 extends Iface68 {
+        void iface69method0();
+        void iface69method1();
+        void iface69method2();
+        void iface69method3();
+        void iface69method4();
+        void iface69method5();
+        void iface69method6();
+        void iface69method7();
+        void iface69method8();
+        void iface69method9();
+    }
+
+    public interface Iface70 extends Iface69 {
+        void iface70method0();
+        void iface70method1();
+        void iface70method2();
+        void iface70method3();
+        void iface70method4();
+        void iface70method5();
+        void iface70method6();
+        void iface70method7();
+        void iface70method8();
+        void iface70method9();
+    }
+
+    public interface Iface71 extends Iface70 {
+        void iface71method0();
+        void iface71method1();
+        void iface71method2();
+        void iface71method3();
+        void iface71method4();
+        void iface71method5();
+        void iface71method6();
+        void iface71method7();
+        void iface71method8();
+        void iface71method9();
+    }
+
+    public interface Iface72 extends Iface71 {
+        void iface72method0();
+        void iface72method1();
+        void iface72method2();
+        void iface72method3();
+        void iface72method4();
+        void iface72method5();
+        void iface72method6();
+        void iface72method7();
+        void iface72method8();
+        void iface72method9();
+    }
+
+    public interface Iface73 extends Iface72 {
+        void iface73method0();
+        void iface73method1();
+        void iface73method2();
+        void iface73method3();
+        void iface73method4();
+        void iface73method5();
+        void iface73method6();
+        void iface73method7();
+        void iface73method8();
+        void iface73method9();
+    }
+
+    public interface Iface74 extends Iface73 {
+        void iface74method0();
+        void iface74method1();
+        void iface74method2();
+        void iface74method3();
+        void iface74method4();
+        void iface74method5();
+        void iface74method6();
+        void iface74method7();
+        void iface74method8();
+        void iface74method9();
+    }
+
+    public interface Iface75 extends Iface74 {
+        void iface75method0();
+        void iface75method1();
+        void iface75method2();
+        void iface75method3();
+        void iface75method4();
+        void iface75method5();
+        void iface75method6();
+        void iface75method7();
+        void iface75method8();
+        void iface75method9();
+    }
+
+    public interface Iface76 extends Iface75 {
+        void iface76method0();
+        void iface76method1();
+        void iface76method2();
+        void iface76method3();
+        void iface76method4();
+        void iface76method5();
+        void iface76method6();
+        void iface76method7();
+        void iface76method8();
+        void iface76method9();
+    }
+
+    public interface Iface77 extends Iface76 {
+        void iface77method0();
+        void iface77method1();
+        void iface77method2();
+        void iface77method3();
+        void iface77method4();
+        void iface77method5();
+        void iface77method6();
+        void iface77method7();
+        void iface77method8();
+        void iface77method9();
+    }
+
+    public interface Iface78 extends Iface77 {
+        void iface78method0();
+        void iface78method1();
+        void iface78method2();
+        void iface78method3();
+        void iface78method4();
+        void iface78method5();
+        void iface78method6();
+        void iface78method7();
+        void iface78method8();
+        void iface78method9();
+    }
+
+    public interface Iface79 extends Iface78 {
+        void iface79method0();
+        void iface79method1();
+        void iface79method2();
+        void iface79method3();
+        void iface79method4();
+        void iface79method5();
+        void iface79method6();
+        void iface79method7();
+        void iface79method8();
+        void iface79method9();
+    }
+
+    public interface Iface80 extends Iface79 {
+        void iface80method0();
+        void iface80method1();
+        void iface80method2();
+        void iface80method3();
+        void iface80method4();
+        void iface80method5();
+        void iface80method6();
+        void iface80method7();
+        void iface80method8();
+        void iface80method9();
+    }
+
+    public interface Iface81 extends Iface80 {
+        void iface81method0();
+        void iface81method1();
+        void iface81method2();
+        void iface81method3();
+        void iface81method4();
+        void iface81method5();
+        void iface81method6();
+        void iface81method7();
+        void iface81method8();
+        void iface81method9();
+    }
+
+    public interface Iface82 extends Iface81 {
+        void iface82method0();
+        void iface82method1();
+        void iface82method2();
+        void iface82method3();
+        void iface82method4();
+        void iface82method5();
+        void iface82method6();
+        void iface82method7();
+        void iface82method8();
+        void iface82method9();
+    }
+
+    public interface Iface83 extends Iface82 {
+        void iface83method0();
+        void iface83method1();
+        void iface83method2();
+        void iface83method3();
+        void iface83method4();
+        void iface83method5();
+        void iface83method6();
+        void iface83method7();
+        void iface83method8();
+        void iface83method9();
+    }
+
+    public interface Iface84 extends Iface83 {
+        void iface84method0();
+        void iface84method1();
+        void iface84method2();
+        void iface84method3();
+        void iface84method4();
+        void iface84method5();
+        void iface84method6();
+        void iface84method7();
+        void iface84method8();
+        void iface84method9();
+    }
+
+    public interface Iface85 extends Iface84 {
+        void iface85method0();
+        void iface85method1();
+        void iface85method2();
+        void iface85method3();
+        void iface85method4();
+        void iface85method5();
+        void iface85method6();
+        void iface85method7();
+        void iface85method8();
+        void iface85method9();
+    }
+
+    public interface Iface86 extends Iface85 {
+        void iface86method0();
+        void iface86method1();
+        void iface86method2();
+        void iface86method3();
+        void iface86method4();
+        void iface86method5();
+        void iface86method6();
+        void iface86method7();
+        void iface86method8();
+        void iface86method9();
+    }
+
+    public interface Iface87 extends Iface86 {
+        void iface87method0();
+        void iface87method1();
+        void iface87method2();
+        void iface87method3();
+        void iface87method4();
+        void iface87method5();
+        void iface87method6();
+        void iface87method7();
+        void iface87method8();
+        void iface87method9();
+    }
+
+    public interface Iface88 extends Iface87 {
+        void iface88method0();
+        void iface88method1();
+        void iface88method2();
+        void iface88method3();
+        void iface88method4();
+        void iface88method5();
+        void iface88method6();
+        void iface88method7();
+        void iface88method8();
+        void iface88method9();
+    }
+
+    public interface Iface89 extends Iface88 {
+        void iface89method0();
+        void iface89method1();
+        void iface89method2();
+        void iface89method3();
+        void iface89method4();
+        void iface89method5();
+        void iface89method6();
+        void iface89method7();
+        void iface89method8();
+        void iface89method9();
+    }
+
+    public interface Iface90 extends Iface89 {
+        void iface90method0();
+        void iface90method1();
+        void iface90method2();
+        void iface90method3();
+        void iface90method4();
+        void iface90method5();
+        void iface90method6();
+        void iface90method7();
+        void iface90method8();
+        void iface90method9();
+    }
+
+    public interface Iface91 extends Iface90 {
+        void iface91method0();
+        void iface91method1();
+        void iface91method2();
+        void iface91method3();
+        void iface91method4();
+        void iface91method5();
+        void iface91method6();
+        void iface91method7();
+        void iface91method8();
+        void iface91method9();
+    }
+
+    public interface Iface92 extends Iface91 {
+        void iface92method0();
+        void iface92method1();
+        void iface92method2();
+        void iface92method3();
+        void iface92method4();
+        void iface92method5();
+        void iface92method6();
+        void iface92method7();
+        void iface92method8();
+        void iface92method9();
+    }
+
+    public interface Iface93 extends Iface92 {
+        void iface93method0();
+        void iface93method1();
+        void iface93method2();
+        void iface93method3();
+        void iface93method4();
+        void iface93method5();
+        void iface93method6();
+        void iface93method7();
+        void iface93method8();
+        void iface93method9();
+    }
+
+    public interface Iface94 extends Iface93 {
+        void iface94method0();
+        void iface94method1();
+        void iface94method2();
+        void iface94method3();
+        void iface94method4();
+        void iface94method5();
+        void iface94method6();
+        void iface94method7();
+        void iface94method8();
+        void iface94method9();
+    }
+
+    public interface Iface95 extends Iface94 {
+        void iface95method0();
+        void iface95method1();
+        void iface95method2();
+        void iface95method3();
+        void iface95method4();
+        void iface95method5();
+        void iface95method6();
+        void iface95method7();
+        void iface95method8();
+        void iface95method9();
+    }
+
+    public interface Iface96 extends Iface95 {
+        void iface96method0();
+        void iface96method1();
+        void iface96method2();
+        void iface96method3();
+        void iface96method4();
+        void iface96method5();
+        void iface96method6();
+        void iface96method7();
+        void iface96method8();
+        void iface96method9();
+    }
+
+    public interface Iface97 extends Iface96 {
+        void iface97method0();
+        void iface97method1();
+        void iface97method2();
+        void iface97method3();
+        void iface97method4();
+        void iface97method5();
+        void iface97method6();
+        void iface97method7();
+        void iface97method8();
+        void iface97method9();
+    }
+
+    public interface Iface98 extends Iface97 {
+        void iface98method0();
+        void iface98method1();
+        void iface98method2();
+        void iface98method3();
+        void iface98method4();
+        void iface98method5();
+        void iface98method6();
+        void iface98method7();
+        void iface98method8();
+        void iface98method9();
+    }
+
+    public interface Iface99 extends Iface98 {
+        void iface99method0();
+        void iface99method1();
+        void iface99method2();
+        void iface99method3();
+        void iface99method4();
+        void iface99method5();
+        void iface99method6();
+        void iface99method7();
+        void iface99method8();
+        void iface99method9();
+    }
+}

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/ByteBuddyInstrumentation.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/ByteBuddyInstrumentation.java
@@ -202,6 +202,10 @@ final class ByteBuddyInstrumentation {
         checkState(interfaceClass.equals(discoveredInterfaces[0]), "Expected the provided interface first");
         for (int i = 1; i < discoveredInterfaces.length; i++) {
             Class<?> additionalInterface = discoveredInterfaces[i];
+            if (assignableFromAny(additionalInterface, discoveredInterfaces)) {
+                // No need to retain interfaces already provided by the requested interface class
+                continue;
+            }
             if (isAccessibleFrom(classLoader, additionalInterface)) {
                 additionalInterfaces.add(additionalInterface);
             } else {
@@ -211,6 +215,16 @@ final class ByteBuddyInstrumentation {
             }
         }
         return additionalInterfaces.build();
+    }
+
+    private static boolean assignableFromAny(Class<?> target, Class<?>[] allInterfaces) {
+        for (Class<?> toCheck : allInterfaces) {
+            // allInterfaces always contains target
+            if (toCheck != target && target.isAssignableFrom(toCheck)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static ClassLoader getClassLoader(Class<?> clazz) {

--- a/tritium-proxy/src/main/java/com/palantir/tritium/proxy/Proxies.java
+++ b/tritium-proxy/src/main/java/com/palantir/tritium/proxy/Proxies.java
@@ -19,8 +19,6 @@ package com.palantir.tritium.proxy;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -58,39 +56,24 @@ public final class Proxies {
      *
      * @param iface primary interface class
      * @param delegateClass delegate class
-     * @param additionalInterfaces additional interfaces
      * @return the set of interfaces for the specified classes
      * @throws IllegalArgumentException if the specified interface class is not an interface
      */
     static Class<?>[] interfaces(Class<?> iface,
-                                 Class<?> delegateClass,
-                                 Collection<Class<?>> additionalInterfaces) {
+                                 Class<?> delegateClass) {
         checkIsInterface(iface);
-        Objects.requireNonNull(additionalInterfaces, "additionalInterfaces");
         Objects.requireNonNull(delegateClass, "delegateClass");
 
         Set<Class<?>> interfaces = new LinkedHashSet<>();
         interfaces.add(iface);
-        interfaces.addAll(additionalInterfaces);
         if (delegateClass.isInterface()) {
             interfaces.add(delegateClass);
+        } else {
+            interfaces.addAll(Arrays.asList(delegateClass.getInterfaces()));
         }
-        interfaces.addAll(Arrays.asList(delegateClass.getInterfaces()));
 
         checkAreAllInterfaces(interfaces);
         return interfaces.toArray(new Class<?>[0]);
-    }
-
-    /**
-     * Determine the superset of interfaces for the specified arguments.
-     *
-     * @param iface primary interface class
-     * @param delegateClass delegate class
-     * @return the set of interfaces for the specified classes
-     * @throws IllegalArgumentException if the specified interface class is not an interface
-     */
-    static Class<?>[] interfaces(Class<?> iface, Class<?> delegateClass) {
-        return interfaces(iface, delegateClass, Collections.emptySet());
     }
 
     static void checkIsInterface(Class<?> iface) {

--- a/tritium-proxy/src/test/java/com/palantir/tritium/proxy/ProxiesTest.java
+++ b/tritium-proxy/src/test/java/com/palantir/tritium/proxy/ProxiesTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.tritium.test.MoreSpecificReturn;
 import com.palantir.tritium.test.TestImplementation;
@@ -39,12 +38,6 @@ final class ProxiesTest {
         TestInterface proxy = Proxies.newProxy(TestInterface.class, implementation,
                 (delegate, method, args) -> method.invoke(implementation, args) + ", world");
         assertThat(proxy.test()).isEqualTo("hello, world");
-    }
-
-    @Test
-    void testInterfacesAdditionalInterfaces() {
-        Class<?>[] interfaces = Proxies.interfaces(TestInterface.class, Runnable.class, ImmutableList.of(List.class));
-        assertThat(interfaces).containsExactly(TestInterface.class, List.class, Runnable.class);
     }
 
     @Test


### PR DESCRIPTION
## After this PR
==COMMIT_MSG==
Deduplicate interfaces for byte-buddy instrumentation

This leads to a sizable performance improvement creating
instrumented objects in scenarios where interfaces are declared
multiple times. This is particularly common when dynamic proxies
are instrumented, as many additional interfaces are discovered.
==COMMIT_MSG==

### Before:
```
Benchmark
(mode)  Mode  Cnt      Score   Error  Units
InstrumentationCreationBenchmark.createInstrumentationLargeComplexInterface
BYTE_BUDDY    ss       12328.392          ms/op
InstrumentationCreationBenchmark.createInstrumentationLargeComplexInterface
DYNAMIC_PROXY    ss         149.691          ms/op
InstrumentationCreationBenchmark.createInstrumentationLargeInterface
BYTE_BUDDY    ss        1294.853          ms/op
InstrumentationCreationBenchmark.createInstrumentationLargeInterface
DYNAMIC_PROXY    ss         106.384          ms/op
InstrumentationCreationBenchmark.createInstrumentationSimpleInterface
BYTE_BUDDY    ss         255.033          ms/op
InstrumentationCreationBenchmark.createInstrumentationSimpleInterface
DYNAMIC_PROXY    ss          59.112          ms/op
```

### After:
`createInstrumentationLargeComplexInterface` saw a 10x improvement from 12 seconds to 1.2 seconds. This is a particularly nasty case which is unlikely in real scenarios, but it demonstrates the observed failure mode.
```
Benchmark
(mode)  Mode  Cnt     Score   Error  Units
InstrumentationCreationBenchmark.createInstrumentationLargeComplexInterface
BYTE_BUDDY    ss       1297.733          ms/op
InstrumentationCreationBenchmark.createInstrumentationLargeComplexInterface
DYNAMIC_PROXY    ss        121.315          ms/op
InstrumentationCreationBenchmark.createInstrumentationLargeInterface
BYTE_BUDDY    ss       1220.317          ms/op
InstrumentationCreationBenchmark.createInstrumentationLargeInterface
DYNAMIC_PROXY    ss        104.200          ms/op
InstrumentationCreationBenchmark.createInstrumentationSimpleInterface
BYTE_BUDDY    ss        259.670          ms/op
InstrumentationCreationBenchmark.createInstrumentationSimpleInterface
DYNAMIC_PROXY    ss         60.905          ms/op
```
