### PR TITLE
Do not mock Guava caches in tests

### DIFF
--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/CacheMetricSetTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/CacheMetricSetTest.java
@@ -22,30 +22,23 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricSet;
 import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 @SuppressWarnings({
     "BanGuavaCaches", // this implementation is explicitly for Guava caches
     "NullAway"
 }) // IntelliJ warnings about injected fields
 final class CacheMetricSetTest {
 
-    @Mock
-    Cache<String, String> cache;
+    private final Map<String, Metric> metrics =
+            createCacheMetrics(CacheBuilder.newBuilder().recordStats().build());
 
-    private Map<String, Metric> metrics;
-
-    @BeforeEach
-    void before() {
+    private static Map<String, Metric> createCacheMetrics(Cache<String, String> cache) {
         MetricSet cacheMetricSet = CacheMetricSet.create(cache, "test");
         assertThat(cacheMetricSet).isNotNull();
-        metrics = cacheMetricSet.getMetrics();
+        return cacheMetricSet.getMetrics();
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
#789 [build is failing due to mocked Guava caches](https://app.circleci.com/pipelines/github/palantir/tritium/586/workflows/eac39eea-dd47-4cda-8809-04fd681818c9/jobs/9452/steps).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Do not mock Guava caches in tests

We now use standard Guava caches in unit tests instead of mocks as Guava
caches are marked as DoNotMock by error-prone, see
https://errorprone.info/bugpattern/DoNotMock
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

