### PR TITLE
Deprecated non-tagged caffeine cache metrics

### DIFF
--- a/changelog/@unreleased/pr-715.v2.yml
+++ b/changelog/@unreleased/pr-715.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The `CaffeineCacheStats#registerStats` method that takes a `MetricRegistry`
+    is now deprecated.
+  links:
+  - https://github.com/palantir/tritium/pull/715

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStats.java
@@ -34,7 +34,6 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings("WeakerAccess") // public API
 public final class CaffeineCacheStats {
 
     private static final Logger log = LoggerFactory.getLogger(CaffeineCacheStats.class);
@@ -48,10 +47,13 @@ public final class CaffeineCacheStats {
      * Callers should ensure that they have {@link Caffeine#recordStats() enabled stats recording}
      * {@code Caffeine.newBuilder().recordStats()} otherwise there are no cache metrics to register.
      *
+     * @deprecated use {@link #registerCache(TaggedMetricRegistry, Cache, String)}
+     *
      * @param registry metric registry
      * @param cache cache to instrument
      * @param name cache name
      */
+    @Deprecated
     public static void registerCache(MetricRegistry registry, Cache<?, ?> cache, String name) {
         checkNotNull(registry, "registry");
         checkNotNull(cache, "cache");

--- a/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStatsTest.java
+++ b/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStatsTest.java
@@ -65,6 +65,7 @@ final class CaffeineCacheStatsTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void registerCacheMetrics() {
         Cache<Integer, String> cache =
                 Caffeine.newBuilder().recordStats().maximumSize(2).build();
@@ -168,6 +169,7 @@ final class CaffeineCacheStatsTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void registerCacheWithoutRecordingStats() {
         Cache<Integer, String> cache = Caffeine.newBuilder().build();
         CaffeineCacheStats.registerCache(metricRegistry, cache, "test");

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -201,7 +201,6 @@ public final class MetricRegistries {
      * @param filter metric filter predicate
      * @return sorted map of metrics
      */
-    @SuppressWarnings("WeakerAccess") // public API
     public static SortedMap<String, Metric> metricsMatching(MetricRegistry metrics, MetricFilter filter) {
         SortedMap<String, Metric> matchingMetrics = new TreeMap<>();
         metrics.getMetrics().forEach((key, value) -> {
@@ -218,12 +217,15 @@ public final class MetricRegistries {
      * Callers should ensure that they have {@link CacheBuilder#recordStats() enabled stats recording}
      * {@code CacheBuilder.newBuilder().recordStats()} otherwise there are no cache metrics to register.
      *
+     * @deprecated use {@link #registerCache(TaggedMetricRegistry, Cache, String)}
+     *
      * @param registry metric registry
      * @param cache cache to instrument
      * @param name cache name
      * @throws IllegalArgumentException if name is blank
      */
-    @SuppressWarnings({"BanGuavaCaches", "WeakerAccess"}) // this implementation is explicitly for Guava caches, API
+    @Deprecated
+    @SuppressWarnings("BanGuavaCaches") // this implementation is explicitly for Guava caches
     public static void registerCache(MetricRegistry registry, Cache<?, ?> cache, String name) {
         registerCache(registry, cache, name, Clock.defaultClock());
     }
@@ -253,7 +255,7 @@ public final class MetricRegistries {
      * @param name cache name
      * @throws IllegalArgumentException if name is blank
      */
-    @SuppressWarnings({"BanGuavaCaches", "WeakerAccess"}) // this implementation is explicitly for Guava caches
+    @SuppressWarnings("BanGuavaCaches") // this implementation is explicitly for Guava caches
     public static void registerCache(TaggedMetricRegistry registry, Cache<?, ?> cache, @Safe String name) {
         checkNotNull(registry, "metric registry");
         checkNotNull(cache, "cache");

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
@@ -227,6 +227,7 @@ final class MetricRegistriesTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void testRegisterCacheReplacement() {
         Cache<?, ?> cache1 = CacheBuilder.newBuilder().build();
         MetricRegistries.registerCache(metrics, cache1, "test");
@@ -236,6 +237,7 @@ final class MetricRegistriesTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void testNoStats() {
         MetricRegistries.registerCache(metrics, cache, "test");
 


### PR DESCRIPTION
## Before this PR
The `CaffeineCacheStats#registerStats` method that takes a `MetricRegistry` is not deprecated.

## After this PR
The `CaffeineCacheStats#registerStats` method that takes a `MetricRegistry` is deprecated.

We want to encourage users to use tagged metrics because that allows using the same metrics for every cache.

