### PR TITLE
Baseline no longer provides a SwitchStatementDefaultCase error-prone check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,6 @@ allprojects {
                 'PreferListsPartition',
                 'PreferSafeLoggingPreconditions',
                 'PreferSafeLoggableExceptions',
-                'SwitchStatementDefaultCase',
             ]
 
             com.google.errorprone.scanner.BuiltInCheckerSuppliers.ENABLED_WARNINGS.forEach {


### PR DESCRIPTION
## Before this PR
Baseline bump https://github.com/palantir/tritium/pull/720 [failing with `SwitchStatementDefaultCase is not a valid checker name`](https://app.circleci.com/pipelines/github/palantir/tritium/414/workflows/3b5029ea-45e0-4a86-bdc4-92e4e9bf35be/jobs/8481/steps)

## After this PR
==COMMIT_MSG==
Baseline no longer provides a SwitchStatementDefaultCase error-prone check
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

