### PR TITLE
Update the LockFreeExponentiallyDecayingReservoir based on upstream feedback

### DIFF
--- a/changelog/@unreleased/pr-865.v2.yml
+++ b/changelog/@unreleased/pr-865.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Update the LockFreeExponentiallyDecayingReservoir based on upstream
+    feedback
+  links:
+  - https://github.com/palantir/tritium/pull/865

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
@@ -57,7 +57,7 @@ import java.util.function.BiConsumer;
 @Beta
 public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
 
-    private static final double SECONDS_PER_NANO = .000000001D;
+    private static final double SECONDS_PER_NANO = .000_000_001D;
     private static final AtomicReferenceFieldUpdater<LockFreeExponentiallyDecayingReservoir, State> stateUpdater =
             AtomicReferenceFieldUpdater.newUpdater(LockFreeExponentiallyDecayingReservoir.class, State.class, "state");
 

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
@@ -157,9 +157,6 @@ public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
     private LockFreeExponentiallyDecayingReservoir(int size, double alpha, Duration rescaleThreshold, Clock clock) {
         // Scale alpha to nanoseconds
         this.alphaNanos = alpha * SECONDS_PER_NANO;
-        if (Double.compare(alphaNanos, 0) == 0) {
-            throw new IllegalArgumentException("Alpha value " + alpha + " is to small to be scaled to nanoseconds");
-        }
         this.size = size;
         this.clock = clock;
         this.rescaleThresholdNanos = rescaleThreshold.toNanos();


### PR DESCRIPTION
Before:
```
ReservoirBenchmarks.updateReservoir  LOCK_FREE_EXPO_DECAY  avgt    5   758.315 ±   36.916  ns/op
```

After:
```
ReservoirBenchmarks.updateReservoir  LOCK_FREE_EXPO_DECAY  avgt    5    72.031 ±    2.393  ns/op
```

This improvement is a consequence of avoiding CAS operations on the
counter in the fast path, when sample priority is too low to track.

==COMMIT_MSG==
Update the LockFreeExponentiallyDecayingReservoir based on upstream feedback
==COMMIT_MSG==

Upstream PR: https://github.com/dropwizard/metrics/pull/1656
