### PR TITLE
Warn registering Caffeine cache without recording stats

### DIFF
--- a/changelog/@unreleased/pr-689.v2.yml
+++ b/changelog/@unreleased/pr-689.v2.yml
@@ -1,0 +1,13 @@
+type: improvement
+improvement:
+  description: |-
+    When registering a Caffeine cache that does not have stats recording
+    enabled, log a warning and increment a "cache.stats.disabled" counter to
+    notify consumers of that their caches will not produce expected metrics.
+
+    Unfortunately Guava Caches do not currently expose a mechanism to
+    determine this, so this only applies to Caffeine caches (which should
+    generally be preferred over Guava caches anyway, see
+    <https://github.com/palantir/gradle-baseline/pull/317>).
+  links:
+  - https://github.com/palantir/tritium/pull/689

--- a/tritium-caffeine/build.gradle
+++ b/tritium-caffeine/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'io.dropwizard.metrics:metrics-core'
+    implementation 'org.slf4j:slf4j-api'
 
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.awaitility:awaitility'

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStats.java
@@ -22,6 +22,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
@@ -44,6 +45,9 @@ public final class CaffeineCacheStats {
     /**
      * Register specified cache with the given metric registry.
      *
+     * Callers should ensure that they have {@link Caffeine#recordStats() enabled stats recording}
+     * {@code Caffeine.newBuilder().recordStats()} otherwise there are no cache metrics to register.
+     *
      * @param registry metric registry
      * @param cache cache to instrument
      * @param name cache name
@@ -63,6 +67,9 @@ public final class CaffeineCacheStats {
 
     /**
      * Register specified cache with the given metric registry.
+     *
+     * Callers should ensure that they have {@link Caffeine#recordStats() enabled stats recording}
+     * {@code Caffeine.newBuilder().recordStats()} otherwise there are no cache metrics to register.
      *
      * @param registry metric registry
      * @param cache cache to instrument

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -33,6 +33,7 @@ import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
@@ -213,6 +214,9 @@ public final class MetricRegistries {
     /**
      * Register specified cache with the given metric registry.
      *
+     * Callers should ensure that they have {@link CacheBuilder#recordStats() enabled stats recording}
+     * {@code CacheBuilder.newBuilder().recordStats()} otherwise there are no cache metrics to register.
+     *
      * @param registry metric registry
      * @param cache cache to instrument
      * @param name cache name
@@ -239,6 +243,9 @@ public final class MetricRegistries {
 
     /**
      * Register specified cache with the given metric registry.
+     *
+     * Callers should ensure that they have {@link CacheBuilder#recordStats() enabled stats recording}
+     * {@code CacheBuilder.newBuilder().recordStats()} otherwise there are no cache metrics to register.
      *
      * @param registry metric registry
      * @param cache cache to instrument


### PR DESCRIPTION
## Before this PR
If a caller of `CaffeineCacheStats.registerCache` had does not enable stats recording on their Caffeine cache via `Caffeine.newBuilder().recordStats()`, the resulting cache metrics are always 0, which can be surprising.

## After this PR
==COMMIT_MSG==
When registering a Caffeine cache that does not have stats recording
enabled, log a warning and increment a "cache.stats.disabled" counter to
notify consumers of that their caches will not produce expected metrics.

Unfortunately Guava Caches do not currently expose a mechanism to
determine this, so this only applies to Caffeine caches (which should
generally be preferred over Guava caches anyway, see
<https://github.com/palantir/gradle-baseline/pull/317>).
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

