### PR TITLE
Simplify error-prone configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,12 +76,6 @@ allprojects {
                 disableWarningsInGeneratedCode = true
                 excludedPaths = '.*(generated).*'
 
-                errorproneArgs.addAll([
-                    '-Werror',
-                    '-Xlint:deprecation',
-                    '-Xlint:unchecked',
-                ])
-
                 option('NullAway:AnnotatedPackages', 'com.palantir')
 
                 // warnings not explicitly provided by error-prone

--- a/build.gradle
+++ b/build.gradle
@@ -71,46 +71,37 @@ allprojects {
                 '-Xlint:deprecation',
                 '-Xlint:unchecked',
             ]
-            options.errorprone.disableWarningsInGeneratedCode = true
-            options.errorprone.errorproneArgs.addAll([
-                '-Werror',
-                '-Xlint:deprecation',
-                '-Xlint:unchecked',
-                '-XepDisableWarningsInGeneratedCode',
-                '-XepExcludedPaths:.*(generated).*',
-                '-XepOpt:NullAway:AnnotatedPackages=com.palantir',
-            ])
 
-            // warnings not explicitly provided by error-prone
-            Set<String> warningsToPromote = [
-                'NullAway',
-                'Slf4jLogsafeArgs',
-                'PreferCollectionTransform',
-                'PreferListsPartition',
-                'PreferSafeLoggingPreconditions',
-                'PreferSafeLoggableExceptions',
-            ]
+            options.errorprone {
+                disableWarningsInGeneratedCode = true
+                excludedPaths = '.*(generated).*'
 
-            com.google.errorprone.scanner.BuiltInCheckerSuppliers.ENABLED_WARNINGS.forEach {
-                check -> warningsToPromote << check.canonicalName()
+                errorproneArgs.addAll([
+                    '-Werror',
+                    '-Xlint:deprecation',
+                    '-Xlint:unchecked',
+                ])
+
+                option('NullAway:AnnotatedPackages', 'com.palantir')
+
+                // warnings not explicitly provided by error-prone
+                error 'NullAway',
+                    'Slf4jLogsafeArgs',
+                    'PreferCollectionTransform',
+                    'PreferListsPartition',
+                    'PreferSafeLoggingPreconditions',
+                    'PreferSafeLoggableExceptions'
+
+                // increase strictness for built-in error-prone checks
+                error((com.google.errorprone.scanner.BuiltInCheckerSuppliers.ENABLED_WARNINGS +
+                        com.google.errorprone.scanner.BuiltInCheckerSuppliers.DISABLED_CHECKS
+                    ).collect { it.canonicalName() } as String[])
+
+                disable 'AndroidJdkLibsChecker', // ignore Android
+                    'Java7ApiChecker', // tritium requires JDK8+
+                    'StaticOrDefaultInterfaceMethod', // Android specific
+                    'Var' // high noise, low signal
             }
-
-            com.google.errorprone.scanner.BuiltInCheckerSuppliers.DISABLED_CHECKS.forEach {
-                check -> warningsToPromote << check.canonicalName()
-            }
-
-            warningsToPromote.removeAll([
-                'AndroidJdkLibsChecker', // ignore Android
-                'Java7ApiChecker', // tritium requires JDK8+
-                'StaticOrDefaultInterfaceMethod', // Android specific
-                'Var', // high noise, low signal
-            ])
-
-            for (String checkName : warningsToPromote) {
-                options.errorprone.error(checkName)
-            }
-
-            logger.info("Error-prone args: {}", options.errorprone.errorproneArgs)
         }
     })
 

--- a/build.gradle
+++ b/build.gradle
@@ -73,9 +73,6 @@ allprojects {
             ]
 
             options.errorprone {
-                disableWarningsInGeneratedCode = true
-                excludedPaths = '.*(generated).*'
-
                 option('NullAway:AnnotatedPackages', 'com.palantir')
 
                 // warnings not explicitly provided by error-prone


### PR DESCRIPTION
## Before this PR
The error-prone configuration was overly verbose and could be simplified using the [`gradle-errorprone-plugin` DSL](https://github.com/tbroyer/gradle-errorprone-plugin#migration-from-versions-00x).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Simplify error-prone configuration
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

