### PR TITLE
Allow executor queuedDuration metrics to be disabled

### DIFF
--- a/changelog/@unreleased/pr-1012.v2.yml
+++ b/changelog/@unreleased/pr-1012.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow executor queuedDuration metrics to be disabled
+  links:
+  - https://github.com/palantir/tritium/pull/1012


### PR DESCRIPTION
## Before this PR
Some common executor configurations never queue work so it's
not necessary to report and index metrics describing the scenario.

## After this PR
==COMMIT_MSG==
Allow executor queuedDuration metrics to be disabled
==COMMIT_MSG==

## Possible downsides?
The flag could be used incorrectly

