### PR TITLE
Fix class initialization race

### DIFF
--- a/changelog/@unreleased/pr-551.v2.yml
+++ b/changelog/@unreleased/pr-551.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix class initialization race with logging frameworks that consume
+    the singleton registry
+  links:
+  - https://github.com/palantir/tritium/pull/551


### PR DESCRIPTION
The tritium singleton registry is used by logger initialization,
which can result in the following failure:

```
java.lang.ExceptionInInitializerError
	at com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries.<clinit>(SharedTaggedMetricRegistries.java:34)
	at com.palantir.sls.logging.log4j.service.InternalSlsAsyncQueueFullPolicy.<init>(InternalSlsAsyncQueueFullPolicy.java:34)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at org.apache.logging.log4j.core.async.AsyncQueueFullPolicyFactory.createCustomRouter(AsyncQueueFullPolicyFactory.java:93)
	at org.apache.logging.log4j.core.async.AsyncQueueFullPolicyFactory.create(AsyncQueueFullPolicyFactory.java:77)
	at org.apache.logging.log4j.core.async.AsyncLoggerDisruptor.start(AsyncLoggerDisruptor.java:100)
	at org.apache.logging.log4j.core.async.AsyncLoggerContext.start(AsyncLoggerContext.java:75)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:153)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:45)
	at org.apache.logging.log4j.LogManager.getContext(LogManager.java:194)
	at org.apache.logging.log4j.spi.AbstractLoggerAdapter.getContext(AbstractLoggerAdapter.java:138)
	at org.apache.logging.slf4j.Log4jLoggerFactory.getContext(Log4jLoggerFactory.java:45)
	at org.apache.logging.log4j.spi.AbstractLoggerAdapter.getLogger(AbstractLoggerAdapter.java:48)
	at org.apache.logging.slf4j.Log4jLoggerFactory.getLogger(Log4jLoggerFactory.java:30)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:358)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:383)
	at com.palantir.tokens.auth.BearerToken.<clinit>(BearerToken.java:37)
	at com.palantir.tokens.auth.AuthHeader.valueOf(AuthHeader.java:37)
...
Caused by: com.palantir.logsafe.exceptions.SafeNullPointerException: TaggedMetricRegistry is required
	at com.palantir.logsafe.Preconditions.checkNotNull(Preconditions.java:207)
	at com.palantir.sls.logging.log4j.ServiceLogLayout$Builder.taggedMetrics(ServiceLogLayout.java:89)
	at com.palantir.sls.logging.log4j.service.Log4jServiceLogging.getServiceLogLayout(Log4jServiceLogging.java:190)
	at com.palantir.sls.logging.log4j.service.Log4jServiceLogging.createConfiguration(Log4jServiceLogging.java:128)
	at com.palantir.sls.logging.log4j.service.InternalSlsServiceConfigurationFactory.buildDefaultConfiguration(InternalSlsServiceConfigurationFactory.java:35)
	at com.palantir.sls.logging.log4j.service.InternalSlsServiceConfigurationFactory.getConfiguration(InternalSlsServiceConfigurationFactory.java:31)
	at org.apache.logging.log4j.core.config.ConfigurationFactory$Factory.getConfiguration(ConfigurationFactory.java:392)
	at org.apache.logging.log4j.core.config.ConfigurationFactory.getConfiguration(ConfigurationFactory.java:293)
	at org.apache.logging.log4j.core.LoggerContext.reconfigure(LoggerContext.java:647)
	at org.apache.logging.log4j.core.LoggerContext.reconfigure(LoggerContext.java:668)
	at org.apache.logging.log4j.core.LoggerContext.start(LoggerContext.java:253)
	at org.apache.logging.log4j.core.async.AsyncLoggerContext.start(AsyncLoggerContext.java:76)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:153)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:45)
	at org.apache.logging.log4j.LogManager.getContext(LogManager.java:194)
	at org.apache.logging.log4j.spi.AbstractLoggerAdapter.getContext(AbstractLoggerAdapter.java:138)
	at org.apache.logging.slf4j.Log4jLoggerFactory.getContext(Log4jLoggerFactory.java:45)
	at org.apache.logging.log4j.spi.AbstractLoggerAdapter.getLogger(AbstractLoggerAdapter.java:48)
	at org.apache.logging.slf4j.Log4jLoggerFactory.getLogger(Log4jLoggerFactory.java:30)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:358)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:383)
	at com.palantir.tritium.metrics.registry.AbstractTaggedMetricRegistry.<clinit>(AbstractTaggedMetricRegistry.java:44)
	... 62 more
```

## After this PR
==COMMIT_MSG==
Fix class initialization race with logging frameworks that consume the singleton registry
==COMMIT_MSG==

