### PR TITLE
Apply ConsistentLoggerName

### DIFF
--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 
 abstract class InvocationEventProxy implements InvocationHandler {
 
-    private static final Logger logger = LoggerFactory.getLogger(InvocationEventProxy.class);
+    private static final Logger log = LoggerFactory.getLogger(InvocationEventProxy.class);
     private static final Object[] EMPTY_ARRAY = new Object[0];
 
     private final InstrumentationFilter filter;
@@ -194,8 +194,8 @@ abstract class InvocationEventProxy implements InvocationHandler {
 
     static void logInvocationWarning(
             String event, @Nullable InvocationContext context, @Nullable Object result, Throwable cause) {
-        if (logger.isWarnEnabled()) {
-            logger.warn(
+        if (log.isWarnEnabled()) {
+            log.warn(
                     "{} occurred handling '{}' ({}, {}): {}",
                     safeSimpleClassName("cause", cause),
                     SafeArg.of("event", event),
@@ -206,8 +206,8 @@ abstract class InvocationEventProxy implements InvocationHandler {
     }
 
     static void logInvocationWarning(String event, Object instance, Method method, Throwable cause) {
-        if (logger.isWarnEnabled()) {
-            logger.warn(
+        if (log.isWarnEnabled()) {
+            log.warn(
                     "{} occurred handling '{}' invocation of {} {} on {} instance: {}",
                     safeSimpleClassName("cause", cause),
                     SafeArg.of("event", event),

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -64,7 +64,7 @@ import org.slf4j.LoggerFactory;
 /** Utilities for working with {@link MetricRegistry} instances. */
 public final class MetricRegistries {
 
-    private static final Logger logger = LoggerFactory.getLogger(MetricRegistries.class);
+    private static final Logger log = LoggerFactory.getLogger(MetricRegistries.class);
 
     static final String RESERVOIR_TYPE_METRIC_NAME = MetricRegistry.name(MetricRegistries.class, "reservoir.type");
 
@@ -461,7 +461,7 @@ public final class MetricRegistries {
                 }
 
                 if (replace && registry.remove(name)) {
-                    logger.info(
+                    log.info(
                             "Removed existing registered metric with name {}: {}",
                             SafeArg.of("name", name),
                             // #256: Metric implementations are necessarily json serializable
@@ -469,7 +469,7 @@ public final class MetricRegistries {
                     registry.register(name, metric);
                     return metric;
                 } else {
-                    logger.warn(
+                    log.warn(
                             "Metric already registered at this name. Name: {}, existing metric: {}",
                             SafeArg.of("name", name),
                             // #256: Metric implementations are necessarily json serializable

--- a/tritium-tracing/src/main/java/com/palantir/tritium/tracing/RemotingCompatibleTracingInvocationEventHandler.java
+++ b/tritium-tracing/src/main/java/com/palantir/tritium/tracing/RemotingCompatibleTracingInvocationEventHandler.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 public final class RemotingCompatibleTracingInvocationEventHandler
         extends AbstractInvocationEventHandler<InvocationContext> {
 
-    private static final Logger logger = LoggerFactory.getLogger(RemotingCompatibleTracingInvocationEventHandler.class);
+    private static final Logger log = LoggerFactory.getLogger(RemotingCompatibleTracingInvocationEventHandler.class);
 
     private static final AtomicBoolean shouldLogFallbackError = new AtomicBoolean();
 
@@ -76,7 +76,7 @@ public final class RemotingCompatibleTracingInvocationEventHandler
             }
         } catch (ReflectiveOperationException e) {
             // expected case when remoting3 is not on classpath
-            logger.debug("Remoting3 unavailable, using Java tracing", e);
+            log.debug("Remoting3 unavailable, using Java tracing", e);
         }
 
         return JavaTracingTracer.INSTANCE;
@@ -157,7 +157,7 @@ public final class RemotingCompatibleTracingInvocationEventHandler
                         wrappedTrace.getClass().getPackage().getName();
                 if (!Objects.equals(expectedTracingPackage, actualTracingPackage)) {
                     if (shouldLogFallbackError.compareAndSet(false, true)) {
-                        logger.error(
+                        log.error(
                                 "Multiple tracing implementations detected, expected '{}' but found '{}',"
                                         + " using legacy remoting3 tracing for backward compatibility",
                                 SafeArg.of("expectedPackage", expectedTracingPackage),


### PR DESCRIPTION
## Before this PR
Gradle Baseline https://github.com/palantir/gradle-baseline/pull/1644 added `ConsistentLoggerName` check and automated refactor, but excavator https://github.com/palantir/tritium/pull/992 missed a few causing compilation failures https://app.circleci.com/pipelines/github/palantir/tritium/1039/workflows/b6cbe846-bcfd-4469-8f28-dc16cbbac371/jobs/12402

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Apply ConsistentLoggerName
==COMMIT_MSG==

## Possible downsides?
This is just a one off fix, need to fix the upstream gradle-baseline `ConsistentLoggerName` check