### PR TITLE
Safepoint metrics no longer return warnings

### DIFF
--- a/changelog/@unreleased/pr-989.v2.yml
+++ b/changelog/@unreleased/pr-989.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Safepoint metrics no longer return illegal access warnings
+  links:
+  - https://github.com/palantir/tritium/pull/989

--- a/tritium-metrics-jvm/build.gradle
+++ b/tritium-metrics-jvm/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'org.slf4j:slf4j-api'
+    implementation 'net.bytebuddy:byte-buddy'
 
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
@@ -103,7 +103,7 @@ final class SafepointMetrics {
                     .newInstance();
             gaugeImplementation.getValue();
             return Optional.of(gaugeImplementation);
-        } catch (ReflectiveOperationException e) {
+        } catch (ReflectiveOperationException | NoClassDefFoundError e) {
             log.info("Could not get the total safepoint time, these metrics will not be registered.", e);
             return Optional.empty();
         }

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
@@ -37,7 +37,7 @@ final class SafepointMetrics {
         }
     }
 
-    @SuppressWarnings("UnnecessarilyFullyQualified") // would otherwise be an illegal import
+    @SuppressWarnings({"UnnecessarilyFullyQualified", "restriction"}) // would otherwise be an illegal import
     private static final class HotspotSafepointMetrics {
         private static final sun.management.HotspotRuntimeMBean runtime =
                 sun.management.ManagementFactoryHelper.getHotspotRuntimeMBean();

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
@@ -53,6 +53,19 @@ final class SafepointMetrics {
      * reflection is caught by JDK internal security and eventually will be blocked by the module system.
      * So, we generate a short class where we call the actual method, which does not have the same module boundary
      * issues.
+     *
+     * Code should be equivalent to:
+     *
+     * <pre>
+     *     class SomeGauge implements Gauge {
+     *         private static final HotspotRuntimeMBean runtime = ManagementFactoryHelper.getHotspotRuntimeMBean();
+     *
+     *         public Object getValue() {
+     *             return runtime.getTotalSafepointTime();
+     *         }
+     *     }
+     * </pre>
+     *
      */
     @SuppressWarnings("unchecked")
     private static Optional<Gauge<Long>> getGauge() {

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
@@ -48,12 +48,13 @@ final class SafepointMetrics {
 
     /**
      * This is somewhat involved. Basically, Java 11+ does not let you compile against sun.management classes when using
-     * the --release flag. But the classes are present at runtime. We used to use reflection to access this, but the
-     * reflection is caught by JDK internal security and eventually will be blocked by the module system.
+     * the --release flag, and they may or may not even be present. But the classes are present at runtime on JVMs we
+     * use, and the beans are available for diagnostics purposes (e.g. JMX). We used to use reflection to access
+     * this, but the reflection is caught by JDK internal security and eventually will be blocked by the module system.
      * So, we generate a short class where we call the actual method, which does not have the same module boundary
      * issues.
      *
-     * Code should be equivalent to:
+     * Code should end up being equivalent to:
      *
      * <pre>
      *     class SomeGauge implements Gauge {
@@ -64,6 +65,8 @@ final class SafepointMetrics {
      *         }
      *     }
      * </pre>
+     *
+     * but is generated at runtime.
      *
      */
     @SuppressWarnings("unchecked")

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
@@ -18,8 +18,6 @@ package com.palantir.tritium.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,27 +29,21 @@ import org.slf4j.LoggerFactory;
 final class SafepointMetrics {
     private static final Logger log = LoggerFactory.getLogger(SafepointMetrics.class);
 
-    // The reflection is so that we can use this on non-Hotspot JVMs
-    @SuppressWarnings("LiteralClassName")
     static void register(TaggedMetricRegistry registry) {
         try {
-            Class<?> managementFactoryHelper = Class.forName("sun.management.ManagementFactoryHelper");
-            Method getHotspotRuntimeMBean = managementFactoryHelper.getMethod("getHotspotRuntimeMBean");
-            Object hotspotRuntimeMBean = getHotspotRuntimeMBean.invoke(null);
-            Method getTotalSafepointTime = hotspotRuntimeMBean.getClass().getMethod("getTotalSafepointTime");
-            getTotalSafepointTime.setAccessible(true);
-            Gauge<Long> gauge = () -> (Long) invoke(getTotalSafepointTime, hotspotRuntimeMBean);
-            InternalJvmMetrics.of(registry).safepointTime(gauge);
-        } catch (ReflectiveOperationException e) {
+            InternalJvmMetrics.of(registry).safepointTime(HotspotSafepointMetrics.getTotalSafepointTime());
+        } catch (NoClassDefFoundError e) {
             log.info("Could not get the total safepoint time, these metrics will not be registered.", e);
         }
     }
 
-    private static Object invoke(Method method, Object object) {
-        try {
-            return method.invoke(object);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new IllegalStateException(e);
+    private static final class HotspotSafepointMetrics {
+        private static final sun.management.HotspotRuntimeMBean runtime =
+                sun.management.ManagementFactoryHelper.getHotspotRuntimeMBean();
+
+        public static Gauge<Long> getTotalSafepointTime() {
+            runtime.getTotalSafepointTime();
+            return runtime::getTotalSafepointTime;
         }
     }
 

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
@@ -37,6 +37,7 @@ final class SafepointMetrics {
         }
     }
 
+    @SuppressWarnings("UnnecessarilyFullyQualified") // would otherwise be an illegal import
     private static final class HotspotSafepointMetrics {
         private static final sun.management.HotspotRuntimeMBean runtime =
                 sun.management.ManagementFactoryHelper.getHotspotRuntimeMBean();

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
@@ -103,7 +103,7 @@ final class SafepointMetrics {
                     .newInstance();
             gaugeImplementation.getValue();
             return Optional.of(gaugeImplementation);
-        } catch (ReflectiveOperationException | NoClassDefFoundError e) {
+        } catch (RuntimeException | ReflectiveOperationException | NoClassDefFoundError e) {
             log.info("Could not get the total safepoint time, these metrics will not be registered.", e);
             return Optional.empty();
         }

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
@@ -18,7 +18,6 @@ package com.palantir.tritium.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.description.type.TypeDescription;
@@ -104,11 +103,7 @@ final class SafepointMetrics {
                     .newInstance();
             gaugeImplementation.getValue();
             return Optional.of(gaugeImplementation);
-        } catch (ClassNotFoundException
-                | NoSuchMethodException
-                | IllegalAccessException
-                | InstantiationException
-                | InvocationTargetException e) {
+        } catch (ReflectiveOperationException e) {
             log.info("Could not get the total safepoint time, these metrics will not be registered.", e);
             return Optional.empty();
         }


### PR DESCRIPTION
Still cross-jvm compatible due to usage of inner class. Generally this is a bit heinous as a tactic, though I don't really see a better way without hacks. Java won't let us compile against the code with our javac settings, while using reflection directly will trigger the detection mechanisms.