### PR TITLE
Add `instrument.tls.socket` property to disable handshake metrics using sockets

### DIFF
--- a/changelog/@unreleased/pr-790.v2.yml
+++ b/changelog/@unreleased/pr-790.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add `instrument.tls.socket` property to disable handshake metrics using
+    sockets
+  links:
+  - https://github.com/palantir/tritium/pull/790

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslServerSocketFactory.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslServerSocketFactory.java
@@ -222,7 +222,7 @@ final class InstrumentedSslServerSocketFactory extends SSLServerSocketFactory {
         }
 
         private Socket wrap(Socket socket) {
-            if (socket instanceof SSLSocket) {
+            if (socket instanceof SSLSocket && InstrumentedSslSocketFactory.tlsMetricsEnabled.getAsBoolean()) {
                 ((SSLSocket) socket).addHandshakeCompletedListener(listener);
             }
             return socket;

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslSocketFactory.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslSocketFactory.java
@@ -16,17 +16,20 @@
 
 package com.palantir.tritium.metrics;
 
+import com.palantir.tritium.event.InstrumentationProperties;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.util.Objects;
+import java.util.function.BooleanSupplier;
 import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
 final class InstrumentedSslSocketFactory extends SSLSocketFactory {
 
+    static final BooleanSupplier tlsMetricsEnabled = InstrumentationProperties.getSystemPropertySupplier("tls.socket");
     private final SSLSocketFactory delegate;
     private final HandshakeCompletedListener listener;
     private final String name;
@@ -106,7 +109,7 @@ final class InstrumentedSslSocketFactory extends SSLSocketFactory {
     }
 
     private Socket wrap(Socket socket) {
-        if (socket instanceof SSLSocket) {
+        if (socket instanceof SSLSocket && tlsMetricsEnabled.getAsBoolean()) {
             ((SSLSocket) socket).addHandshakeCompletedListener(listener);
         }
         return socket;


### PR DESCRIPTION
Socket handshake listeners result in a `HandshakeCompleteNotify-Thread`
being created to run the callback rather than running on the same
thread.

Threads are expensive. So are handshakes, we shouldn't do either frequently, but it's possible the latter is occurring enough that the former compounds the problem.

==COMMIT_MSG==
Add `instrument.tls.socket` property to disable handshake metrics using sockets
==COMMIT_MSG==
