### PR TITLE
Socket handshake metrics are not recorded by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ allprojects {
 
     tasks.withType(Test) {
         useJUnitPlatform {
-            includeEngines 'jqwik'
+            includeEngines 'jqwik', 'junit-jupiter'
         }
         maxParallelForks Runtime.getRuntime().availableProcessors()
         testLogging {

--- a/changelog/@unreleased/pr-792.v2.yml
+++ b/changelog/@unreleased/pr-792.v2.yml
@@ -1,0 +1,10 @@
+type: improvement
+improvement:
+  description: |-
+    Socket handshake metrics are not recorded by default to prevent new threads for each handshake
+
+    Metrics and logging can be enabled by either enabling debug logging
+    on `com.palantir.tritium.metrics.HandshakeInstrumentation` or
+    by setting the `instrument.tls.socket` property to `true`.
+  links:
+  - https://github.com/palantir/tritium/pull/792

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/HandshakeInstrumentation.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/HandshakeInstrumentation.java
@@ -17,6 +17,7 @@
 package com.palantir.tritium.metrics;
 
 import com.palantir.logsafe.SafeArg;
+import com.palantir.tritium.event.InstrumentationProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +43,15 @@ final class HandshakeInstrumentation {
                     SafeArg.of("cipherSuite", cipherSuite),
                     SafeArg.of("protocol", protocol));
         }
+    }
+
+    /**
+     * Socket metrics are more expensive than SSLEngine instrumentation due to HandshakeCompletedListener
+     * instances running on a new short-lived thread. When no HandshakeCompletedListeners are registered,
+     * the thread is completely avoided.
+     */
+    static boolean isSocketInstrumentationEnabled() {
+        return log.isDebugEnabled() || InstrumentationProperties.isSpecificEnabled("tls.socket", false);
     }
 
     private HandshakeInstrumentation() {}

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslServerSocketFactory.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslServerSocketFactory.java
@@ -222,7 +222,7 @@ final class InstrumentedSslServerSocketFactory extends SSLServerSocketFactory {
         }
 
         private Socket wrap(Socket socket) {
-            if (socket instanceof SSLSocket && InstrumentedSslSocketFactory.tlsMetricsEnabled.getAsBoolean()) {
+            if (socket instanceof SSLSocket && HandshakeInstrumentation.isSocketInstrumentationEnabled()) {
                 ((SSLSocket) socket).addHandshakeCompletedListener(listener);
             }
             return socket;

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslSocketFactory.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslSocketFactory.java
@@ -16,20 +16,17 @@
 
 package com.palantir.tritium.metrics;
 
-import com.palantir.tritium.event.InstrumentationProperties;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.util.Objects;
-import java.util.function.BooleanSupplier;
 import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
 final class InstrumentedSslSocketFactory extends SSLSocketFactory {
 
-    static final BooleanSupplier tlsMetricsEnabled = InstrumentationProperties.getSystemPropertySupplier("tls.socket");
     private final SSLSocketFactory delegate;
     private final HandshakeCompletedListener listener;
     private final String name;
@@ -109,7 +106,7 @@ final class InstrumentedSslSocketFactory extends SSLSocketFactory {
     }
 
     private Socket wrap(Socket socket) {
-        if (socket instanceof SSLSocket && tlsMetricsEnabled.getAsBoolean()) {
+        if (socket instanceof SSLSocket && HandshakeInstrumentation.isSocketInstrumentationEnabled()) {
             ((SSLSocket) socket).addHandshakeCompletedListener(listener);
         }
         return socket;

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/InstrumentedSslContextTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/InstrumentedSslContextTest.java
@@ -19,6 +19,7 @@ package com.palantir.tritium.metrics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import com.palantir.tritium.event.InstrumentationProperties;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -45,6 +46,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xnio.Options;
 import org.xnio.Sequence;
@@ -56,6 +59,18 @@ final class InstrumentedSslContextTest {
     private static final boolean IS_JAVA_8 = System.getProperty("java.version").startsWith("1.8");
 
     private static final int PORT = 4483;
+
+    @BeforeEach
+    void beforeEach() {
+        System.setProperty("instrument.tls.socket", "true");
+        InstrumentationProperties.reload();
+    }
+
+    @AfterEach
+    void afterEach() {
+        System.clearProperty("instrument.tls.socket");
+        InstrumentationProperties.reload();
+    }
 
     @Test
     void testClientInstrumentationHttpsUrlConnection() throws Exception {

--- a/tritium-tracing/src/test/java/com/palantir/tritium/tracing/TracingInvocationEventHandlerTest.java
+++ b/tritium-tracing/src/test/java/com/palantir/tritium/tracing/TracingInvocationEventHandlerTest.java
@@ -26,7 +26,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.tracing.AlwaysSampler;
 import com.palantir.tracing.AsyncSlf4jSpanObserver;
 import com.palantir.tracing.Tracer;
-import com.palantir.tracing.Tracers;
 import com.palantir.tracing.api.Span;
 import com.palantir.tracing.api.SpanObserver;
 import com.palantir.tritium.event.InvocationContext;
@@ -96,14 +95,14 @@ public class TracingInvocationEventHandlerTest {
         assertThat(context.getArgs()).isEqualTo(args);
         assertThat(context.getStartTimeNanos()).isGreaterThan(startNanoseconds);
         assertThat(context.getStartTimeNanos()).isLessThan(System.nanoTime());
-        assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isNotNull();
+        assertThat(Tracer.hasTraceId()).isTrue();
     }
 
     @Test
     public void testSuccess() {
         InvocationContext context = handler.preInvocation(instance, method, args);
 
-        assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isNotNull();
+        assertThat(Tracer.hasTraceId()).isTrue();
 
         handler.onSuccess(context, null);
 
@@ -112,14 +111,14 @@ public class TracingInvocationEventHandlerTest {
 
         Span span = spanCaptor.getValue();
         assertThat(span.getDurationNanoSeconds()).isGreaterThan(0L);
-        assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isNull();
+        assertThat(Tracer.hasTraceId()).isFalse();
     }
 
     @Test
     public void testFailure() {
         InvocationContext context = handler.preInvocation(instance, method, args);
 
-        assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isNotNull();
+        assertThat(Tracer.hasTraceId()).isTrue();
 
         handler.onFailure(context, new RuntimeException("unexpected"));
 
@@ -128,7 +127,7 @@ public class TracingInvocationEventHandlerTest {
 
         Span span = spanCaptor.getValue();
         assertThat(span.getDurationNanoSeconds()).isGreaterThan(0L);
-        assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isNull();
+        assertThat(Tracer.hasTraceId()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
==COMMIT_MSG==
Socket handshake metrics are not recorded by default to prevent new threads for each handshake

Metrics and logging can be enabled by either enabling debug logging
on `com.palantir.tritium.metrics.HandshakeInstrumentation` or
by setting the `instrument.tls.socket` property to `true`.
==COMMIT_MSG==

## Possible downsides?

Reduced insight into how the system is behaving.
