### PR TITLE
Apply AutoCloseableMustBeClosed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,8 @@ allprojects {
                 option('NullAway:AnnotatedPackages', 'com.palantir')
 
                 // warnings not explicitly provided by error-prone
-                error 'NullAway',
+                error 'AutoCloseableMustBeClosed',
+                        'NullAway',
                         'Slf4jLogsafeArgs',
                         'PreferCollectionTransform',
                         'PreferListsPartition',

--- a/changelog/@unreleased/pr-1009.v2.yml
+++ b/changelog/@unreleased/pr-1009.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    Methods returning `AutoCloseable` marked as `@MustBeClosed`
+
+    ./gradlew clean compileJava compileTestJava -PerrorProneApply=AutoCloseableMustBeClosed
+    ./gradlew format
+  links:
+  - https://github.com/palantir/tritium/pull/1009

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslServerSocketFactory.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslServerSocketFactory.java
@@ -16,6 +16,7 @@
 
 package com.palantir.tritium.metrics;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
@@ -94,6 +95,7 @@ final class InstrumentedSslServerSocketFactory extends SSLServerSocketFactory {
         return Objects.hash(name, delegate);
     }
 
+    @MustBeClosed
     private ServerSocket wrap(ServerSocket serverSocket) throws IOException {
         if (serverSocket instanceof SSLServerSocket) {
             return new InstrumentedServerSocket((SSLServerSocket) serverSocket, listener);
@@ -106,6 +108,7 @@ final class InstrumentedSslServerSocketFactory extends SSLServerSocketFactory {
         private final SSLServerSocket delegate;
         private final HandshakeCompletedListener listener;
 
+        @MustBeClosed
         InstrumentedServerSocket(SSLServerSocket delegate, HandshakeCompletedListener listener) throws IOException {
             this.delegate = delegate;
             this.listener = listener;
@@ -221,6 +224,7 @@ final class InstrumentedSslServerSocketFactory extends SSLServerSocketFactory {
             return wrap(delegate.accept());
         }
 
+        @MustBeClosed
         private Socket wrap(Socket socket) {
             if (socket instanceof SSLSocket && HandshakeInstrumentation.isSocketInstrumentationEnabled()) {
                 ((SSLSocket) socket).addHandshakeCompletedListener(listener);

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslSocketFactory.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslSocketFactory.java
@@ -16,6 +16,7 @@
 
 package com.palantir.tritium.metrics;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
@@ -105,6 +106,7 @@ final class InstrumentedSslSocketFactory extends SSLSocketFactory {
         return Objects.hash(delegate, name);
     }
 
+    @MustBeClosed
     private Socket wrap(Socket socket) {
         if (socket instanceof SSLSocket && HandshakeInstrumentation.isSocketInstrumentationEnabled()) {
             ((SSLSocket) socket).addHandshakeCompletedListener(listener);

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsExecutorService.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsExecutorService.java
@@ -19,6 +19,7 @@ package com.palantir.tritium.metrics;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
+import com.google.errorprone.annotations.MustBeClosed;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -141,6 +142,7 @@ final class TaggedMetricsExecutorService implements ExecutorService {
     }
 
     @Nullable
+    @MustBeClosed
     private Timer.Context startQueueTimerIfEnabled() {
         Timer queuedDurationTimer = queuedDuration;
         return queuedDurationTimer == null ? null : queuedDurationTimer.time();

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/InstrumentedSslContextTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/InstrumentedSslContextTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.google.common.collect.MoreCollectors;
+import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.tritium.event.InstrumentationProperties;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.MetricName;
@@ -258,6 +259,7 @@ final class InstrumentedSslContextTest {
         assertThat(instrumentedFirst.hashCode()).isNotEqualTo(instrumentedThirdDifferentName.hashCode());
     }
 
+    @MustBeClosed
     private static Closeable server(SSLContext context) {
         Undertow server = Undertow.builder()
                 .addHttpsListener(PORT, "0.0.0.0", context)


### PR DESCRIPTION
Apply `AutoCloseableMustBeClosed` from https://github.com/palantir/gradle-baseline/pull/1673

## Before this PR
Methods returning `AutoCloseable` were not marked as `@MustBeClosed`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Methods returning `AutoCloseable` marked as `@MustBeClosed`

./gradlew clean compileJava compileTestJava -PerrorProneApply=AutoCloseableMustBeClosed
./gradlew format
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

