### PR TITLE
Avoid spurious dependency flags on dropwizard metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,10 @@ allprojects {
     }
     tasks.check.dependsOn(javadoc)
 
+    checkImplicitDependencies {
+        // avoid spurious flags on dropwizard metrics
+        ignore 'io.dropwizard.metrics', 'metrics-core'
+    }
     tasks.check.dependsOn(checkImplicitDependencies)
     tasks.check.dependsOn(checkUnusedDependencies)
 


### PR DESCRIPTION
## Before this PR
`checkImplicitDependencies` is flaking in https://github.com/palantir/tritium/pull/701 on `io.dropwizard.metrics:metrics-core` dependencies for several modules that have explicit dependencies (`api` for `tritium-metrics`, `jmh` for `tritium-jmh`)
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':tritium-metrics:checkImplicitDependenciesTest'.
> Found 1 implicit dependencies - consider adding the following explicit dependencies to 'tritium-metrics/build.gradle', or avoid using classes from these jars:
      dependencies {
          'io.dropwizard.metrics:metrics-core'
      }
```

## After this PR
==COMMIT_MSG==
Avoid spurious dependency flags on dropwizard metrics
==COMMIT_MSG==

## Possible downsides?
Papering over problem in `checkImplicitDependencies` that needs to be fixed, see https://github.com/palantir/gradle-baseline/issues/1285

