### PR TITLE
Fix StrictUnusedVariable errors

### DIFF
--- a/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineStatsTest.java
+++ b/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineStatsTest.java
@@ -52,8 +52,8 @@ final class CaffeineStatsTest {
     @BeforeEach
     void before() {
         stats = new CaffeineStats(cache, () -> new CacheStats(1, 2, 3, 4, 5, 6, 7));
-        lenient().when(cache.policy()).thenAnswer(ignored -> policy);
-        lenient().when(policy.eviction()).thenAnswer(ignored -> Optional.of(eviction));
+        lenient().when(cache.policy()).thenAnswer(_ignored -> policy);
+        lenient().when(policy.eviction()).thenAnswer(_ignored -> Optional.of(eviction));
     }
 
     @Test

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/InstrumentationCreationBenchmark.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/InstrumentationCreationBenchmark.java
@@ -76,7 +76,7 @@ public class InstrumentationCreationBenchmark {
                 getClass().getClassLoader(),
                 // Apply runnable to avoid benchmarks reusing the proxy class
                 new Class<?>[] {Runnable.class, Stubs.Iface99.class},
-                (proxy, method, args) -> null);
+                (_proxy, _method, _args) -> null);
         this.duplicateStub = (Stubs.Iface99) Proxy.newProxyInstance(
                 getClass().getClassLoader(),
                 // Apply runnable to avoid benchmarks reusing the proxy class
@@ -91,7 +91,7 @@ public class InstrumentationCreationBenchmark {
                                     }
                                 }))
                         .toArray(Class<?>[]::new),
-                (proxy, method, args) -> null);
+                (_proxy, _method, _args) -> null);
     }
 
     @Benchmark

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
@@ -626,7 +626,7 @@ public abstract class InstrumentationTest {
 
     @SuppressWarnings("SameParameterValue")
     private static InstrumentationFilter methodNameFilter(String methodName) {
-        return (instance, method, args) -> method.getName().equals(methodName);
+        return (_instance, method, _args) -> method.getName().equals(methodName);
     }
 
     @Test

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -104,7 +104,7 @@ public final class JvmMetrics {
     }
 
     @SuppressWarnings("UnnecessaryLambda") // Avoid allocations in the threads-by-state loop
-    private static final BiFunction<Thread.State, Integer, Integer> incrementThreadState = (state, input) -> {
+    private static final BiFunction<Thread.State, Integer, Integer> incrementThreadState = (_state, input) -> {
         int existingValue = input == null ? 0 : input;
         return existingValue + 1;
     };

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
@@ -415,7 +415,7 @@ final class MetricRegistriesTest {
 
     @Test
     void testMetricsMatching() {
-        MetricFilter palantirFilter = (name, metric) -> name.startsWith("test");
+        MetricFilter palantirFilter = (name, _metric) -> name.startsWith("test");
 
         metrics.counter("test.a");
         metrics.timer("test.b");

--- a/tritium-slf4j/src/test/java/com/palantir/tritium/event/log/LoggingInvocationEventHandlerTest.java
+++ b/tritium-slf4j/src/test/java/com/palantir/tritium/event/log/LoggingInvocationEventHandlerTest.java
@@ -163,7 +163,7 @@ public class LoggingInvocationEventHandlerTest {
         assertThat(LoggingInvocationEventHandler.LOG_DURATIONS_GREATER_THAN_1_MICROSECOND)
                 .isInstanceOf(com.palantir.tritium.api.functions.LongPredicate.class);
 
-        java.util.function.LongPredicate legacyPredicate = input -> false;
+        java.util.function.LongPredicate legacyPredicate = _ignored -> false;
         assertThat(new LoggingInvocationEventHandler(getLogger(), LoggingLevel.TRACE, legacyPredicate))
                 .isNotNull();
     }


### PR DESCRIPTION
## Before this PR
Baseline excavator bump flagging unused variables / args compilation errors: https://app.circleci.com/pipelines/github/palantir/tritium/463/workflows/1de80732-d210-469a-9d62-490f3218c261/jobs/8747/steps

## After this PR
==COMMIT_MSG==
Fix StrictUnusedVariable errors
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

