### PR TITLE
Implement a lock-free exponential decaying reservoir

### DIFF
--- a/changelog/@unreleased/pr-860.v2.yml
+++ b/changelog/@unreleased/pr-860.v2.yml
@@ -1,5 +1,11 @@
-type: improvement
-improvement:
-  description: Implement a lock-free exponential decaying reservoir
-  links:
-  - https://github.com/palantir/tritium/pull/860
+changes:
+  - type: improvement
+    improvement:
+      description: Implement a lock-free exponential decaying reservoir
+      links:
+      - https://github.com/palantir/tritium/pull/860
+  - type: improvement
+    improvement:
+      description: DefaultTaggedMetricRegistry uses the lock-free exponential decay reservoir for improved performance.
+      links:
+        - https://github.com/palantir/tritium/pull/860

--- a/changelog/@unreleased/pr-860.v2.yml
+++ b/changelog/@unreleased/pr-860.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implement a lock-free exponential decaying reservoir
+  links:
+  - https://github.com/palantir/tritium/pull/860

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/ReservoirBenchmarks.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/ReservoirBenchmarks.java
@@ -56,7 +56,7 @@ public class ReservoirBenchmarks {
         LOCK_FREE_EXPO_DECAY() {
             @Override
             Reservoir create() {
-                return new LockFreeExponentiallyDecayingReservoir();
+                return LockFreeExponentiallyDecayingReservoir.builder().build();
             }
         };
 

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/ReservoirBenchmarks.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/ReservoirBenchmarks.java
@@ -1,0 +1,77 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.microbenchmarks;
+
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
+import com.codahale.metrics.Reservoir;
+import com.palantir.tritium.metrics.registry.LockFreeExponentiallyDecayingReservoir;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(32)
+@State(Scope.Benchmark)
+@SuppressWarnings({"designforextension", "NullAway"})
+public class ReservoirBenchmarks {
+
+    @Param({"EXPO_DECAY", "LOCK_FREE_EXPO_DECAY"})
+    private ReservoirType reservoirType;
+
+    public enum ReservoirType {
+        EXPO_DECAY() {
+            @Override
+            Reservoir create() {
+                return new ExponentiallyDecayingReservoir();
+            }
+        },
+        LOCK_FREE_EXPO_DECAY() {
+            @Override
+            Reservoir create() {
+                return new LockFreeExponentiallyDecayingReservoir();
+            }
+        };
+
+        abstract Reservoir create();
+    }
+
+    private Reservoir reservoir;
+
+    @Setup
+    public void before() {
+        reservoir = reservoirType.create();
+    }
+
+    @Benchmark
+    public void updateReservoir() {
+        reservoir.update(1L);
+    }
+}

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
@@ -16,14 +16,13 @@
 
 package com.palantir.tritium.metrics.registry;
 
-import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.google.auto.service.AutoService;
 
 @AutoService(TaggedMetricRegistry.class)
 public final class DefaultTaggedMetricRegistry extends AbstractTaggedMetricRegistry {
 
     public DefaultTaggedMetricRegistry() {
-        super(ExponentiallyDecayingReservoir::new);
+        super(() -> LockFreeExponentiallyDecayingReservoir.builder().build());
     }
 
     /**

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
@@ -22,9 +22,9 @@ import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.WeightedSnapshot;
 import com.codahale.metrics.WeightedSnapshot.WeightedSample;
 import com.google.common.annotations.Beta;
+import java.time.Duration;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
     private static final int DEFAULT_SIZE = 1028;
     private static final double DEFAULT_ALPHA = 0.015;
-    private static final long DEFAULT_RESCALE_THRESHOLD = TimeUnit.HOURS.toNanos(1);
+    private static final Duration DEFAULT_RESCALE_THRESHOLD = Duration.ofHours(1);
 
     private static final AtomicReferenceFieldUpdater<LockFreeExponentiallyDecayingReservoir, State> stateUpdater =
             AtomicReferenceFieldUpdater.newUpdater(LockFreeExponentiallyDecayingReservoir.class, State.class, "state");
@@ -109,15 +109,15 @@ public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
         this(DEFAULT_SIZE, DEFAULT_ALPHA, DEFAULT_RESCALE_THRESHOLD);
     }
 
-    public LockFreeExponentiallyDecayingReservoir(int size, double alpha, long rescaleThresholdNanos) {
-        this(size, alpha, rescaleThresholdNanos, Clock.defaultClock());
+    public LockFreeExponentiallyDecayingReservoir(int size, double alpha, Duration rescaleThreshold) {
+        this(size, alpha, rescaleThreshold, Clock.defaultClock());
     }
 
-    public LockFreeExponentiallyDecayingReservoir(int size, double alpha, long rescaleThresholdNanos, Clock clock) {
+    public LockFreeExponentiallyDecayingReservoir(int size, double alpha, Duration rescaleThreshold, Clock clock) {
         this.alpha = alpha;
         this.size = size;
         this.clock = clock;
-        this.rescaleThresholdNanos = rescaleThresholdNanos;
+        this.rescaleThresholdNanos = rescaleThreshold.toNanos();
         this.state = new State(clock.getTick(), new AtomicLong(), new ConcurrentSkipListMap<>());
     }
 

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
@@ -51,7 +51,6 @@ public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
     private final long rescaleThresholdNanos;
     private final Clock clock;
 
-    // state
     private volatile State state;
 
     private final class State {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
@@ -122,10 +122,6 @@ public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
         rescaleIfNeeded(now).update(value, now);
     }
 
-    private State rescaleIfNeeded() {
-        return rescaleIfNeeded(clock.getTick());
-    }
-
     private State rescaleIfNeeded(long currentTick) {
         State stateSnapshot = this.state;
         final long lastScaleTick = stateSnapshot.startTick;
@@ -145,7 +141,7 @@ public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
 
     @Override
     public Snapshot getSnapshot() {
-        State stateSnapshot = rescaleIfNeeded();
+        State stateSnapshot = rescaleIfNeeded(clock.getTick());
         return new WeightedSnapshot(stateSnapshot.values.values());
     }
 

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
@@ -21,6 +21,7 @@ import com.codahale.metrics.Reservoir;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.WeightedSnapshot;
 import com.codahale.metrics.WeightedSnapshot.WeightedSample;
+import com.google.common.annotations.Beta;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
  * See {@link com.codahale.metrics.ExponentiallyDecayingReservoir} Copyright 2010-2012 Coda Hale and Yammer, Inc.
  * Licensed under the Apache License, Version 2.0. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
+@Beta
 public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
     private static final int DEFAULT_SIZE = 1028;
     private static final double DEFAULT_ALPHA = 0.015;

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
@@ -168,7 +168,7 @@ public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
 
     public static final class Builder {
         private static final int DEFAULT_SIZE = 1028;
-        private static final double DEFAULT_ALPHA = 0.015;
+        private static final double DEFAULT_ALPHA = 0.015D;
         private static final Duration DEFAULT_RESCALE_THRESHOLD = Duration.ofHours(1);
 
         private int size = DEFAULT_SIZE;
@@ -178,21 +178,34 @@ public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
 
         private Builder() {}
 
+        /**
+         * Maximum number of samples to keep in the reservoir. Once this number is reached older samples are
+         * replaced (based on weight, with some amount of random jitter).
+         */
         public Builder size(int value) {
             this.size = value;
             return this;
         }
 
+        /**
+         * Alpha is the exponential decay factor. Higher values bias results more heavily toward newer values.
+         */
         public Builder alpha(double value) {
             this.alpha = value;
             return this;
         }
 
+        /**
+         * Interval at which this reservoir is rescaled.
+         */
         public Builder rescaleThreshold(Duration value) {
             this.rescaleThreshold = Preconditions.checkNotNull(value, "rescaleThreshold is required");
             return this;
         }
 
+        /**
+         * Clock instance used for decay.
+         */
         public Builder clock(Clock value) {
             this.clock = Preconditions.checkNotNull(value, "clock is required");
             return this;

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
@@ -1,0 +1,165 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.registry;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.WeightedSnapshot;
+import com.codahale.metrics.WeightedSnapshot.WeightedSample;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+/**
+ * {@link LockFreeExponentiallyDecayingReservoir} is based closely on the codahale
+ * <a href="https://github.com/dropwizard/metrics/blob/0313a104bf785e87d7d14a18a82026225304c402/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java">
+ * ExponentiallyDecayingReservoir.java</a>, however it provides looser guarantees (updates which race rescale may be
+ * lost) while completely avoiding locks.
+ *
+ * See {@link com.codahale.metrics.ExponentiallyDecayingReservoir} Copyright 2010-2012 Coda Hale and Yammer, Inc.
+ * Licensed under the Apache License, Version 2.0. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
+    private static final int DEFAULT_SIZE = 1028;
+    private static final double DEFAULT_ALPHA = 0.015;
+    private static final long DEFAULT_RESCALE_THRESHOLD = TimeUnit.HOURS.toNanos(1);
+
+    private static final AtomicReferenceFieldUpdater<LockFreeExponentiallyDecayingReservoir, State> stateUpdater =
+            AtomicReferenceFieldUpdater.newUpdater(LockFreeExponentiallyDecayingReservoir.class, State.class, "state");
+
+    private final double alpha;
+    private final int size;
+    private final long rescaleThresholdNanos;
+    private final Clock clock;
+
+    // state
+    private volatile State state;
+
+    private final class State {
+        private final long startTick;
+        private final AtomicLong count;
+        private final ConcurrentSkipListMap<Double, WeightedSample> values;
+
+        State(long startTick, AtomicLong count, ConcurrentSkipListMap<Double, WeightedSample> values) {
+            this.startTick = startTick;
+            this.values = values;
+            this.count = count;
+        }
+
+        private void update(long value, long timestampNanos) {
+            final double itemWeight = weight(timestampNanos - startTick);
+            final WeightedSample sample = new WeightedSample(value, itemWeight);
+            final double priority = itemWeight / ThreadLocalRandom.current().nextDouble();
+
+            final long newCount = count.incrementAndGet();
+            if (newCount <= size || values.isEmpty()) {
+                values.put(priority, sample);
+            } else {
+                Double first = values.firstKey();
+                if (first < priority && values.putIfAbsent(priority, sample) == null) {
+                    // Always remove an item
+                    while (values.remove(first) == null) {
+                        first = values.firstKey();
+                    }
+                }
+            }
+        }
+
+        State rescale(long newTick) {
+            long durationNanos = newTick - startTick;
+            double durationSeconds = durationNanos / 1_000_000_000D;
+            double scalingFactor = Math.exp(-alpha * durationSeconds);
+            AtomicLong newCount = new AtomicLong();
+            ConcurrentSkipListMap<Double, WeightedSample> newValues = new ConcurrentSkipListMap<>();
+            if (Double.compare(scalingFactor, 0) != 0) {
+                values.forEach((key, sample) -> {
+                    double newWeight = sample.weight * scalingFactor;
+                    if (Double.compare(newWeight, 0) == 0) {
+                        return;
+                    }
+                    WeightedSample newSample = new WeightedSample(sample.value, newWeight);
+                    if (newValues.put(key * scalingFactor, newSample) == null) {
+                        newCount.incrementAndGet();
+                    }
+                });
+            }
+            return new State(newTick, newCount, newValues);
+        }
+    }
+
+    public LockFreeExponentiallyDecayingReservoir() {
+        this(DEFAULT_SIZE, DEFAULT_ALPHA, DEFAULT_RESCALE_THRESHOLD);
+    }
+
+    public LockFreeExponentiallyDecayingReservoir(int size, double alpha, long rescaleThresholdNanos) {
+        this(size, alpha, rescaleThresholdNanos, Clock.defaultClock());
+    }
+
+    public LockFreeExponentiallyDecayingReservoir(int size, double alpha, long rescaleThresholdNanos, Clock clock) {
+        this.alpha = alpha;
+        this.size = size;
+        this.clock = clock;
+        this.rescaleThresholdNanos = rescaleThresholdNanos;
+        this.state = new State(clock.getTick(), new AtomicLong(), new ConcurrentSkipListMap<>());
+    }
+
+    @Override
+    public int size() {
+        return (int) Math.min(size, state.count.get());
+    }
+
+    @Override
+    public void update(long value) {
+        long now = clock.getTick();
+        rescaleIfNeeded(now).update(value, now);
+    }
+
+    private State rescaleIfNeeded() {
+        return rescaleIfNeeded(clock.getTick());
+    }
+
+    private State rescaleIfNeeded(long currentTick) {
+        State stateSnapshot = this.state;
+        final long lastScaleTick = stateSnapshot.startTick;
+        if (currentTick - lastScaleTick >= rescaleThresholdNanos) {
+            State newState = stateSnapshot.rescale(currentTick);
+            if (stateUpdater.compareAndSet(this, stateSnapshot, newState)) {
+                // newState successfully installed
+                return newState;
+            }
+            // Otherwise another thread has won the race and we can return the result of a volatile read.
+            // It's possible this has taken so long that another update is required, however that's unlikely
+            // and no worse than the standard race between a rescale and update.
+            return this.state;
+        }
+        return stateSnapshot;
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        State stateSnapshot = rescaleIfNeeded();
+        return new WeightedSnapshot(stateSnapshot.values.values());
+    }
+
+    private double weight(long durationNanos) {
+        double durationSeconds = durationNanos / 1_000_000_000D;
+        return Math.exp(alpha * durationSeconds);
+    }
+}

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoirTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoirTest.java
@@ -1,0 +1,415 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.registry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.Timer.Context;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link LockFreeExponentiallyDecayingReservoirTest} is based closely on the codahale
+ * <a href="https://github.com/dropwizard/metrics/blob/a314e903d7ba3c5ec47ee7c9103d73ed09a20bd6/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java">
+ * ExponentiallyDecayingReservoirTest.java</a>.
+ *
+ * See {@code ExponentiallyDecayingReservoirTest.java} Licensed under the Apache License, Version 2.0. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+class LockFreeExponentiallyDecayingReservoirTest {
+
+    @Test
+    public void aReservoirOf100OutOf1000Elements() {
+        LockFreeExponentiallyDecayingReservoir reservoir =
+                new LockFreeExponentiallyDecayingReservoir(100, 0.99, TimeUnit.HOURS.toNanos(1));
+        for (int i = 0; i < 1000; i++) {
+            reservoir.update(i);
+        }
+
+        assertThat(reservoir.size()).isEqualTo(100);
+
+        Snapshot snapshot = reservoir.getSnapshot();
+
+        assertThat(snapshot.size()).isEqualTo(100);
+
+        assertAllValuesBetween(reservoir, 0, 1000);
+    }
+
+    @Test
+    public void aReservoirOf100OutOf10Elements() {
+        LockFreeExponentiallyDecayingReservoir reservoir =
+                new LockFreeExponentiallyDecayingReservoir(100, 0.99, TimeUnit.HOURS.toNanos(1));
+        for (int i = 0; i < 10; i++) {
+            reservoir.update(i);
+        }
+
+        Snapshot snapshot = reservoir.getSnapshot();
+
+        assertThat(snapshot.size()).isEqualTo(10);
+
+        assertThat(snapshot.size()).isEqualTo(10);
+
+        assertAllValuesBetween(reservoir, 0, 10);
+    }
+
+    @Test
+    public void aHeavilyBiasedReservoirOf100OutOf1000Elements() {
+        LockFreeExponentiallyDecayingReservoir reservoir =
+                new LockFreeExponentiallyDecayingReservoir(1000, 0.01, TimeUnit.HOURS.toNanos(1));
+        for (int i = 0; i < 100; i++) {
+            reservoir.update(i);
+        }
+
+        assertThat(reservoir.size()).isEqualTo(100);
+
+        Snapshot snapshot = reservoir.getSnapshot();
+
+        assertThat(snapshot.size()).isEqualTo(100);
+
+        assertAllValuesBetween(reservoir, 0, 100);
+    }
+
+    @Test
+    public void longPeriodsOfInactivityShouldNotCorruptSamplingState() {
+        ManualClock clock = new ManualClock();
+        LockFreeExponentiallyDecayingReservoir reservoir =
+                new LockFreeExponentiallyDecayingReservoir(10, 0.15, TimeUnit.HOURS.toNanos(1), clock);
+
+        // add 1000 values at a rate of 10 values/second
+        for (int i = 0; i < 1000; i++) {
+            reservoir.update(1000 + i);
+            clock.addMillis(100);
+        }
+        assertThat(reservoir.getSnapshot().size()).isEqualTo(10);
+        assertAllValuesBetween(reservoir, 1000, 2000);
+
+        // wait for 15 hours and add another value.
+        // this should trigger a rescale. Note that the number of samples will be reduced to 1
+        // because scaling factor equal to zero will remove all existing entries after rescale.
+        clock.addHours(15);
+        reservoir.update(2000);
+        assertThat(reservoir.getSnapshot().size()).isEqualTo(1);
+        assertAllValuesBetween(reservoir, 1000, 2001);
+
+        // add 1000 values at a rate of 10 values/second
+        for (int i = 0; i < 1000; i++) {
+            reservoir.update(3000 + i);
+            clock.addMillis(100);
+        }
+        assertThat(reservoir.getSnapshot().size()).isEqualTo(10);
+        assertAllValuesBetween(reservoir, 3000, 4000);
+    }
+
+    @Test
+    public void longPeriodsOfInactivity_fetchShouldResample() {
+        ManualClock clock = new ManualClock();
+        LockFreeExponentiallyDecayingReservoir reservoir =
+                new LockFreeExponentiallyDecayingReservoir(10, 0.015, TimeUnit.HOURS.toNanos(1), clock);
+
+        // add 1000 values at a rate of 10 values/second
+        for (int i = 0; i < 1000; i++) {
+            reservoir.update(1000 + i);
+            clock.addMillis(100);
+        }
+        assertThat(reservoir.getSnapshot().size()).isEqualTo(10);
+        assertAllValuesBetween(reservoir, 1000, 2000);
+
+        // wait for 20 hours and take snapshot.
+        // this should trigger a rescale. Note that the number of samples will be reduced to 0
+        // because scaling factor equal to zero will remove all existing entries after rescale.
+        clock.addHours(20);
+        Snapshot snapshot = reservoir.getSnapshot();
+        assertThat(snapshot.getMax()).isEqualTo(0);
+        assertThat(snapshot.getMean()).isEqualTo(0);
+        assertThat(snapshot.getMedian()).isEqualTo(0);
+        assertThat(snapshot.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void emptyReservoirSnapshot_shouldReturnZeroForAllValues() {
+        LockFreeExponentiallyDecayingReservoir reservoir =
+                new LockFreeExponentiallyDecayingReservoir(100, 0.015, TimeUnit.HOURS.toNanos(1), new ManualClock());
+
+        Snapshot snapshot = reservoir.getSnapshot();
+        assertThat(snapshot.getMax()).isEqualTo(0);
+        assertThat(snapshot.getMean()).isEqualTo(0);
+        assertThat(snapshot.getMedian()).isEqualTo(0);
+        assertThat(snapshot.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void removeZeroWeightsInSamplesToPreventNaNInMeanValues() {
+        ManualClock clock = new ManualClock();
+        LockFreeExponentiallyDecayingReservoir reservoir =
+                new LockFreeExponentiallyDecayingReservoir(1028, 0.015, TimeUnit.HOURS.toNanos(1), clock);
+        Timer timer = new Timer(reservoir, clock);
+
+        Context context = timer.time();
+        clock.addMillis(100);
+        context.stop();
+
+        for (int i = 1; i < 48; i++) {
+            clock.addHours(1);
+            assertThat(reservoir.getSnapshot().getMean()).isBetween(0.0, Double.MAX_VALUE);
+        }
+    }
+
+    @Test
+    public void multipleUpdatesAfterlongPeriodsOfInactivityShouldNotCorruptSamplingState() throws Exception {
+        // This test illustrates the potential race condition in rescale that
+        // can lead to a corrupt state.  Note that while this test uses updates
+        // exclusively to trigger the race condition, two concurrent updates
+        // may be made much more likely to trigger this behavior if executed
+        // while another thread is constructing a snapshot of the reservoir;
+        // that thread then holds the read lock when the two competing updates
+        // are executed and the race condition's window is substantially
+        // expanded.
+
+        // Run the test several times.
+        for (int attempt = 0; attempt < 10; attempt++) {
+            ManualClock clock = new ManualClock();
+            LockFreeExponentiallyDecayingReservoir reservoir =
+                    new LockFreeExponentiallyDecayingReservoir(10, 0.015, TimeUnit.HOURS.toNanos(1), clock);
+
+            // Various atomics used to communicate between this thread and the
+            // thread created below.
+            AtomicBoolean running = new AtomicBoolean(true);
+            AtomicInteger threadUpdates = new AtomicInteger(0);
+            AtomicInteger testUpdates = new AtomicInteger(0);
+
+            Thread thread = new Thread(() -> {
+                int previous = 0;
+                while (running.get()) {
+                    // Wait for the test thread to update it's counter
+                    // before updaing the reservoir.
+                    while (true) {
+                        int next = testUpdates.get();
+                        if (previous < next) {
+                            previous = next;
+                            break;
+                        }
+                    }
+
+                    // Update the reservoir.  This needs to occur at the
+                    // same time as the test thread's update.
+                    reservoir.update(1000);
+
+                    // Signal the main thread; allows the next update
+                    // attempt to begin.
+                    threadUpdates.incrementAndGet();
+                }
+            });
+
+            thread.start();
+
+            int sum = 0;
+            int previous = -1;
+            for (int i = 0; i < 100; i++) {
+                // Wait for 15 hours before attempting the next concurrent
+                // update.  The delay here needs to be sufficiently long to
+                // overflow if an update attempt is allowed to add a value to
+                // the reservoir without rescaling.  Note that:
+                // e(alpha*(15*60*60)) =~ 10^351 >> Double.MAX_VALUE =~ 1.8*10^308.
+                clock.addHours(15);
+
+                // Signal the other thread; asynchronously updates the reservoir.
+                testUpdates.incrementAndGet();
+
+                // Delay a variable length of time.  Without a delay here this
+                // thread is heavily favored and the race condition is almost
+                // never observed.
+                for (int j = 0; j < i; j++) {
+                    sum += j;
+                }
+
+                // Competing reservoir update.
+                reservoir.update(1000);
+
+                // Wait for the other thread to finish it's update.
+                while (true) {
+                    int next = threadUpdates.get();
+                    if (previous < next) {
+                        previous = next;
+                        break;
+                    }
+                }
+            }
+
+            // Terminate the thread.
+            running.set(false);
+            testUpdates.incrementAndGet();
+            thread.join();
+
+            // Test failures will result in normWeights that are not finite;
+            // checking the mean value here is sufficient.
+            assertThat(reservoir.getSnapshot().getMean()).isBetween(0.0, Double.MAX_VALUE);
+
+            // Check the value of sum; should prevent the JVM from optimizing
+            // out the delay loop entirely.
+            assertThat(sum).isEqualTo(161700);
+        }
+    }
+
+    @Test
+    public void spotLift() {
+        ManualClock clock = new ManualClock();
+        LockFreeExponentiallyDecayingReservoir reservoir =
+                new LockFreeExponentiallyDecayingReservoir(1000, 0.015, TimeUnit.HOURS.toNanos(1), clock);
+
+        int valuesRatePerMinute = 10;
+        int valuesIntervalMillis = (int) (TimeUnit.MINUTES.toMillis(1) / valuesRatePerMinute);
+        // mode 1: steady regime for 120 minutes
+        for (int i = 0; i < 120 * valuesRatePerMinute; i++) {
+            reservoir.update(177);
+            clock.addMillis(valuesIntervalMillis);
+        }
+
+        // switching to mode 2: 10 minutes more with the same rate, but larger value
+        for (int i = 0; i < 10 * valuesRatePerMinute; i++) {
+            reservoir.update(9999);
+            clock.addMillis(valuesIntervalMillis);
+        }
+
+        // expect that quantiles should be more about mode 2 after 10 minutes
+        assertThat(reservoir.getSnapshot().getMedian()).isEqualTo(9999);
+    }
+
+    @Test
+    public void spotFall() {
+        ManualClock clock = new ManualClock();
+        LockFreeExponentiallyDecayingReservoir reservoir =
+                new LockFreeExponentiallyDecayingReservoir(1000, 0.015, TimeUnit.HOURS.toNanos(1), clock);
+
+        int valuesRatePerMinute = 10;
+        int valuesIntervalMillis = (int) (TimeUnit.MINUTES.toMillis(1) / valuesRatePerMinute);
+        // mode 1: steady regime for 120 minutes
+        for (int i = 0; i < 120 * valuesRatePerMinute; i++) {
+            reservoir.update(9998);
+            clock.addMillis(valuesIntervalMillis);
+        }
+
+        // switching to mode 2: 10 minutes more with the same rate, but smaller value
+        for (int i = 0; i < 10 * valuesRatePerMinute; i++) {
+            reservoir.update(178);
+            clock.addMillis(valuesIntervalMillis);
+        }
+
+        // expect that quantiles should be more about mode 2 after 10 minutes
+        assertThat(reservoir.getSnapshot().get95thPercentile()).isEqualTo(178);
+    }
+
+    @Test
+    public void quantiliesShouldBeBasedOnWeights() {
+        ManualClock clock = new ManualClock();
+        LockFreeExponentiallyDecayingReservoir reservoir =
+                new LockFreeExponentiallyDecayingReservoir(1000, 0.015, TimeUnit.HOURS.toNanos(1), clock);
+        for (int i = 0; i < 40; i++) {
+            reservoir.update(177);
+        }
+
+        clock.addSeconds(120);
+
+        for (int i = 0; i < 10; i++) {
+            reservoir.update(9999);
+        }
+
+        assertThat(reservoir.getSnapshot().size()).isEqualTo(50);
+
+        // the first added 40 items (177) have weights 1
+        // the next added 10 items (9999) have weights ~6
+        // so, it's 40 vs 60 distribution, not 40 vs 10
+        assertThat(reservoir.getSnapshot().getMedian()).isEqualTo(9999);
+        assertThat(reservoir.getSnapshot().get75thPercentile()).isEqualTo(9999);
+    }
+
+    @Test
+    public void clockWrapShouldNotRescale() {
+        // First verify the test works as expected given low values
+        testShortPeriodShouldNotRescale(0);
+        // Now revalidate using an edge case nanoTime value just prior to wrapping
+        testShortPeriodShouldNotRescale(Long.MAX_VALUE - TimeUnit.MINUTES.toNanos(30));
+    }
+
+    private static void testShortPeriodShouldNotRescale(long startTimeNanos) {
+        ManualClock clock = new ManualClock(startTimeNanos);
+        LockFreeExponentiallyDecayingReservoir reservoir =
+                new LockFreeExponentiallyDecayingReservoir(10, 1, TimeUnit.HOURS.toNanos(1), clock);
+
+        reservoir.update(1000);
+        assertThat(reservoir.getSnapshot().size()).isEqualTo(1);
+
+        assertAllValuesBetween(reservoir, 1000, 1001);
+
+        // wait for 10 millis and take snapshot.
+        // this should not trigger a rescale. Note that the number of samples will be reduced to 0
+        // because scaling factor equal to zero will remove all existing entries after rescale.
+        clock.addSeconds(20 * 60);
+        Snapshot snapshot = reservoir.getSnapshot();
+        assertThat(snapshot.getMax()).isEqualTo(1000);
+        assertThat(snapshot.getMean()).isEqualTo(1000);
+        assertThat(snapshot.getMedian()).isEqualTo(1000);
+        assertThat(snapshot.size()).isEqualTo(1);
+    }
+
+    private static void assertAllValuesBetween(Reservoir reservoir, double min, double max) {
+        for (double i : reservoir.getSnapshot().getValues()) {
+            assertThat(i).isLessThan(max).isGreaterThanOrEqualTo(min);
+        }
+    }
+
+    private static final class ManualClock extends Clock {
+        private final long initialTicksInNanos;
+        long ticksInNanos;
+
+        ManualClock(long initialTicksInNanos) {
+            this.initialTicksInNanos = initialTicksInNanos;
+            this.ticksInNanos = initialTicksInNanos;
+        }
+
+        ManualClock() {
+            this(0L);
+        }
+
+        synchronized void addSeconds(long seconds) {
+            ticksInNanos += TimeUnit.SECONDS.toNanos(seconds);
+        }
+
+        synchronized void addMillis(long millis) {
+            ticksInNanos += TimeUnit.MILLISECONDS.toNanos(millis);
+        }
+
+        synchronized void addHours(long hours) {
+            ticksInNanos += TimeUnit.HOURS.toNanos(hours);
+        }
+
+        @Override
+        public synchronized long getTick() {
+            return ticksInNanos;
+        }
+
+        @Override
+        public synchronized long getTime() {
+            return TimeUnit.NANOSECONDS.toMillis(ticksInNanos - initialTicksInNanos);
+        }
+    }
+}


### PR DESCRIPTION
This solves both the nanotime issue reported in
https://github.com/dropwizard/metrics/pull/1654 as well
as correctness issues when the system clock changes in the original
implementation as this one only uses the precise clock.

More importantly, unexpected errors (OME, ThreadDeath, etc) cannot leave
this reservoir in a blocked state because it has no locks. If a thread
is descheduled while rescaling, another thread may complete the task
first.

This Reservoir allows us to specify a rescale threshold rather than
the hard coded 1-hour threshold.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Implement a lock-free exponential decaying reservoir
==COMMIT_MSG==

## Possible downsides?
More code to maintain, could have bugs, but it can't block entire applications!

## Benchmarks

```
Benchmark                                 (reservoirType)  Mode  Cnt     Score      Error  Units
ReservoirBenchmarks.updateReservoir            EXPO_DECAY  avgt    5  8235.861 ± 1306.404  ns/op
ReservoirBenchmarks.updateReservoir  LOCK_FREE_EXPO_DECAY  avgt    5   758.315 ±   36.916  ns/op
```