### PR TITLE
HasBeenUpdatedCounter allows differentiating the getCount() = 0 case

### DIFF
--- a/changelog/@unreleased/pr-872.v2.yml
+++ b/changelog/@unreleased/pr-872.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Creating a counter in a TaggedMetricRegistry will now provide a `HasBeenUpdatedCounter`
+    instance, which allows users to differentiate whether the counter has ever been
+    updated and avoid writing down the count=0 case.
+  links:
+  - https://github.com/palantir/tritium/pull/872

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AbstractTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AbstractTaggedMetricRegistry.java
@@ -63,7 +63,7 @@ public abstract class AbstractTaggedMetricRegistry implements TaggedMetricRegist
     @Nonnull
     @SuppressWarnings("NoFunctionalReturnType") // metric factory
     protected Supplier<Counter> counterSupplier() {
-        return Counter::new;
+        return HasBeenUpdatedCounter::new;
     }
 
     /**

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/HasBeenUpdatedCounter.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/HasBeenUpdatedCounter.java
@@ -23,9 +23,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class HasBeenUpdatedCounter extends Counter {
     private volatile boolean hasBeenUpdated = false;
 
-    HasBeenUpdatedCounter() {
-        super();
-    }
+    HasBeenUpdatedCounter() {}
 
     /**
      * Returns false if this counter has never been interacted with, allowing users to differentiate whether
@@ -42,9 +40,9 @@ public final class HasBeenUpdatedCounter extends Counter {
     }
 
     @Override
-    public void inc(long n) {
+    public void inc(long num) {
         hasBeenUpdated = true;
-        super.inc(n);
+        super.inc(num);
     }
 
     @Override
@@ -53,8 +51,8 @@ public final class HasBeenUpdatedCounter extends Counter {
     }
 
     @Override
-    public void dec(long n) {
+    public void dec(long num) {
         hasBeenUpdated = true;
-        super.dec(n);
+        super.dec(num);
     }
 }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/HasBeenUpdatedCounter.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/HasBeenUpdatedCounter.java
@@ -17,18 +17,17 @@
 package com.palantir.tritium.metrics.registry;
 
 import com.codahale.metrics.Counter;
-import javax.annotation.concurrent.ThreadSafe;
 
-@ThreadSafe
 public final class HasBeenUpdatedCounter extends Counter {
-    private volatile boolean hasBeenUpdated = false;
+
+    private boolean hasBeenUpdated = false;
 
     HasBeenUpdatedCounter() {}
 
     /**
      * Returns false if this counter has never been interacted with, allowing users to differentiate whether
-     * {#getCount} returns 0 because the Counter has never been touched from the case where it has been incremented
-     * and then decremented.
+     * {#getCount} returns 0 because the Counter has never been touched or whether it has been incremented
+     * and then decremented back down to 0.
      */
     public boolean hasBeenUpdated() {
         return hasBeenUpdated;

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/HasBeenUpdatedCounter.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/HasBeenUpdatedCounter.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.registry;
+
+import com.codahale.metrics.Counter;
+import javax.annotation.concurrent.ThreadSafe;
+
+@ThreadSafe
+public final class HasBeenUpdatedCounter extends Counter {
+    private volatile boolean hasBeenUpdated = false;
+
+    HasBeenUpdatedCounter() {
+        super();
+    }
+
+    /**
+     * Returns false if this counter has never been interacted with, allowing users to differentiate whether
+     * {#getCount} returns 0 because the Counter has never been touched from the case where it has been incremented
+     * and then decremented.
+     */
+    public boolean hasBeenUpdated() {
+        return hasBeenUpdated;
+    }
+
+    @Override
+    public void inc() {
+        inc(1);
+    }
+
+    @Override
+    public void inc(long n) {
+        hasBeenUpdated = true;
+        super.inc(n);
+    }
+
+    @Override
+    public void dec() {
+        dec(1);
+    }
+
+    @Override
+    public void dec(long n) {
+        hasBeenUpdated = true;
+        super.dec(n);
+    }
+}

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistryTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistryTest.java
@@ -211,7 +211,7 @@ final class TaggedMetricRegistryTest {
                 .isThrownBy(() -> registry.timer(METRIC_1))
                 .withMessageStartingWith("Metric name already used for different metric type: ")
                 .withMessageContaining("metricName=name")
-                .withMessageContaining("existingMetricType=Counter")
+                .withMessageContaining("existingMetricType=" + HasBeenUpdatedCounter.class.getSimpleName())
                 .withMessageContaining("newMetricType=Timer")
                 .withMessageContaining("safeTags={}");
     }


### PR DESCRIPTION
## Before this PR

Internally, we try to reduce the DD$ cost by not writing down metrics until they've recorded an interaction using the following snippet:

```java
    static boolean metricHasNeverBeenUpdated(Metric metric) {
        if (metric instanceof Meter || metric instanceof Histogram || metric instanceof Timer) {
            return ((Counting) metric).getCount() == 0L;
        } else {
            // intentionally not including Counters because .inc().dec() is indistinguishable from never updated
            // we always want to report gauges
            return false;
        }
    }
```

In Dialogue, we're considering lazily constructing Counters to achieve this same outcome, of avoiding writing down `count=0` lines until the counter is actually interacted with.  I figured it might be worth just applying this optimization to _all_ counters.

## After this PR
==COMMIT_MSG==
Creating a counter in a TaggedMetricRegistry will now provide a `HasBeenUpdatedCounter` instance, which allows users to differentiate whether the counter has ever been updated and avoid writing down the count=0 case.
==COMMIT_MSG==

Hopefully this should save some DD $ for every counter that is never used, while also allowing us to write slightly simpler code in dialogue.

## Possible downsides?
- teeny performance hit, every time you interact with a counter it will now involve a write to a boolean.
- Like our other meters, histograms and timers, this PR might make graphs of Counters look a bit funny across restarts, because there won't be a count=0 point immediately after startup, so DD will have to draw a line from the last non-zero point to the first non-zero point.
<!-- Please describe any way users could be negatively affected by this PR. -->

