### PR TITLE
Implement equals and hashcode on instrumented TLS components

### DIFF
--- a/changelog/@unreleased/pr-672.v2.yml
+++ b/changelog/@unreleased/pr-672.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implement equals and hashcode on instrumented TLS components
+  links:
+  - https://github.com/palantir/tritium/pull/672

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslContext.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslContext.java
@@ -18,6 +18,7 @@ package com.palantir.tritium.metrics;
 
 import java.security.KeyManagementException;
 import java.security.SecureRandom;
+import java.util.Objects;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLContextSpi;
@@ -42,6 +43,23 @@ final class InstrumentedSslContext extends SSLContext {
     @Override
     public String toString() {
         return "InstrumentedSSLContext{delegate=" + context + ", name=" + name + '}';
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        InstrumentedSslContext that = (InstrumentedSslContext) other;
+        return context.equals(that.context) && name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(context, name);
     }
 
     private static final class InstrumentedSslContextSpi extends SSLContextSpi {

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslEngine.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslEngine.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import javax.annotation.Nullable;
@@ -275,6 +276,23 @@ class InstrumentedSslEngine extends SSLEngine {
     @Override
     public String toString() {
         return getClass().getSimpleName() + "{name=" + name + ", delegate=" + engine + '}';
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other instanceof InstrumentedSslEngine) {
+            InstrumentedSslEngine that = (InstrumentedSslEngine) other;
+            return engine.equals(that.engine) && name.equals(that.name);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(engine, name);
     }
 
     private SSLEngineResult check(SSLEngineResult result) {

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslServerSocketFactory.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslServerSocketFactory.java
@@ -23,6 +23,7 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.channels.ServerSocketChannel;
+import java.util.Objects;
 import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
@@ -31,11 +32,13 @@ import javax.net.ssl.SSLSocket;
 
 final class InstrumentedSslServerSocketFactory extends SSLServerSocketFactory {
 
+    private final String name;
     private final SSLServerSocketFactory delegate;
     private final HandshakeCompletedListener listener;
 
     InstrumentedSslServerSocketFactory(SSLServerSocketFactory delegate, TlsMetrics metrics, String name) {
         this.delegate = delegate;
+        this.name = name;
         this.listener = InstrumentedSslSocketFactory.newHandshakeListener(metrics, name);
     }
 
@@ -72,6 +75,23 @@ final class InstrumentedSslServerSocketFactory extends SSLServerSocketFactory {
     @Override
     public String toString() {
         return "InstrumentedSSLServerSocketFactory{delegate=" + delegate + '}';
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        InstrumentedSslServerSocketFactory that = (InstrumentedSslServerSocketFactory) other;
+        return name.equals(that.name) && delegate.equals(that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, delegate);
     }
 
     private ServerSocket wrap(ServerSocket serverSocket) throws IOException {

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslSocketFactory.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslSocketFactory.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.util.Objects;
 import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -28,9 +29,11 @@ final class InstrumentedSslSocketFactory extends SSLSocketFactory {
 
     private final SSLSocketFactory delegate;
     private final HandshakeCompletedListener listener;
+    private final String name;
 
     InstrumentedSslSocketFactory(SSLSocketFactory delegate, TlsMetrics metrics, String name) {
         this.delegate = delegate;
+        this.name = name;
         this.listener = newHandshakeListener(metrics, name);
     }
 
@@ -82,7 +85,24 @@ final class InstrumentedSslSocketFactory extends SSLSocketFactory {
 
     @Override
     public String toString() {
-        return "InstrumentedSSLSocketFactory{delegate=" + delegate + '}';
+        return "InstrumentedSSLSocketFactory{delegate=" + delegate + ", name=" + name + '}';
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        InstrumentedSslSocketFactory that = (InstrumentedSslSocketFactory) other;
+        return delegate.equals(that.delegate) && name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(delegate, name);
     }
 
     private Socket wrap(Socket socket) {

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/InstrumentedSslContextTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/InstrumentedSslContextTest.java
@@ -207,6 +207,30 @@ final class InstrumentedSslContextTest {
         assertThat(MetricRegistries.unwrap(engine)).isNotNull().isNotInstanceOf(InstrumentedSslEngine.class);
     }
 
+    @Test
+    void testSslContext_equality() throws IOException, GeneralSecurityException {
+        TaggedMetricRegistry metrics = new DefaultTaggedMetricRegistry();
+        SSLContext context = newClientContext();
+        SSLContext instrumentedFirst = MetricRegistries.instrument(metrics, context, "factory");
+        SSLContext instrumentedSecond = MetricRegistries.instrument(metrics, context, "factory");
+        SSLContext instrumentedThirdDifferentName = MetricRegistries.instrument(metrics, context, "other");
+        assertThat(instrumentedFirst).isEqualTo(instrumentedSecond).isNotEqualTo(instrumentedThirdDifferentName);
+        assertThat(instrumentedFirst).hasSameHashCodeAs(instrumentedSecond);
+        assertThat(instrumentedFirst.hashCode()).isNotEqualTo(instrumentedThirdDifferentName.hashCode());
+    }
+
+    @Test
+    void testSslSocketFactory_equality() throws IOException, GeneralSecurityException {
+        TaggedMetricRegistry metrics = new DefaultTaggedMetricRegistry();
+        SSLSocketFactory socketFactory = newClientContext().getSocketFactory();
+        SSLSocketFactory instrumentedFirst = MetricRegistries.instrument(metrics, socketFactory, "factory");
+        SSLSocketFactory instrumentedSecond = MetricRegistries.instrument(metrics, socketFactory, "factory");
+        SSLSocketFactory instrumentedThirdDifferentName = MetricRegistries.instrument(metrics, socketFactory, "other");
+        assertThat(instrumentedFirst).isEqualTo(instrumentedSecond).isNotEqualTo(instrumentedThirdDifferentName);
+        assertThat(instrumentedFirst).hasSameHashCodeAs(instrumentedSecond);
+        assertThat(instrumentedFirst.hashCode()).isNotEqualTo(instrumentedThirdDifferentName.hashCode());
+    }
+
     private static Closeable server(SSLContext context) {
         Undertow server = Undertow.builder()
                 .addHttpsListener(PORT, "0.0.0.0", context)


### PR DESCRIPTION
Some libraries pool connections with a check for SSLSocketFactory
equality. If we provide two connections from the same factory
wrapped with the same name in different places. While it's
safer to pool connections from a constant factory object, not
sharing a pool between client instances, we shouldn't
unexpectedly break this case.

## After this PR
==COMMIT_MSG==
Implement equals and hashcode on instrumented TLS components
==COMMIT_MSG==

