### PR TITLE
Enable JDK 11 and 15 test runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,57 @@ jobs:
       - store_test_results: { path: ~/junit }
       - store_artifacts: { path: ~/artifacts }
 
+  unit-test-11:
+    docker: [{ image: 'circleci/openjdk:11-node' }]
+    resource_class: large
+    environment:
+      CIRCLE_TEST_REPORTS: /home/circleci/junit
+      CIRCLE_ARTIFACTS: /home/circleci/artifacts
+      GRADLE_OPTS: -Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=256m' -Dorg.gradle.workers.max=4
+      _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -Xmx1177m -XX:MaxMetaspaceSize=512m  -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
+    steps:
+      - checkout
+      - restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
+      - restore_cache: { key: 'unit-test-11-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
+      - run: ./gradlew --parallel --stacktrace --continue test -Pcom.palantir.baseline-error-prone.disable
+      - save_cache:
+          key: 'unit-test-11-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'
+          paths: [ ~/.gradle/caches ]
+      - run:
+          command: mkdir -p ~/junit && find . -type f -regex ".*/build/.*TEST.*xml" -exec cp --parents {} ~/junit/ \;
+          when: always
+      - store_test_results: { path: ~/junit }
+      - store_artifacts: { path: ~/artifacts }
+
+  unit-test-15:
+    docker: [{ image: 'circleci/openjdk:11-node' }]
+    resource_class: large
+    environment:
+      CIRCLE_TEST_REPORTS: /home/circleci/junit
+      CIRCLE_ARTIFACTS: /home/circleci/artifacts
+      GRADLE_OPTS: -Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=256m' -Dorg.gradle.workers.max=4
+      _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -Xmx1177m -XX:MaxMetaspaceSize=512m  -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
+      JAVA_HOME: /opt/java15
+    steps:
+      - checkout
+      - run:
+          name: Install Java
+          command: |
+            sudo mkdir -p /opt/java && cd /opt/java && sudo chown -R circleci:circleci .
+            curl https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-linux_x64.tar.gz | tar -xzf - -C /opt/java
+            sudo ln -s /opt/java/zulu*/ /opt/java15
+      - restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
+      - restore_cache: { key: 'unit-test-15-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
+      - run: ./gradlew --parallel --stacktrace --continue test -Pcom.palantir.baseline-error-prone.disable
+      - save_cache:
+          key: 'unit-test-15-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'
+          paths: [ ~/.gradle/caches ]
+      - run:
+          command: mkdir -p ~/junit && find . -type f -regex ".*/build/.*TEST.*xml" -exec cp --parents {} ~/junit/ \;
+          when: always
+      - store_test_results: { path: ~/junit }
+      - store_artifacts: { path: ~/artifacts }
+
 
   unit-test-14:
     docker: [{ image: 'circleci/openjdk:11-node' }]
@@ -181,6 +232,12 @@ workflows:
           requires: [ compile ]
           filters: { tags: { only: /.*/ } }
 
+      - unit-test-11:
+          filters: { tags: { only: /.*/ } }
+
+      - unit-test-15:
+          filters: { tags: { only: /.*/ } }
+
       - unit-test-14:
           filters: { tags: { only: /.*/ } }
 
@@ -196,5 +253,5 @@ workflows:
           filters: { branches: { ignore: develop } }
 
       - publish:
-          requires: [ unit-test, unit-test-14, check, trial-publish ]
+          requires: [ unit-test, unit-test-11, unit-test-15, unit-test-14, check, trial-publish ]
           filters: { tags: { only: /.*/ }, branches: { only: develop } }

--- a/.circleci/template.sh
+++ b/.circleci/template.sh
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
 export CIRCLECI_TEMPLATE=java-library-oss
+export JAVA_11=true
+export UNIT_TEST_15=true


### PR DESCRIPTION
## Before this PR
Generated circle config includes end-of-life JDK 14 unit tests, but doesn't run tests on JDK 11 or 15.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Enable JDK 11 and 15 test runs
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

