### PR TITLE
Use Caffeine CacheStats.of for testing

### DIFF
--- a/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineStatsTest.java
+++ b/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineStatsTest.java
@@ -51,7 +51,7 @@ final class CaffeineStatsTest {
 
     @BeforeEach
     void before() {
-        stats = new CaffeineStats(cache, () -> new CacheStats(1, 2, 3, 4, 5, 6, 7));
+        stats = new CaffeineStats(cache, () -> CacheStats.of(1, 2, 3, 4, 5, 6, 7));
         lenient().when(cache.policy()).thenAnswer(_ignored -> policy);
         lenient().when(policy.eviction()).thenAnswer(_ignored -> Optional.of(eviction));
     }


### PR DESCRIPTION
## Before this PR
Excavator bump to Caffeine 2.9.0 release failed due to deprecation warning on use of `CacheStats(long,long,long,long,long,long,long)` constructor in test code.

```
> Task :tritium-caffeine:compileTestJava FAILED
/home/circleci/project/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineStatsTest.java:54: warning: [deprecation] CacheStats(long,long,long,long,long,long,long) in CacheStats has been deprecated
        stats = new CaffeineStats(cache, () -> new CacheStats(1, 2, 3, 4, 5, 6, 7));
                                               ^
error: warnings found and -Werror specified
1 error
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove use of deprecated CacheStats constructor slated for removal in
Caffeine 3.0 to support eventual use of value types.

See https://github.com/ben-manes/caffeine/releases/tag/v2.9.0 and 
https://github.com/ben-manes/caffeine/commit/4f189d7ea885fd72a51b1482ad567c8279ec86b3
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

