### PR TITLE
Implement a tagged instrumented ThreadFactory

### DIFF
--- a/changelog/@unreleased/pr-698.v2.yml
+++ b/changelog/@unreleased/pr-698.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implement a tagged instrumented ThreadFactory
+  links:
+  - https://github.com/palantir/tritium/pull/698

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -50,6 +50,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -343,6 +344,22 @@ public final class MetricRegistries {
         }
         return new TaggedMetricsExecutorService(
                 checkNotNull(delegate, "delegate"), ExecutorMetrics.of(registry), checkNotNull(name, "name"));
+    }
+
+    /**
+     * Returns an instrumented {@link ThreadFactory} that monitors the number of created, running, and terminated
+     * threads.
+     *
+     * @param registry tagged metric registry
+     * @param delegate Thread factory to instrument
+     * @param name Thread factory name
+     * @return instrumented thread factory
+     */
+    public static ThreadFactory instrument(TaggedMetricRegistry registry, ThreadFactory delegate, String name) {
+        return new TaggedMetricsThreadFactory(
+                checkNotNull(delegate, "ThreadFactory is required"),
+                ExecutorMetrics.of(registry),
+                checkNotNull(name, "Name is required"));
     }
 
     /**

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsThreadFactory.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsThreadFactory.java
@@ -1,0 +1,84 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
+import com.palantir.logsafe.Preconditions;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * An instrumented {@link ThreadFactory} based on the codahale {@link com.codahale.metrics.InstrumentedThreadFactory}.
+ */
+final class TaggedMetricsThreadFactory implements ThreadFactory {
+
+    private final ThreadFactory delegate;
+    private final Meter created;
+    private final Meter terminated;
+    private final Counter running;
+
+    TaggedMetricsThreadFactory(ThreadFactory delegate, ExecutorMetrics metrics, String name) {
+        this.delegate = Preconditions.checkNotNull(delegate, "ThreadFactory is required");
+        Preconditions.checkNotNull(name, "Name is required");
+        Preconditions.checkNotNull(metrics, "ExecutorMetrics is required");
+        this.created = metrics.threadsCreated(name);
+        this.terminated = metrics.threadsTerminated(name);
+        this.running = metrics.threadsRunning(name);
+    }
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+        Thread result = delegate.newThread(new InstrumentedTask(
+                Preconditions.checkNotNull(runnable, "Runnable is required"), running, terminated));
+        created.mark();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TaggedMetricsThreadFactory{delegate=" + delegate + '}';
+    }
+
+    private static final class InstrumentedTask implements Runnable {
+
+        private final Runnable delegate;
+        private final Meter terminated;
+        private final Counter running;
+
+        InstrumentedTask(Runnable delegate, Counter running, Meter terminated) {
+            this.delegate = delegate;
+            this.running = running;
+            this.terminated = terminated;
+        }
+
+        @Override
+        public void run() {
+            running.inc();
+            try {
+                delegate.run();
+            } finally {
+                running.dec();
+                terminated.mark();
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "InstrumentedTask{delegate=" + delegate + '}';
+        }
+    }
+}

--- a/tritium-metrics/src/main/metrics/metrics.yml
+++ b/tritium-metrics/src/main/metrics/metrics.yml
@@ -86,3 +86,16 @@ namespaces:
         type: histogram
         tags: [executor]
         docs: A histogram of the time it took to run a fixed-rate scheduled task as a percentage of the scheduled rate. Applies only to scheduled executors.
+      # ThreadFactory metrics
+      threads.created:
+        type: meter
+        tags: [executor]
+        docs: Rate that new threads are created for this executor.
+      threads.terminated:
+        type: meter
+        tags: [executor]
+        docs: Rate that executor threads are terminated.
+      threads.running:
+        type: counter
+        tags: [executor]
+        docs: Number of live threads created by this executor.

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsThreadFactoryTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsThreadFactoryTest.java
@@ -1,0 +1,106 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.logsafe.exceptions.SafeNullPointerException;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadFactory;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+class TaggedMetricsThreadFactoryTest {
+
+    @Test
+    void testInstrumentation() {
+        String name = "name";
+        TaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+        ThreadFactory delegate = new ThreadFactoryBuilder()
+                .setNameFormat("test-%d")
+                .setDaemon(true)
+                .build();
+        ThreadFactory instrumented = MetricRegistries.instrument(registry, delegate, name);
+        ExecutorMetrics metrics = ExecutorMetrics.of(registry);
+        Counter running = metrics.threadsRunning(name);
+        Meter created = metrics.threadsCreated(name);
+        Meter terminated = metrics.threadsTerminated(name);
+        assertThat(running.getCount()).isZero();
+        assertThat(created.getCount()).isZero();
+        assertThat(terminated.getCount()).isZero();
+        CountDownLatch latch = new CountDownLatch(1);
+        Thread thread = instrumented.newThread(() -> Uninterruptibles.awaitUninterruptibly(latch));
+        assertThat(created.getCount()).isOne();
+        // thread has not started yet
+        assertThat(running.getCount()).isZero();
+        assertThat(terminated.getCount()).isZero();
+        thread.start();
+        // Allow the thread to start in the background
+        Awaitility.waitAtMost(Duration.ofSeconds(3)).untilAsserted(() -> {
+            assertThat(created.getCount()).isOne();
+            assertThat(running.getCount()).isOne();
+            assertThat(terminated.getCount()).isZero();
+        });
+        latch.countDown();
+        Awaitility.waitAtMost(Duration.ofSeconds(3)).untilAsserted(() -> {
+            assertThat(created.getCount()).isOne();
+            assertThat(running.getCount()).isZero();
+            assertThat(terminated.getCount()).isOne();
+        });
+        Awaitility.waitAtMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> assertThat(thread.isAlive()).isFalse());
+    }
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void testNullThreadFactory() {
+        assertThatThrownBy(() ->
+                        MetricRegistries.instrument(new DefaultTaggedMetricRegistry(), (ThreadFactory) null, "name"))
+                .isInstanceOf(SafeNullPointerException.class)
+                .hasMessageContaining("ThreadFactory is required");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void testNullName() {
+        assertThatThrownBy(() -> MetricRegistries.instrument(
+                        new DefaultTaggedMetricRegistry(),
+                        new ThreadFactoryBuilder().setNameFormat("test-%d").build(),
+                        null))
+                .isInstanceOf(SafeNullPointerException.class)
+                .hasMessageContaining("Name is required");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void testNullRegistry() {
+        assertThatThrownBy(() -> MetricRegistries.instrument(
+                        null,
+                        new ThreadFactoryBuilder().setNameFormat("test-%d").build(),
+                        "name"))
+                .isInstanceOf(SafeNullPointerException.class)
+                .hasMessageContaining("TaggedMetricRegistry");
+    }
+}


### PR DESCRIPTION
This is based on the codahale InstrumentedThreadFactory, but
uses tagged metrics for reusable dashboarding and metric-schema
for auto-generated documentation.

## After this PR
==COMMIT_MSG==
Implement a tagged instrumented ThreadFactory
==COMMIT_MSG==

## Possible downsides?
metrics aren't free. But neither are compute resources, and metrics are cheaper.
