### PR TITLE
Apply com.palantir.baseline-fix-gradle-java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ allprojects {
     apply plugin: 'org.inferred.processors'  // installs the "processor" configuration needed for baseline-error-prone
     apply plugin: 'com.palantir.baseline-class-uniqueness'
     apply plugin: 'com.palantir.baseline-exact-dependencies'
+    apply plugin: 'com.palantir.baseline-fix-gradle-java'
     apply plugin: 'com.palantir.java-format'
 
     sourceCompatibility = '1.8'


### PR DESCRIPTION
## Before this PR
Gradle `compile`, `runtime`, and `compileOnly` configurations were resolvable.

## After this PR
Enforce Gradle 7.0+ [expected behavior for configurations.](https://github.com/palantir/gradle-baseline#compalantirbaseline-fix-gradle-java-off-by-default)

==COMMIT_MSG==
Apply com.palantir.baseline-fix-gradle-java

See https://github.com/palantir/gradle-baseline#compalantirbaseline-fix-gradle-java-off-by-default
==COMMIT_MSG==


## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

