### PR TITLE
LoggingInvocationEventHandler precomputes level information

### DIFF
--- a/changelog/@unreleased/pr-997.v2.yml
+++ b/changelog/@unreleased/pr-997.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: LoggingInvocationEventHandler precomputes level information
+  links:
+  - https://github.com/palantir/tritium/pull/997

--- a/tritium-lib/src/test/java/com/palantir/tritium/event/log/LoggingInstrumentationTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/event/log/LoggingInstrumentationTest.java
@@ -105,7 +105,7 @@ public class LoggingInstrumentationTest {
                 .withHandler(handler)
                 .build();
 
-        assertThat(LoggingInvocationEventHandler.isEnabled(logger, level)).isTrue();
+        assertThat(handler.isEnabled()).isTrue();
 
         assertThat(delegate.invocationCount()).isZero();
 

--- a/tritium-slf4j/src/test/java/com/palantir/tritium/event/log/LoggingInvocationEventHandlerTest.java
+++ b/tritium-slf4j/src/test/java/com/palantir/tritium/event/log/LoggingInvocationEventHandlerTest.java
@@ -94,13 +94,6 @@ public class LoggingInvocationEventHandlerTest {
 
     @Test
     @SuppressWarnings("NullAway") // explicitly testing null handling
-    public void testNullIsEnabled() {
-        assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> LoggingInvocationEventHandler.isEnabled(getLogger(), null));
-    }
-
-    @Test
-    @SuppressWarnings("NullAway") // explicitly testing null handling
     public void testNullLevel() {
         assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(() -> new LoggingInvocationEventHandler(getLogger(), null));


### PR DESCRIPTION
This avoids branching duplicating the level checks for is-enabled
and the logging call on each method invocation.

This commit originally used a new LoggingLevel.Visitor, however
upon inspection the visitor was unnecessary -- logging level is
a constant so we can do all branching up front. I've not rerun
the benchmarks yet, it's possible the lambda incurs an additional
pointer jump, however I'd expect it to be quickly inlined.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
LoggingInvocationEventHandler precomputes level information
==COMMIT_MSG==

