### PR TITLE
Fix LockFreeExponentiallyDecayingReservoir potential race

### DIFF
--- a/changelog/@unreleased/pr-869.v2.yml
+++ b/changelog/@unreleased/pr-869.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix LockFreeExponentiallyDecayingReservoir potential race allowing
+    additional samples to be retained on rescale
+  links:
+  - https://github.com/palantir/tritium/pull/869

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
@@ -132,15 +132,19 @@ public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
         State rescale(long newTick) {
             long durationNanos = newTick - startTick;
             double scalingFactor = Math.exp(-alphaNanos * durationNanos);
-            final int newCount;
+            int newCount = 0;
             ConcurrentSkipListMap<Double, WeightedSample> newValues = new ConcurrentSkipListMap<>();
             if (Double.compare(scalingFactor, 0) != 0) {
                 RescalingConsumer consumer = new RescalingConsumer(scalingFactor, newValues);
                 values.forEach(consumer);
                 // make sure the counter is in sync with the number of stored samples.
                 newCount = consumer.count;
-            } else {
-                newCount = 0;
+            }
+            // It's possible that more values were added while the map was scanned, those with the
+            // minimum priorities are removed.
+            while (newCount > size) {
+                newValues.pollFirstEntry();
+                newCount--;
             }
             return new State(alphaNanos, size, newTick, newCount, newValues);
         }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
@@ -143,7 +143,7 @@ public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
             // It's possible that more values were added while the map was scanned, those with the
             // minimum priorities are removed.
             while (newCount > size) {
-                newValues.pollFirstEntry();
+                Preconditions.checkNotNull(newValues.pollFirstEntry(), "Expected an entry");
                 newCount--;
             }
             return new State(alphaNanos, size, newTick, newCount, newValues);


### PR DESCRIPTION
Fix a potential race in which the values map could grow beyond the
upper bound when it is rescaled. This is unlikely, however over
the course of months/years it's possible it could increase memory
pressure.

==COMMIT_MSG==
Fix LockFreeExponentiallyDecayingReservoir potential race allowing additional samples to be retained on rescale
==COMMIT_MSG==

