### PR TITLE
Update LockFreeExponentiallyDecayingReservoir based on upstream feedback

### DIFF
--- a/changelog/@unreleased/pr-867.v2.yml
+++ b/changelog/@unreleased/pr-867.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Update LockFreeExponentiallyDecayingReservoir based on upstream feedback
+  links:
+  - https://github.com/palantir/tritium/pull/867


### PR DESCRIPTION
Latest set of changes from https://github.com/dropwizard/metrics/pull/1656

Benchmark results with 32 threads:
```
Benchmark                                 (reservoirType)  Mode  Cnt     Score      Error  Units
ReservoirBenchmarks.updateReservoir            EXPO_DECAY  avgt    5  8362.404 ± 1556.259  ns/op
ReservoirBenchmarks.updateReservoir  LOCK_FREE_EXPO_DECAY  avgt    5    68.769 ±    1.325  ns/op
```

Benchmark results with a single thread:
```
Benchmark                                 (reservoirType)  Mode  Cnt   Score   Error  Units
ReservoirBenchmarks.updateReservoir            EXPO_DECAY  avgt    5  82.767 ± 1.393  ns/op
ReservoirBenchmarks.updateReservoir  LOCK_FREE_EXPO_DECAY  avgt    5  40.086 ± 0.330  ns/op
```

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update LockFreeExponentiallyDecayingReservoir based on upstream feedback
==COMMIT_MSG==

