### PR TITLE
Dependabot uses no changelog label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "no changelog"


### PR DESCRIPTION
## Before this PR
@iamdanfox tried to teach dependabot to set labels in #850 but dependabot is using `.github/dependabot.yml` config per https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Dependabot sets `no changelog` label
==COMMIT_MSG==

## Possible downsides?
I didn't add `merge when ready` yet, wanted to build trust in this robot before it takes over. Dependabot currently only upgrades the gradle dependencies because they are the only ones that express a full versioned coordinate in the source code itself, while all the normal dependencies use `gradle-consistent-versions` & `versions.props`

