### PR TITLE
Expose a factory for untagged registries with lock-free reservoirs

### DIFF
--- a/changelog/@unreleased/pr-906.v2.yml
+++ b/changelog/@unreleased/pr-906.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Expose a factory for untagged registries with lock-free reservoirs
+  links:
+  - https://github.com/palantir/tritium/pull/906

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -39,6 +39,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.tritium.metrics.registry.LockFreeExponentiallyDecayingReservoir;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.time.ZoneOffset;
@@ -102,6 +103,18 @@ public final class MetricRegistries {
      */
     public static MetricRegistry createWithSlidingTimeWindowReservoirs(long window, TimeUnit windowUnit) {
         return createWithReservoirType(() -> Reservoirs.slidingTimeWindowArrayReservoir(window, windowUnit));
+    }
+
+    /**
+     * Create a {@link MetricRegistry metric registry} which produces timers and histograms backed by
+     * {@link LockFreeExponentiallyDecayingReservoir lock free expoentially decaying reservoirs}.
+     *
+     * @see LockFreeExponentiallyDecayingReservoir
+     * @return metric registry
+     */
+    public static MetricRegistry createWithLockFreeExponentiallyDecayingReservoirs() {
+        return createWithReservoirType(
+                () -> LockFreeExponentiallyDecayingReservoir.builder().build());
     }
 
     @VisibleForTesting

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
@@ -194,6 +194,23 @@ final class MetricRegistriesTest {
     }
 
     @Test
+    void testLockFreeDecayingHistogramReservoirs() {
+        metrics = MetricRegistries.createWithLockFreeExponentiallyDecayingReservoirs();
+        assertThat(metrics).isNotNull();
+
+        Histogram histogram = metrics.histogram("histogram");
+        histogram.update(42L);
+        assertThat(histogram.getCount()).isOne();
+        Snapshot histogramSnapshot = histogram.getSnapshot();
+        assertThat(histogram.getCount()).isOne();
+        assertThat(histogramSnapshot.size()).isOne();
+        assertThat(histogramSnapshot.getMax()).isEqualTo(42);
+
+        metrics.timer("timer").update(123, TimeUnit.MILLISECONDS);
+        assertThat(metrics.timer("timer").getCount()).isOne();
+    }
+
+    @Test
     void testRegisterCache() {
         MetricRegistries.registerCache(metrics, cache, "test", clock);
 


### PR DESCRIPTION
This adds a factory for untagged codahale registries using
lock-free exponentially decaying reservoirs. While the introduction
for tagged registries helped substantially, we've seen similar errors
from metrics added to non-tagged reservoirs.

==COMMIT_MSG==
Expose a factory for untagged registries with lock-free reservoirs
==COMMIT_MSG==
