### PR TITLE
Pin caffeine 2.9.0 for JDK 8 compatibility

### DIFF
--- a/versions.props
+++ b/versions.props
@@ -1,5 +1,4 @@
 com.fasterxml.jackson.*:* = 2.11.3
-com.github.ben-manes.caffeine:caffeine = 2.9.0
 com.google.auto.service:auto-service = 1.0-rc4
 com.google.auto:auto-common = 0.11
 com.google.code.findbugs:jFormatString = 3.0.0
@@ -27,6 +26,11 @@ org.openjdk.jmh:* = 1.27
 org.slf4j:* = 1.7.30
 
 # dependency-upgrader:OFF
+
+# caffeine 3.0 requires JDK 11+ see https://github.com/ben-manes/caffeine/releases/tag/v3.0.0
+com.github.ben-manes.caffeine:caffeine = 2.9.0
+
 # Explicitly maintaining back-compat with dropwizard metrics
 io.dropwizard.metrics:* = 3.2.5
+
 # dependency-upgrader:ON


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Excavator https://github.com/palantir/tritium/pull/998 bumping caffeine to 3.0 fails because tritium still requires JDK 8 while Caffeine 3.0 requires JDK 11+, see https://github.com/ben-manes/caffeine/releases/tag/v3.0.0

See also the discussion in https://github.com/palantir/tritium/pull/998#discussion_r580677931

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Pin caffeine 2.9.0 for JDK 8 compatibility

Caffeine 3.0 requires JDK 11+, see
https://github.com/ben-manes/caffeine/releases/tag/v3.0.0
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

