### PR TITLE
Use jcenter repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,8 @@
 buildscript {
     repositories {
-        mavenCentral()
-        maven {
-            url 'https://dl.bintray.com/palantir/releases/'
-        }
-        maven {
-            url 'https://plugins.gradle.org/m2/'
-        }
+        jcenter()
+        gradlePluginPortal()
+        maven { url  'https://palantir.bintray.com/releases'}
     }
 
     dependencies {
@@ -55,13 +51,10 @@ allprojects {
     }
 
     repositories {
-        mavenCentral()
-        maven {
-            url 'https://dl.bintray.com/palantir/releases/'
-        }
-        maven {
-            url 'https://dl.bintray.com/marshallpierce/maven/'
-        }
+        jcenter()
+        gradlePluginPortal()
+        maven { url 'https://dl.bintray.com/palantir/releases/' }
+        maven { url 'https://dl.bintray.com/marshallpierce/maven/' }
     }
 
     dependencies {


### PR DESCRIPTION
## Before this PR
Builds were failing to find mockito-errorprone dependency in maven central, but they're published in jcenter bintray.

```
FAILURE: Build completed with 3 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':tritium-api:compileJava'.
> Could not resolve all files for configuration ':tritium-api:annotationProcessor'.
   > Could not find org.mockito:mockito-errorprone:3.3.1.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/org/mockito/mockito-errorprone/3.3.1/mockito-errorprone-3.3.1.pom
       - https://dl.bintray.com/palantir/releases/org/mockito/mockito-errorprone/3.3.1/mockito-errorprone-3.3.1.pom
       - https://dl.bintray.com/marshallpierce/maven/org/mockito/mockito-errorprone/3.3.1/mockito-errorprone-3.3.1.pom
     Required by:
         project :tritium-api > com.palantir.baseline:baseline-error-prone:3.7.1
```

## After this PR
==COMMIT_MSG==
Use jcenter repository for gradle plugins and dependencies.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

