### PR TITLE
TaggedMetricRegistry with baked-in libraryName and libraryVersion tags

### DIFF
--- a/changelog/@unreleased/pr-754.v2.yml
+++ b/changelog/@unreleased/pr-754.v2.yml
@@ -1,0 +1,13 @@
+type: feature
+feature:
+  description: |-
+    Library authors can now construct a TaggedMetricRegistry that augments all created metrics with a `libraryName` and `libraryVersion` tag:
+    ```java
+    MetricRegistries.wrapWithLibraryInfo()
+                    .registry(registry)
+                    .libraryName("my-library")
+                    .libraryVersionFromClass(MyLibrary.class)
+                    .build()
+    ```
+  links:
+  - https://github.com/palantir/tritium/pull/754

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -578,7 +578,7 @@ public final class MetricRegistries {
             AugmentedTaggedMetricRegistry augmented = AugmentedTaggedMetricRegistry.create(
                     Preconditions.checkNotNull(registry, "registry"),
                     "libraryName",
-                    Preconditions.checkNotNull(libraryName));
+                    Preconditions.checkNotNull(libraryName, "libraryName"));
             if (libraryVersion != null) {
                 augmented = AugmentedTaggedMetricRegistry.create(augmented, "libraryVersion", libraryVersion);
             }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -523,7 +523,7 @@ public final class MetricRegistries {
                 Pattern.compile("[a-z0-9]+(-[a-z0-9]+)*").asPredicate();
 
         @Nullable
-        private TaggedMetricRegistry delegate;
+        private TaggedMetricRegistry registry;
 
         @Nullable
         private String libraryName;
@@ -533,7 +533,7 @@ public final class MetricRegistries {
 
         /** Metrics will be created in this registry. */
         public WrapWithLibraryInfoBuilder registry(TaggedMetricRegistry value) {
-            this.delegate = value;
+            this.registry = value;
             return this;
         }
 
@@ -575,12 +575,14 @@ public final class MetricRegistries {
         }
 
         public AugmentedTaggedMetricRegistry build() {
-            AugmentedTaggedMetricRegistry registry = AugmentedTaggedMetricRegistry.create(
-                    Preconditions.checkNotNull(delegate), "libraryName", Preconditions.checkNotNull(libraryName));
+            AugmentedTaggedMetricRegistry augmented = AugmentedTaggedMetricRegistry.create(
+                    Preconditions.checkNotNull(registry, "registry"),
+                    "libraryName",
+                    Preconditions.checkNotNull(libraryName));
             if (libraryVersion != null) {
-                registry = AugmentedTaggedMetricRegistry.create(registry, "libraryVersion", libraryVersion);
+                augmented = AugmentedTaggedMetricRegistry.create(augmented, "libraryVersion", libraryVersion);
             }
-            return registry;
+            return augmented;
         }
     }
 }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AugmentedTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AugmentedTaggedMetricRegistry.java
@@ -178,14 +178,14 @@ public final class AugmentedTaggedMetricRegistry implements TaggedMetricRegistry
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object obj) {
+        if (this == obj) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        AugmentedTaggedMetricRegistry that = (AugmentedTaggedMetricRegistry) o;
+        AugmentedTaggedMetricRegistry that = (AugmentedTaggedMetricRegistry) obj;
         return delegate.equals(that.delegate) && tagName.equals(that.tagName) && tagValue.equals(that.tagValue);
     }
 

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AugmentedTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AugmentedTaggedMetricRegistry.java
@@ -47,7 +47,7 @@ public final class AugmentedTaggedMetricRegistry implements TaggedMetricRegistry
         this.tagValue = Preconditions.checkNotNull(tagValue, "tagValue");
     }
 
-    static AugmentedTaggedMetricRegistry create(
+    public static AugmentedTaggedMetricRegistry create(
             TaggedMetricRegistry delegate, @Safe String tagName, @Safe String tagValue) {
         if (delegate instanceof AugmentedTaggedMetricRegistry) {
             AugmentedTaggedMetricRegistry other = (AugmentedTaggedMetricRegistry) delegate;

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AugmentedTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AugmentedTaggedMetricRegistry.java
@@ -1,0 +1,179 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.registry;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.Timer;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+/**
+ * Any metric created on this registry will be saved into the delegate {@link TaggedMetricRegistry} with an extra tag
+ * added.
+ *
+ * 'Read' methods (like {@link #getMetrics} and {@link #forEachMetric} just read from the delegate, so some
+ * returned MetricNames may not have the extra tag.
+ */
+public final class AugmentedTaggedMetricRegistry implements TaggedMetricRegistry {
+    private final TaggedMetricRegistry delegate;
+    private final String tagName;
+    private final String tagValue;
+
+    private AugmentedTaggedMetricRegistry(TaggedMetricRegistry delegate, String tagName, String tagValue) {
+        this.delegate = Preconditions.checkNotNull(delegate, "delegate");
+        this.tagName = Preconditions.checkNotNull(tagName, "tagName");
+        this.tagValue = Preconditions.checkNotNull(tagValue, "tagValue");
+    }
+
+    static AugmentedTaggedMetricRegistry create(
+            TaggedMetricRegistry delegate, @Safe String tagName, @Safe String tagValue) {
+        if (delegate instanceof AugmentedTaggedMetricRegistry) {
+            AugmentedTaggedMetricRegistry other = (AugmentedTaggedMetricRegistry) delegate;
+            if (Objects.equals(delegate, other.delegate)
+                    && Objects.equals(tagName, other.tagName)
+                    && Objects.equals(tagValue, other.tagValue)) {
+                return other;
+            }
+        }
+        return new AugmentedTaggedMetricRegistry(delegate, tagName, tagValue);
+    }
+
+    private MetricName augment(MetricName existing) {
+        return RealMetricName.create(existing, tagName, tagValue);
+    }
+
+    @Override
+    public Map<MetricName, Metric> getMetrics() {
+        return delegate.getMetrics();
+    }
+
+    @Override
+    public void forEachMetric(BiConsumer<MetricName, Metric> consumer) {
+        delegate.forEachMetric(consumer);
+    }
+
+    @Override
+    public <T> Optional<Gauge<T>> gauge(MetricName metricName) {
+        return delegate.gauge(augment(metricName));
+    }
+
+    @Override
+    public <T> Gauge<T> gauge(MetricName metricName, Gauge<T> gauge) {
+        return delegate.gauge(augment(metricName), gauge);
+    }
+
+    @Override
+    public void registerWithReplacement(MetricName metricName, Gauge<?> gauge) {
+        delegate.registerWithReplacement(augment(metricName), gauge);
+    }
+
+    @Override
+    public Timer timer(MetricName metricName) {
+        return delegate.timer(augment(metricName));
+    }
+
+    @Override
+    public Timer timer(MetricName metricName, Supplier<Timer> timerSupplier) {
+        return delegate.timer(augment(metricName), timerSupplier);
+    }
+
+    @Override
+    public Meter meter(MetricName metricName) {
+        return delegate.meter(augment(metricName));
+    }
+
+    @Override
+    public Meter meter(MetricName metricName, Supplier<Meter> meterSupplier) {
+        return delegate.meter(augment(metricName), meterSupplier);
+    }
+
+    @Override
+    public Histogram histogram(MetricName metricName) {
+        return delegate.histogram(augment(metricName));
+    }
+
+    @Override
+    public Histogram histogram(MetricName metricName, Supplier<Histogram> histogramSupplier) {
+        return delegate.histogram(augment(metricName), histogramSupplier);
+    }
+
+    @Override
+    public Counter counter(MetricName metricName) {
+        return delegate.counter(augment(metricName));
+    }
+
+    @Override
+    public Counter counter(MetricName metricName, Supplier<Counter> counterSupplier) {
+        return delegate.counter(augment(metricName), counterSupplier);
+    }
+
+    @Override
+    public Optional<Metric> remove(MetricName metricName) {
+        return delegate.remove(augment(metricName));
+    }
+
+    @Override
+    public void addMetrics(String _safeTagName, String _safeTagValue, TaggedMetricSet _metrics) {
+        throw new UnsupportedOperationException(
+                "Operations involving transforming TaggedMetricSet are not supported, please interact with the "
+                        + "delegate directly");
+    }
+
+    @Override
+    public Optional<TaggedMetricSet> removeMetrics(String _safeTagName, String _safeTagValue) {
+        throw new UnsupportedOperationException(
+                "Removal of an entire TaggedMetricSet is not supported, please interact with the delegate directly");
+    }
+
+    @Override
+    public boolean removeMetrics(String _safeTagName, String _safeTagValue, TaggedMetricSet _metrics) {
+        throw new UnsupportedOperationException(
+                "Removal of an entire TaggedMetricSet is not supported, please interact with the delegate directly");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AugmentedTaggedMetricRegistry that = (AugmentedTaggedMetricRegistry) o;
+        return delegate.equals(that.delegate) && tagName.equals(that.tagName) && tagValue.equals(that.tagValue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(delegate, tagName, tagValue);
+    }
+
+    @Override
+    public String toString() {
+        return "AugmentedTaggedMetricRegistry{tagName='" + tagName + "', tagValue='" + tagValue + "', delegate="
+                + delegate + '}';
+    }
+}

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AugmentedTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AugmentedTaggedMetricRegistry.java
@@ -143,6 +143,11 @@ public final class AugmentedTaggedMetricRegistry implements TaggedMetricRegistry
         return delegate.remove(augment(metricName));
     }
 
+    /**
+     * .
+     * @deprecated not implemented
+     */
+    @Deprecated
     @Override
     public void addMetrics(String _safeTagName, String _safeTagValue, TaggedMetricSet _metrics) {
         throw new UnsupportedOperationException(
@@ -150,12 +155,22 @@ public final class AugmentedTaggedMetricRegistry implements TaggedMetricRegistry
                         + "delegate directly");
     }
 
+    /**
+     * .
+     * @deprecated not implemented
+     */
+    @Deprecated
     @Override
     public Optional<TaggedMetricSet> removeMetrics(String _safeTagName, String _safeTagValue) {
         throw new UnsupportedOperationException(
                 "Removal of an entire TaggedMetricSet is not supported, please interact with the delegate directly");
     }
 
+    /**
+     * .
+     * @deprecated not implemented
+     */
+    @Deprecated
     @Override
     public boolean removeMetrics(String _safeTagName, String _safeTagValue, TaggedMetricSet _metrics) {
         throw new UnsupportedOperationException(

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/AugmentedTaggedMetricRegistryTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/AugmentedTaggedMetricRegistryTest.java
@@ -1,0 +1,87 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.registry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.codahale.metrics.Counter;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import org.junit.jupiter.api.Test;
+
+class AugmentedTaggedMetricRegistryTest {
+    private final DefaultTaggedMetricRegistry delegate = new DefaultTaggedMetricRegistry();
+    private final AugmentedTaggedMetricRegistry registry =
+            AugmentedTaggedMetricRegistry.create(delegate, "dialogueVersion", "1.0.0");
+    private final MetricName hello = MetricName.builder().safeName("hello").build();
+    private final MetricName helloAugmented = MetricName.builder()
+            .safeName("hello")
+            .putSafeTags("dialogueVersion", "1.0.0")
+            .build();
+
+    @Test
+    void creating_a_counter_stores_augmented_metricname_in_underlying_registry() {
+        Counter counter = registry.counter(hello);
+        assertThat(delegate.getMetrics()).containsEntry(helloAugmented, counter);
+        assertThat(registry.getMetrics()).containsEntry(helloAugmented, counter);
+    }
+
+    @Test
+    void foo() {
+        assertThatThrownBy(() -> registry.counter(MetricName.builder()
+                        .safeName("foo")
+                        .putSafeTags("dialogueVersion", "bork")
+                        .build()))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessage("Map must not contain the extra key that is to be added: "
+                        + "{key=dialogueVersion, existingValue=bork, newValue=1.0.0}");
+    }
+
+    @Test
+    void underlying_metrics_can_be_accessed_unmodified() {
+        Counter counter = delegate.counter(hello);
+        assertThat(delegate.getMetrics()).containsEntry(hello, counter);
+        assertThat(registry.getMetrics()).containsEntry(hello, counter);
+    }
+
+    @Test
+    void reewrapping_with_identical_values_does_nothing() {
+        AugmentedTaggedMetricRegistry secondCreate =
+                AugmentedTaggedMetricRegistry.create(registry, "dialogueVersion", "1.0.0");
+        assertThat(secondCreate).isSameAs(registry);
+    }
+
+    @Test
+    void rewrapping_with_different_value_will_break() {
+        assertThatThrownBy(() -> AugmentedTaggedMetricRegistry.create(registry, "dialogueVersion", "2.0.0"))
+                .hasMessage("Tag is already defined with a different value: "
+                        + "{tagName=dialogueVersion, existing=1.0.0, new=2.0.0}");
+    }
+
+    @Test
+    void equals_and_hashcode() {
+        assertThat(AugmentedTaggedMetricRegistry.create(delegate, "dialogueVersion", "1.0.0"))
+                .hasSameHashCodeAs(registry);
+        assertThat(AugmentedTaggedMetricRegistry.create(delegate, "dialogueVersion", "1.0.0"))
+                .isEqualTo(registry);
+        assertThat(AugmentedTaggedMetricRegistry.create(delegate, "dialogueVersion", "1.0.1"))
+                .isNotEqualTo(registry);
+        assertThat(AugmentedTaggedMetricRegistry.create(delegate, "atlasVersion", "1.0.0"))
+                .isNotEqualTo(registry);
+    }
+}

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/AugmentedTaggedMetricRegistryTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/AugmentedTaggedMetricRegistryTest.java
@@ -18,7 +18,6 @@ package com.palantir.tritium.metrics.registry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.codahale.metrics.Counter;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;


### PR DESCRIPTION
## Before this PR

In Dialogue, I've found it incredibly beneficial to have the `dialogueVersion` tag on all my metrics, because when looking at a graph I can tell whether they're on latest or an older version. I've been using this `VersionedTaggedMetricRegistry` class to achieve this: https://github.com/palantir/dialogue/blob/develop/dialogue-core/src/main/java/com/palantir/dialogue/core/VersionedTaggedMetricRegistry.java. I had intended to generalize this and make the pattern available for other libraries e.g. atlasdb (cc @jkong) and witchcraft.

A more urgent reason to pursue this came up recently with regard to our DD $ spend, as our spend reports are currently broken down by `product` tag, which makes it hard to see what proportion of the $ spend our various _libraries_ are responsible for. Apparently we can get cost breakdowns made for _any_ given tag, there just isn't a consistent one across libraries yet. (cc @samrogerson)

## After this PR
==COMMIT_MSG==
Library authors can now construct a TaggedMetricRegistry that augments all created metrics with a `libraryName` and `libraryVersion` tag:
```java
MetricRegistries.wrapWithLibraryInfo()
                .registry(registry)
                .libraryName("my-library")
                .libraryVersionFromClass(MyLibrary.class)
                .build()
```
==COMMIT_MSG==

- this approach means that when we use `Tritium.instrument` to add metrics to our WC clients, we should be able to correctly attribute this to 'witchcraft' rather than tritium (which is less helpful)
- an alternative approach was to implement this in metric-schema, but @ferozco didn't really like that approach (and it also wouldn't catch _all_ atlasdb metrics).

## Possible downsides?

- actually _using_ this may be a little bit fiddly, because in WC we'll need to construct one of these and carefully pass around this `wcInternalTaggedMetricRegistry` without exposing it to users.


