### PR TITLE
Resolves a number of new error-prone warnings and errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ allprojects {
 
                 disable 'AndroidJdkLibsChecker', // ignore Android
                         'Java7ApiChecker', // tritium requires JDK8+
+                        'MemberName', // false positives on ignored lambda args
                         'StaticOrDefaultInterfaceMethod', // Android specific
                         'Var' // high noise, low signal
             }

--- a/tritium-api/src/main/java/com/palantir/tritium/api/functions/BooleanSupplier.java
+++ b/tritium-api/src/main/java/com/palantir/tritium/api/functions/BooleanSupplier.java
@@ -19,10 +19,20 @@ package com.palantir.tritium.api.functions;
 @FunctionalInterface
 public interface BooleanSupplier extends java.util.function.BooleanSupplier {
 
-    /** {@link BooleanSupplier} that always returns true. */
+    /**
+     * {@link BooleanSupplier} that always returns true.
+     * @deprecated prefer simple inlined lambda for clarity
+     */
+    @Deprecated
+    @SuppressWarnings("MemberName") // public API
     BooleanSupplier TRUE = () -> true;
 
-    /** {@link BooleanSupplier} that always returns false. */
+    /**
+     * {@link BooleanSupplier} that always returns false.
+     * @deprecated prefer simple inlined lambda for clarity
+     */
+    @Deprecated
+    @SuppressWarnings("MemberName") // public API
     BooleanSupplier FALSE = () -> false;
 
     /**

--- a/tritium-api/src/main/java/com/palantir/tritium/api/functions/LongPredicate.java
+++ b/tritium-api/src/main/java/com/palantir/tritium/api/functions/LongPredicate.java
@@ -16,12 +16,23 @@
 
 package com.palantir.tritium.api.functions;
 
+@FunctionalInterface
 public interface LongPredicate extends java.util.function.LongPredicate {
 
-    /** {@link LongPredicate} that always returns true. */
+    /**
+     * {@link LongPredicate} that always returns true.
+     * @deprecated prefer simple inlined lambda for clarity
+     */
+    @Deprecated
+    @SuppressWarnings("MemberName") // public API
     LongPredicate TRUE = _input -> true;
 
-    /** {@link LongPredicate} that always returns false. */
+    /**
+     * {@link LongPredicate} that always returns false.
+     * @deprecated prefer simple inlined lambda for clarity
+     */
+    @Deprecated
+    @SuppressWarnings("MemberName") // public API
     LongPredicate FALSE = _input -> false;
 
     /**

--- a/tritium-lib/src/test/java/com/palantir/tritium/JitCompilationTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/JitCompilationTest.java
@@ -24,13 +24,14 @@ import com.palantir.tritium.event.log.LoggingLevel;
 import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.test.TestImplementation;
 import com.palantir.tritium.test.TestInterface;
-import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import org.slf4j.impl.TestLogs;
 
 public final class JitCompilationTest {
 
     private static final long COUNT = 5_000_000L;
+    private static final ImmutableList<String> strings =
+            ImmutableList.of("1", "22", "333", "4444", "55555", "666666", "7777777");
 
     static {
         // avoid logging
@@ -45,8 +46,6 @@ public final class JitCompilationTest {
     }
 
     private final TestImplementation delegate = new TestImplementation() {
-        private final List<String> strings = ImmutableList.of("1", "22", "333", "4444", "55555", "666666", "7777777");
-
         @Override
         public String test() {
             return strings.get(ThreadLocalRandom.current().nextInt(strings.size()));

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InternalCacheMetrics.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InternalCacheMetrics.java
@@ -94,7 +94,7 @@ public final class InternalCacheMetrics {
             return new RatioGauge() {
                 @Override
                 protected Ratio getRatio() {
-                    return RatioGauge.Ratio.of(
+                    return Ratio.of(
                             hitCount().getValue().doubleValue(),
                             requestCount().getValue().doubleValue());
                 }
@@ -105,7 +105,7 @@ public final class InternalCacheMetrics {
             return new RatioGauge() {
                 @Override
                 protected Ratio getRatio() {
-                    return RatioGauge.Ratio.of(
+                    return Ratio.of(
                             missCount().getValue().doubleValue(),
                             requestCount().getValue().doubleValue());
                 }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MemoryPoolMetrics.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MemoryPoolMetrics.java
@@ -67,7 +67,7 @@ final class MemoryPoolMetrics {
                 protected Ratio getRatio() {
                     MemoryUsage memoryUsage = memoryPool.getUsage();
                     long maximum = memoryUsage.getMax() == -1 ? memoryUsage.getCommitted() : memoryUsage.getMax();
-                    return RatioGauge.Ratio.of(memoryUsage.getUsed(), maximum);
+                    return Ratio.of(memoryUsage.getUsed(), maximum);
                 }
             });
 

--- a/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
+++ b/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
@@ -38,8 +38,7 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
 
     private static final ImmutableList<String> MESSAGE_PATTERNS = generateMessagePatterns(20);
 
-    public static final com.palantir.tritium.api.functions.LongPredicate LOG_ALL_DURATIONS =
-            com.palantir.tritium.api.functions.LongPredicate.TRUE;
+    public static final com.palantir.tritium.api.functions.LongPredicate LOG_ALL_DURATIONS = _input -> true;
 
     public static final com.palantir.tritium.api.functions.LongPredicate LOG_DURATIONS_GREATER_THAN_1_MICROSECOND =
             nanos -> TimeUnit.MICROSECONDS.convert(nanos, TimeUnit.NANOSECONDS) > 1;
@@ -47,8 +46,7 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
     public static final com.palantir.tritium.api.functions.LongPredicate LOG_DURATIONS_GREATER_THAN_0_MILLIS =
             nanos -> TimeUnit.MILLISECONDS.convert(nanos, TimeUnit.NANOSECONDS) > 0;
 
-    public static final com.palantir.tritium.api.functions.LongPredicate NEVER_LOG =
-            com.palantir.tritium.api.functions.LongPredicate.FALSE;
+    public static final com.palantir.tritium.api.functions.LongPredicate NEVER_LOG = _input -> false;
 
     private final Logger logger;
     private final LoggingLevel level;
@@ -169,7 +167,7 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
         if (getSystemPropertySupplier(LoggingInvocationEventHandler.class).getAsBoolean()) {
             return () -> isEnabled(logger, level);
         } else {
-            return BooleanSupplier.FALSE;
+            return () -> false;
         }
     }
 

--- a/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
+++ b/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
@@ -109,7 +109,8 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
     }
 
     // All message formats are generated with placeholders and safe args
-    @SuppressWarnings({"Slf4jConstantLogMessage", "Slf4jLogsafeArgs", "Var"})
+    // switch generates larger bytecode and is less JIT inline friendly
+    @SuppressWarnings({"UseEnumSwitch", "Slf4jConstantLogMessage", "Slf4jLogsafeArgs", "Var"})
     private void log(final String messageFormat, Object[] args) {
         if (level == LoggingLevel.TRACE) {
             logger.trace(messageFormat, args);
@@ -121,7 +122,8 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
     }
 
     // explicitly treating this method as slow path as invocation logging is typically only enabled at TRACE or DEBUG
-    @SuppressWarnings({"Slf4jConstantLogMessage", "Slf4jLogsafeArgs", "Var"})
+    // switch generates larger bytecode and is less JIT inline friendly
+    @SuppressWarnings({"UseEnumSwitch", "Slf4jConstantLogMessage", "Slf4jLogsafeArgs", "Var"})
     private void logUncommon(String messageFormat, Object[] args) {
         if (level == LoggingLevel.INFO) {
             logger.info(messageFormat, args);
@@ -134,6 +136,7 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
         }
     }
 
+    @SuppressWarnings("UseEnumSwitch") // switch generates larger bytecode and is less JIT inline friendly
     static boolean isEnabled(Logger logger, LoggingLevel level) {
         if (level == LoggingLevel.TRACE) {
             return logger.isTraceEnabled();
@@ -145,6 +148,7 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
     }
 
     // explicitly treating this method as slow path as invocation logging is typically only enabled at TRACE or DEBUG
+    @SuppressWarnings("UseEnumSwitch") // switch generates larger bytecode and is less JIT inline friendly
     private static boolean isEnabledUncommon(Logger logger, LoggingLevel level) {
         if (level == LoggingLevel.INFO) {
             return logger.isInfoEnabled();


### PR DESCRIPTION
## Before this PR
Baseline excavator https://github.com/palantir/tritium/pull/961 is failing due to new error-prone checks

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Resolves a number of new error-prone warnings and errors.
Address DifferentNameButSame error-prone warning for RatioGauge.Ratio.
Address MutableConstantField and FieldCanBeStatic error-prone warnings in test.

Suppress MemberName error-prone warnings:
Error-prone added https://errorprone.info/bugpattern/MemberName warnings
that are currently low signal and high noise on unused lambda arguments.
Additionally, some functional interface constants are flagged, but part
of public API, so these are being deprecated.


Suppress UseEnumSwitch for hot paths:
Using switch on an enum generates larger bytecode and is less JIT inline
friendly (~46% slower ProxyBenchmark) for hot code paths compared to
using if/else on enum value.

Using if/else on enum value:
Benchmark                                                 (mode)  Mode  Cnt  Score   Error  Units
ProxyBenchmark.instrumentedWithPerformanceLogging     BYTE_BUDDY  avgt    5  4.519 ± 0.087  ns/op
ProxyBenchmark.instrumentedWithPerformanceLogging  DYNAMIC_PROXY  avgt    5  8.331 ± 0.377  ns/op

Using switch on enum value:
Benchmark                                                 (mode)  Mode  Cnt   Score   Error  Units
ProxyBenchmark.instrumentedWithPerformanceLogging     BYTE_BUDDY  avgt    5   6.810 ± 1.354  ns/op
ProxyBenchmark.instrumentedWithPerformanceLogging  DYNAMIC_PROXY  avgt    5  12.191 ± 1.657  ns/op
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Added a few suppressions in places, mainly for [`MemberName`](https://errorprone.info/bugpattern/MemberName) which flags on unused lambda parameter names (e.g. `_unused -> true`) and other places where public API constants are defined.
