### PR TITLE
Stop relying on codahale's JvmAttributeGaugeSet, which was renamed in metrics 4.x

### DIFF
--- a/changelog/@unreleased/pr-592.v2.yml
+++ b/changelog/@unreleased/pr-592.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: tritium-metrics-jvm no longer throws a `NoClassDefFoundError` for `JvmAttributeGaugeSet`
+    when used with codahale metrics 4.x (io.dropwizard.metrics:metrics-jvm).
+  links:
+  - https://github.com/palantir/tritium/pull/592


### PR DESCRIPTION
## Before this PR

If a repo tries to upgrade to Dropwizard 2.X, they get an error like the following (this just happened to me):

```
java.lang.NoClassDefFoundError: com/codahale/metrics/JvmAttributeGaugeSet
	at com.palantir.tritium.metrics.jvm.JvmMetrics.registerAttributes(JvmMetrics.java:67)
	at com.palantir.tritium.metrics.jvm.JvmMetrics.register(JvmMetrics.java:56)
	at com.palantir.witchcraft.metrics.Metrics.registerJvmMetrics(Metrics.java:101)
	at com.palantir.witchcraft.metrics.Metrics.registerDefaultMetrics(Metrics.java:92)
	at com.palantir.witchcraft.metrics.Metrics.createTaggedMetricRegistry(Metrics.java:60)
	at com.palantir.witchcraft.Witchcraft$Builder.<init>(Witchcraft.java:619)
```

It seems like 31 repos internally have just re-declared their own shim to work around this https://internal-github/search?q=JvmAttributeGaugeSet&type=Code, but this seems pretty gross, especially as we are only relying on one method from this class!

## After this PR
==COMMIT_MSG==
tritium-metrics-jvm no longer throws a `NoClassDefFoundError` for `JvmAttributeGaugeSet` when used with codahale metrics 4.x (io.dropwizard.metrics:metrics-jvm).
==COMMIT_MSG==

We're gonna need to be officially compatible with 4.x eventually, because spark has upgraded: https://github.com/apache/spark/commit/19b8c714369802d9057a98076edea94dd0cc3e9c#diff-fcea1e3079499c3558e3cc3a4d038401R182, but this PR makes no guarantees of full compatibility (as we're still testing with only 3.x)

## Possible downsides?
- i literally don't think it's possible to cock this up

