### PR TITLE
Upgrade CircleCI build to JDK 8u252

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2.1
 jobs:
   compile:
-    docker: [{ image: 'circleci/openjdk:8u222-stretch-node' }]
+    docker: [{ image: 'circleci/openjdk:8u252-jdk-buster' }]
     resource_class: large
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -54,7 +54,7 @@ jobs:
           paths: [ project, .gradle/init.gradle ]
 
   check:
-    docker: [{ image: 'circleci/openjdk:8u222-stretch-node' }]
+    docker: [{ image: 'circleci/openjdk:8u252-jdk-buster' }]
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
       CIRCLE_ARTIFACTS: /home/circleci/artifacts
@@ -75,7 +75,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   unit-test:
-    docker: [{ image: 'circleci/openjdk:8u222-stretch-node' }]
+    docker: [{ image: 'circleci/openjdk:8u252-jdk-buster' }]
     resource_class: large
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -127,7 +127,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   trial-publish:
-    docker: [{ image: 'circleci/openjdk:8u222-stretch-node' }]
+    docker: [{ image: 'circleci/openjdk:8u252-jdk-buster' }]
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
       CIRCLE_ARTIFACTS: /home/circleci/artifacts
@@ -145,7 +145,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   publish:
-    docker: [{ image: 'circleci/openjdk:8u222-stretch-node' }]
+    docker: [{ image: 'circleci/openjdk:8u252-jdk-buster' }]
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
       CIRCLE_ARTIFACTS: /home/circleci/artifacts

--- a/changelog/@unreleased/pr-781.v2.yml
+++ b/changelog/@unreleased/pr-781.v2.yml
@@ -1,0 +1,11 @@
+type: improvement
+improvement:
+  description: |-
+    Upgrade CircleCI build to JDK 8u252
+
+    Suppress JEP 244 SSLEngine overrides
+    JEP 244: TLS Application-Layer Protocol Negotiation Extension was backported to JDK8u251+ per https://bugs.openjdk.java.net/browse/JDK-8230977 which added 4 methods that were previously only in JDK9+.
+
+    Unfortunately this causes problems compiling locally when using JDK 8u251+ as error-prone will flag missing `@Override` annotations, so for now going to suppress the missing annotation to allow compilation across multiple different JDK versions without issue.
+  links:
+  - https://github.com/palantir/tritium/pull/781

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslEngine.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslEngine.java
@@ -342,7 +342,7 @@ class InstrumentedSslEngine extends SSLEngine {
         }
 
         // Override(java9+)
-        @SuppressWarnings("unused")
+        @SuppressWarnings({"MissingOverride", "unused"})
         public String getApplicationProtocol() {
             try {
                 return (String) getApplicationProtocol.invoke(engine);
@@ -352,7 +352,7 @@ class InstrumentedSslEngine extends SSLEngine {
         }
 
         // Override(java9+)
-        @SuppressWarnings("unused")
+        @SuppressWarnings({"MissingOverride", "unused"})
         public String getHandshakeApplicationProtocol() {
             try {
                 return (String) getHandshakeApplicationProtocol.invoke(engine);
@@ -362,7 +362,7 @@ class InstrumentedSslEngine extends SSLEngine {
         }
 
         // Override(java9+)
-        @SuppressWarnings("unused")
+        @SuppressWarnings({"MissingOverride", "unused"})
         public void setHandshakeApplicationProtocolSelector(BiFunction<SSLEngine, List<String>, String> selector) {
             try {
                 setHandshakeApplicationProtocolSelector.invoke(engine, selector);
@@ -372,7 +372,7 @@ class InstrumentedSslEngine extends SSLEngine {
         }
 
         // Override(java9+)
-        @SuppressWarnings({"NoFunctionalReturnType", "unchecked", "unused"})
+        @SuppressWarnings({"NoFunctionalReturnType", "MissingOverride", "unchecked", "unused"})
         public BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector() {
             try {
                 return (BiFunction<SSLEngine, List<String>, String>)


### PR DESCRIPTION
## Before this PR
Building locally with JDK 8u251+ fails with errors below (see also [failed build](https://app.circleci.com/pipelines/github/palantir/tritium/561/workflows/77c54399-db55-4854-a331-9381f1f9b3df/jobs/9306)):

```
com.palantir.tritium.metrics.InstrumentedSslEngine - compileJava
InstrumentedSslEngine.java:346: [MissingOverride] getApplicationProtocol overrides method in SSLEngine; expected @Override
ERROR: [MissingOverride] getApplicationProtocol overrides method in SSLEngine; expected @Override
        public String getApplicationProtocol() {
                      ^
    (see https://errorprone.info/bugpattern/MissingOverride)
  Did you mean '@Override @SuppressWarnings("unused")'?
File: tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslEngine.java
Line: 346
com.palantir.tritium.metrics.InstrumentedSslEngine - compileJava
InstrumentedSslEngine.java:356: [MissingOverride] getHandshakeApplicationProtocol overrides method in SSLEngine; expected @Override
ERROR: [MissingOverride] getHandshakeApplicationProtocol overrides method in SSLEngine; expected @Override
        public String getHandshakeApplicationProtocol() {
                      ^
    (see https://errorprone.info/bugpattern/MissingOverride)
  Did you mean '@Override @SuppressWarnings("unused")'?
File: tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslEngine.java
Line: 356
com.palantir.tritium.metrics.InstrumentedSslEngine - compileJava
InstrumentedSslEngine.java:366: [MissingOverride] setHandshakeApplicationProtocolSelector overrides method in SSLEngine; expected @Override
ERROR: [MissingOverride] setHandshakeApplicationProtocolSelector overrides method in SSLEngine; expected @Override
        public void setHandshakeApplicationProtocolSelector(BiFunction<SSLEngine, List<String>, String> selector) {
                    ^
    (see https://errorprone.info/bugpattern/MissingOverride)
  Did you mean '@Override @SuppressWarnings("unused")'?
File: tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslEngine.java
Line: 366
com.palantir.tritium.metrics.InstrumentedSslEngine - compileJava
InstrumentedSslEngine.java:376: [MissingOverride] getHandshakeApplicationProtocolSelector overrides method in SSLEngine; expected @Override
ERROR: [MissingOverride] getHandshakeApplicationProtocolSelector overrides method in SSLEngine; expected @Override
        public BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector() {
                                                           ^
    (see https://errorprone.info/bugpattern/MissingOverride)
  Did you mean '@Override @SuppressWarnings({"NoFunctionalReturnType", "unchecked", "unused"})'?
File: tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslEngine.java
Line: 376
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Upgrade CircleCI build to JDK 8u252

Suppress JEP 244 SSLEngine overrides
JEP 244: TLS Application-Layer Protocol Negotiation Extension was backported to JDK8u251+ per https://bugs.openjdk.java.net/browse/JDK-8230977 which added 4 methods that were previously only in JDK9+.

Unfortunately this causes problems compiling locally when using JDK 8u251+ as error-prone will flag missing `@Override` annotations, so for now going to suppress the missing annotation to allow compilation across multiple different JDK versions without issue.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

