### PR TITLE
Remove extraneous metrics-core test dependency

### DIFF
--- a/tritium-metrics/build.gradle
+++ b/tritium-metrics/build.gradle
@@ -24,7 +24,6 @@ dependencies {
 
     testImplementation project(':tritium-test')
     testImplementation 'com.squareup.okhttp3:okhttp'
-    testImplementation 'io.dropwizard.metrics:metrics-core'
     testImplementation 'io.undertow:undertow-core'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.awaitility:awaitility'


### PR DESCRIPTION
## Before this PR
Excavator PR https://github.com/palantir/tritium/pull/837 [build fails with unused dependency](https://app.circleci.com/pipelines/github/palantir/tritium/690/workflows/9d963fa7-b4bd-4581-8622-c691b3a70dc6/jobs/10060)
```
org.gradle.api.GradleException: Found 1 dependencies unused during compilation, please delete them from 'tritium-metrics/build.gradle' or choose one of the suggested fixes:
	io.dropwizard.metrics:metrics-core
		Did you mean:
			io.dropwizard.metrics:metrics-core
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove extraneous metrics-core test dependency
==COMMIT_MSG==

## Possible downsides?
Excavator PR #837 just bumped `assertj-core` so the `checkUnusedDependenciesTest` failure seems like a flake. The `testImplementation 'io.dropwizard.metrics:metrics-core'` was previously necessary to satisfy a `checkImplicitDependencies` check but should not have been needed as `tritium-metrics` defines a `api 'io.dropwizard.metrics:metrics-core'` dependency. Seems like `gradle-baseline` may have fixed this, though not sure why `checkUnusedDependenciesTest` wouldn't have failed in that specific `gradle-baseline` bump, so there's likely still some flakes in `checkUnusedDependencies`.

