### PR TITLE
Remove Checkstyle guava version override

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,12 +42,6 @@ allprojects {
         testImplementationClasspath {
             exclude module: 'junit'
         }
-        checkstyle {
-            resolutionStrategy {
-                // checkstyle requires different Guava
-                force 'com.google.guava:guava:25.1-jre'
-            }
-        }
     }
 
     repositories {

--- a/changelog/@unreleased/pr-788.v2.yml
+++ b/changelog/@unreleased/pr-788.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Remove Checkstyle guava version override
+  links:
+  - https://github.com/palantir/tritium/pull/788


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Checkstyle plug-in previously required a specific Guava version to be pinned.

This replaces #786 opened by dependbot 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove Checkstyle guava version override
==COMMIT_MSG==

Closes #786 

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Any future Checkstyle plug-in guava dependency mismatches may require restore a pinned version.
