### PR TITLE
Implement a simple metric-schema based handler

### DIFF
--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/Instrumentation.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/Instrumentation.java
@@ -29,6 +29,7 @@ import com.palantir.tritium.event.InvocationEventHandler;
 import com.palantir.tritium.event.log.LoggingInvocationEventHandler;
 import com.palantir.tritium.event.log.LoggingLevel;
 import com.palantir.tritium.event.metrics.MetricsInvocationEventHandler;
+import com.palantir.tritium.event.metrics.TaggedMetricInvocationEventHandler;
 import com.palantir.tritium.event.metrics.TaggedMetricsServiceInvocationEventHandler;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Collections;
@@ -146,10 +147,12 @@ public final class Instrumentation {
          * @param prefix - Metrics name prefix to be used
          * @return - InstrumentationBuilder
          */
+        @SuppressWarnings("deprecation") // TaggedMetricsServiceInvocationEventHandler is provided for backcompat
         public Builder<T, U> withTaggedMetrics(TaggedMetricRegistry metricRegistry, String prefix) {
             checkNotNull(metricRegistry, "metricRegistry");
             String serviceName = Strings.isNullOrEmpty(prefix) ? interfaceClass.getName() : prefix;
             this.handlers.add(new TaggedMetricsServiceInvocationEventHandler(metricRegistry, serviceName));
+            this.handlers.add(TaggedMetricInvocationEventHandler.of(metricRegistry, serviceName));
             return this;
         }
 

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/Instrumentation.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/Instrumentation.java
@@ -144,16 +144,16 @@ public final class Instrumentation {
          * are chosen based off of the interface name and invoked method.
          *
          * @param metricRegistry - TaggedMetricsRegistry used for this application.
-         * @param prefix - Metrics name prefix to be used
-         * @return - InstrumentationBuilder
+         * @param serviceName - Service name with which to associate metrics.
+         * @return - Instrumentation builder
          */
         @SuppressWarnings("deprecation") // TaggedMetricsServiceInvocationEventHandler is provided for backcompat
-        public Builder<T, U> withTaggedMetrics(TaggedMetricRegistry metricRegistry, String prefix) {
+        public Builder<T, U> withTaggedMetrics(TaggedMetricRegistry metricRegistry, String serviceName) {
             checkNotNull(metricRegistry, "metricRegistry");
             this.handlers.add(new TaggedMetricsServiceInvocationEventHandler(
-                    metricRegistry, Strings.isNullOrEmpty(prefix) ? interfaceClass.getName() : prefix));
+                    metricRegistry, Strings.isNullOrEmpty(serviceName) ? interfaceClass.getName() : serviceName));
             this.handlers.add(TaggedMetricInvocationEventHandler.of(
-                    metricRegistry, Strings.isNullOrEmpty(prefix) ? interfaceClass.getSimpleName() : prefix));
+                    metricRegistry, Strings.isNullOrEmpty(serviceName) ? interfaceClass.getSimpleName() : serviceName));
             return this;
         }
 

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/Instrumentation.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/Instrumentation.java
@@ -150,9 +150,10 @@ public final class Instrumentation {
         @SuppressWarnings("deprecation") // TaggedMetricsServiceInvocationEventHandler is provided for backcompat
         public Builder<T, U> withTaggedMetrics(TaggedMetricRegistry metricRegistry, String prefix) {
             checkNotNull(metricRegistry, "metricRegistry");
-            String serviceName = Strings.isNullOrEmpty(prefix) ? interfaceClass.getName() : prefix;
-            this.handlers.add(new TaggedMetricsServiceInvocationEventHandler(metricRegistry, serviceName));
-            this.handlers.add(TaggedMetricInvocationEventHandler.of(metricRegistry, serviceName));
+            this.handlers.add(new TaggedMetricsServiceInvocationEventHandler(
+                    metricRegistry, Strings.isNullOrEmpty(prefix) ? interfaceClass.getName() : prefix));
+            this.handlers.add(TaggedMetricInvocationEventHandler.of(
+                    metricRegistry, Strings.isNullOrEmpty(prefix) ? interfaceClass.getSimpleName() : prefix));
             return this;
         }
 

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
@@ -47,7 +47,7 @@ import com.palantir.tritium.event.InvocationContext;
 import com.palantir.tritium.event.InvocationEventHandler;
 import com.palantir.tritium.event.log.LoggingInvocationEventHandler;
 import com.palantir.tritium.event.metrics.MetricsInvocationEventHandler;
-import com.palantir.tritium.event.metrics.TaggedMetricsServiceInvocationEventHandler;
+import com.palantir.tritium.event.metrics.TaggedMetricInvocationEventHandler;
 import com.palantir.tritium.event.metrics.annotations.MetricGroup;
 import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -593,11 +593,11 @@ public abstract class InstrumentationTest {
         StackTraceSupplier singleHandlerInstrumentedStackSupplier = Instrumentation.builder(
                         StackTraceSupplier.class, stackTraceSupplier)
                 // Use enabled event handlers to avoid bugs from optimizations on disabled handlers
-                .withHandler(new TaggedMetricsServiceInvocationEventHandler(new DefaultTaggedMetricRegistry(), "test0"))
+                .withHandler(TaggedMetricInvocationEventHandler.of(new DefaultTaggedMetricRegistry(), "test0"))
                 .build();
         StackTraceSupplier multipleHandlerInstrumentedStackSupplier = Instrumentation.builder(
                         StackTraceSupplier.class, stackTraceSupplier)
-                .withHandler(new TaggedMetricsServiceInvocationEventHandler(new DefaultTaggedMetricRegistry(), "test1"))
+                .withHandler(TaggedMetricInvocationEventHandler.of(new DefaultTaggedMetricRegistry(), "test1"))
                 .withHandler(new MetricsInvocationEventHandler(new MetricRegistry(), "test2"))
                 .build();
         StackTraceElement[] singleHandlerInstrumentedStackTrace = singleHandlerInstrumentedStackSupplier.get();

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricInvocationEventHandler.java
@@ -1,0 +1,96 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.event.metrics;
+
+import static com.palantir.logsafe.Preconditions.checkNotNull;
+
+import com.codahale.metrics.Timer;
+import com.palantir.tritium.event.AbstractInvocationEventHandler;
+import com.palantir.tritium.event.DefaultInvocationContext;
+import com.palantir.tritium.event.InstrumentationProperties;
+import com.palantir.tritium.event.InvocationContext;
+import com.palantir.tritium.event.InvocationEventHandler;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.lang.reflect.Method;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An implementation of {@link AbstractInvocationEventHandler} whose purpose is to provide tagged metrics as
+ * described in {@code invocation-metrics.yml}.
+ */
+public final class TaggedMetricInvocationEventHandler extends AbstractInvocationEventHandler<InvocationContext> {
+
+    private final String serviceName;
+    private final ConcurrentMap<Method, Timer> timerCache = new ConcurrentHashMap<>();
+    private final Function<Method, Timer> onSuccessTimerMappingFunction;
+    private final InvocationMetrics metrics;
+
+    public static InvocationEventHandler<?> of(TaggedMetricRegistry taggedMetricRegistry, String serviceName) {
+        return new TaggedMetricInvocationEventHandler(taggedMetricRegistry, serviceName);
+    }
+
+    private TaggedMetricInvocationEventHandler(TaggedMetricRegistry taggedMetricRegistry, String serviceName) {
+        super(getEnabledSupplier(serviceName));
+        this.metrics = InvocationMetrics.of(taggedMetricRegistry);
+        this.serviceName = checkNotNull(serviceName, "serviceName");
+        this.onSuccessTimerMappingFunction = method -> metrics.success()
+                .serviceName(serviceName)
+                .methodName(method.getName())
+                .build();
+    }
+
+    @SuppressWarnings("NoFunctionalReturnType") // helper
+    private static BooleanSupplier getEnabledSupplier(String serviceName) {
+        return InstrumentationProperties.getSystemPropertySupplier(serviceName);
+    }
+
+    @Override
+    public InvocationContext preInvocation(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args) {
+        return DefaultInvocationContext.of(instance, method, args);
+    }
+
+    @Override
+    public void onSuccess(@Nullable InvocationContext context, @Nullable Object _result) {
+        debugIfNullContext(context);
+        if (context != null) {
+            long nanos = System.nanoTime() - context.getStartTimeNanos();
+            getSuccessTimer(context.getMethod()).update(nanos, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    private Timer getSuccessTimer(Method method) {
+        return timerCache.computeIfAbsent(method, onSuccessTimerMappingFunction);
+    }
+
+    @Override
+    public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable _cause) {
+        debugIfNullContext(context);
+        if (context != null) {
+            metrics.failure()
+                    .serviceName(serviceName)
+                    .methodName(context.getMethod().getName())
+                    .build()
+                    .mark();
+        }
+    }
+}

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricInvocationEventHandler.java
@@ -46,7 +46,8 @@ public final class TaggedMetricInvocationEventHandler extends AbstractInvocation
     private final Function<Method, Timer> onSuccessTimerMappingFunction;
     private final InvocationMetrics metrics;
 
-    public static InvocationEventHandler<?> of(TaggedMetricRegistry taggedMetricRegistry, @Safe String serviceName) {
+    public static InvocationEventHandler<InvocationContext> of(
+            TaggedMetricRegistry taggedMetricRegistry, @Safe String serviceName) {
         return new TaggedMetricInvocationEventHandler(taggedMetricRegistry, serviceName);
     }
 

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricInvocationEventHandler.java
@@ -19,6 +19,7 @@ package com.palantir.tritium.event.metrics;
 import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.codahale.metrics.Timer;
+import com.palantir.logsafe.Safe;
 import com.palantir.tritium.event.AbstractInvocationEventHandler;
 import com.palantir.tritium.event.DefaultInvocationContext;
 import com.palantir.tritium.event.InstrumentationProperties;
@@ -45,7 +46,7 @@ public final class TaggedMetricInvocationEventHandler extends AbstractInvocation
     private final Function<Method, Timer> onSuccessTimerMappingFunction;
     private final InvocationMetrics metrics;
 
-    public static InvocationEventHandler<?> of(TaggedMetricRegistry taggedMetricRegistry, String serviceName) {
+    public static InvocationEventHandler<?> of(TaggedMetricRegistry taggedMetricRegistry, @Safe String serviceName) {
         return new TaggedMetricInvocationEventHandler(taggedMetricRegistry, serviceName);
     }
 

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandler.java
@@ -60,6 +60,12 @@ public class TaggedMetricsServiceInvocationEventHandler extends AbstractInvocati
     private final ConcurrentMap<Method, Timer> timerCache = new ConcurrentHashMap<>();
     private final Function<Method, Timer> onSuccessTimerMappingFunction;
 
+    /**
+     * Please prefer {@link TaggedMetricInvocationEventHandler} over {@link TaggedMetricsServiceInvocationEventHandler}.
+     *
+     * @deprecated in favor of {@link TaggedMetricInvocationEventHandler}.
+     */
+    @Deprecated
     public TaggedMetricsServiceInvocationEventHandler(TaggedMetricRegistry taggedMetricRegistry, String serviceName) {
         super(getEnabledSupplier(serviceName));
         this.taggedMetricRegistry = checkNotNull(taggedMetricRegistry, "metricRegistry");

--- a/tritium-metrics/src/main/metrics/invocation-metrics.yml
+++ b/tritium-metrics/src/main/metrics/invocation-metrics.yml
@@ -1,0 +1,15 @@
+options:
+  javaPackage: com.palantir.tritium.event.metrics
+  javaVisibility: packagePrivate
+namespaces:
+  invocation:
+    docs: Tritium invocation proxy metrics for components wrapped using `Tritium.instrument` or `Instrumentation.builder()` with tagged metrics handlers.
+    metrics:
+      success:
+        type: timer
+        tags: [service-name, method-name]
+        docs: Time taken for a successful invocation to complete.
+      failure:
+        type: meter
+        tags: [service-name, method-name]
+        docs: Rate of invocations which resulted in exceptions.

--- a/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/TaggedMetricInvocationEventHandlerTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/TaggedMetricInvocationEventHandlerTest.java
@@ -1,0 +1,91 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.event.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.Metric;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import com.palantir.tritium.event.DefaultInvocationContext;
+import com.palantir.tritium.event.InvocationContext;
+import com.palantir.tritium.event.InvocationEventHandler;
+import com.palantir.tritium.metrics.registry.MetricName;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import com.palantir.tritium.metrics.test.TestTaggedMetricRegistries;
+import java.util.Map;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+final class TaggedMetricInvocationEventHandlerTest {
+
+    public static final class TestImplementation {
+
+        @SuppressWarnings("unused") // instrumented
+        public String doFoo() {
+            return this.getClass().getSimpleName();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource(TestTaggedMetricRegistries.REGISTRIES)
+    void testTaggedServiceMetricsCaptured(TaggedMetricRegistry registry) throws Exception {
+        TestImplementation testInterface = new TestImplementation();
+
+        InvocationEventHandler<?> handler = TaggedMetricInvocationEventHandler.of(registry, "quux");
+
+        invokeMethod(handler, testInterface, "doFoo", "bar", /* success= */ true);
+
+        Map<MetricName, Metric> metrics = registry.getMetrics();
+        MetricName expectedMetricName = MetricName.builder()
+                .safeName("invocation.success")
+                .putSafeTags("service-name", "quux")
+                .putSafeTags("method-name", "doFoo")
+                .build();
+        assertThat(metrics).containsKey(expectedMetricName);
+    }
+
+    @ParameterizedTest
+    @MethodSource(TestTaggedMetricRegistries.REGISTRIES)
+    void testTaggedServiceMetricsCapturedAsErrors(TaggedMetricRegistry registry) throws Exception {
+        TestImplementation testInterface = new TestImplementation();
+
+        InvocationEventHandler<?> handler = TaggedMetricInvocationEventHandler.of(registry, "quux");
+
+        invokeMethod(handler, testInterface, "doFoo", "bar", /* success= */ false);
+
+        Map<MetricName, Metric> metrics = registry.getMetrics();
+        MetricName expectedMetricName = MetricName.builder()
+                .safeName("invocation.failure")
+                .putSafeTags("service-name", "quux")
+                .putSafeTags("method-name", "doFoo")
+                .build();
+        assertThat(metrics).containsKey(expectedMetricName);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static void invokeMethod(
+            InvocationEventHandler<?> handler, Object obj, String methodName, Object result, boolean success)
+            throws Exception {
+        InvocationContext context =
+                DefaultInvocationContext.of(obj, obj.getClass().getMethod(methodName), null);
+        if (success) {
+            handler.onSuccess(context, result);
+        } else {
+            handler.onFailure(context, new SafeRuntimeException("fail"));
+        }
+    }
+}

--- a/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandlerTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandlerTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@SuppressWarnings("deprecation") // Testing a deprecated class
 final class TaggedMetricsServiceInvocationEventHandlerTest {
 
     public static final class TestImplementation {


### PR DESCRIPTION
Changes from the existing tagged metric invocation handler:
* Metrics use constant safe-names.
* There is no global failure metric, failures are all recorded
  using the standard service-name,method-name tuple.
* Failures are not tagged with the exception type in order to
  reduce cardinality. Other observability components exist to
  discover failure causes.
* Metrics are tagged with the provided service name, but no longer
  provide a tag including the declaring class as the two are generally
  either equivalent or interchangeable.

These changes are aimed at leveraging auto-generated documentation
from metric-schema, and allowing general purpose dashboards to take
advantage of tritium instrumentation metrics.

## Before this PR
No documentation for instrumentation proxy metrics through metric-schema. No reasonable way to build a generalized dashboard for instrumented proxies.

## After this PR
==COMMIT_MSG==
Implement a simple constant-safe-name metric-schema based metric invocation handler replacement for `TaggedMetricsServiceInvocationEventHandler`
==COMMIT_MSG==

## Possible downsides?

TODO: Build a reasonable migration path from existing tagged metrics
to those defined using metric-schema. Ideas?

