### PR TITLE
Instrument only public interface methods by default

### DIFF
--- a/changelog/@unreleased/pr-1018.v2.yml
+++ b/changelog/@unreleased/pr-1018.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Instrument only public interface methods by default
+  links:
+  - https://github.com/palantir/tritium/pull/1018

--- a/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationFilters.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationFilters.java
@@ -18,6 +18,7 @@ package com.palantir.tritium.event;
 
 import com.palantir.tritium.api.event.InstrumentationFilter;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import javax.annotation.Nonnull;
 
 public enum InstrumentationFilters implements InstrumentationFilter {
@@ -35,6 +36,16 @@ public enum InstrumentationFilters implements InstrumentationFilter {
         @Override
         public boolean shouldInstrument(@Nonnull Object _instance, @Nonnull Method _method, @Nonnull Object[] _args) {
             return false;
+        }
+    },
+
+    /** Instrument public interface methods. */
+    INSTRUMENT_PUBLIC_INTERFACE_METHODS {
+        @Override
+        public boolean shouldInstrument(@Nonnull Object _instance, @Nonnull Method method, @Nonnull Object[] _args) {
+            return Modifier.isPublic(method.getModifiers())
+                    && method.getDeclaringClass().isInterface()
+                    && !Modifier.isStatic(method.getModifiers());
         }
     };
 

--- a/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationFiltersTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/InstrumentationFiltersTest.java
@@ -19,48 +19,79 @@ package com.palantir.tritium.event;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.tritium.api.event.InstrumentationFilter;
 import com.palantir.tritium.test.TestImplementation;
 import com.palantir.tritium.test.TestInterface;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("UnnecessarilyFullyQualified") // explicitly qualifying BooleanSupplier types for deconfliction
 final class InstrumentationFiltersTest {
 
     private final TestInterface instance = mock(TestImplementation.class);
-    private final Method method = testMethod();
     private final Object[] args = new Object[0];
 
     @Test
-    void testInstrumentAll() {
+    void testInstrumentAll() throws Exception {
+        Method method = TestInterface.class.getDeclaredMethod("test");
         assertThat(InstrumentationFilters.INSTRUMENT_ALL.shouldInstrument(instance, method, args))
                 .isTrue();
     }
 
     @Test
-    void testInstrumentNone() {
+    void testInstrumentNone() throws Exception {
+        Method method = TestInterface.class.getDeclaredMethod("test");
         assertThat(InstrumentationFilters.INSTRUMENT_NONE.shouldInstrument(instance, method, args))
                 .isFalse();
     }
 
     @Test
-    void testFromTrueSupplier() {
+    void testFromTrueSupplier() throws Exception {
+        Method method = TestInterface.class.getDeclaredMethod("test");
         InstrumentationFilter filter = InstrumentationFilters.from((java.util.function.BooleanSupplier) () -> true);
         assertThat(filter.shouldInstrument(instance, method, args)).isTrue();
     }
 
     @Test
-    void testFromFalseSupplier() {
+    void testFromFalseSupplier() throws Exception {
+        Method method = TestInterface.class.getDeclaredMethod("test");
         InstrumentationFilter filter = InstrumentationFilters.from((java.util.function.BooleanSupplier) () -> false);
         assertThat(filter.shouldInstrument(instance, method, args)).isFalse();
     }
 
-    private static Method testMethod() {
-        try {
-            return TestInterface.class.getDeclaredMethod("test");
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException(e);
+    @Test
+    void testInstrumentPublicInterfaceMethod() throws Exception {
+        Method method = TestInterface.class.getDeclaredMethod("test");
+        assertThat(Modifier.isPublic(method.getModifiers())).isTrue();
+        assertThat(method.getDeclaringClass()).isInterface();
+        assertThat(InstrumentationFilters.INSTRUMENT_PUBLIC_INTERFACE_METHODS.shouldInstrument(instance, method, args))
+                .isTrue();
+    }
+
+    @Test
+    void testDoesNotInstrumentPublicObjectMethod() throws Exception {
+        for (String methodName : ImmutableList.of("hashCode", "toString")) {
+            Method method = TestImplementation.class.getMethod(methodName);
+            assertThat(Modifier.isPublic(method.getModifiers())).isTrue();
+            assertThat(method.getDeclaringClass()).isPublic().isNotInterface();
+            assertThat(InstrumentationFilters.INSTRUMENT_PUBLIC_INTERFACE_METHODS.shouldInstrument(
+                            instance, method, args))
+                    .isFalse();
         }
+    }
+
+    @Test
+    void testDelegateMethod() throws Exception {
+        Method invocationCount = TestImplementation.class.getMethod("invocationCount");
+        assertThat(Modifier.isPublic(invocationCount.getModifiers())).isTrue();
+        assertThat(invocationCount.getDeclaringClass())
+                .isEqualTo(TestImplementation.class)
+                .isPublic()
+                .isNotInterface();
+        assertThat(InstrumentationFilters.INSTRUMENT_PUBLIC_INTERFACE_METHODS.shouldInstrument(
+                        instance, invocationCount, args))
+                .isFalse();
     }
 }

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/Instrumentation.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/Instrumentation.java
@@ -54,7 +54,7 @@ public final class Instrumentation {
         checkNotNull(instrumentationFilter, "instrumentationFilter");
         checkNotNull(handlers, "handlers");
 
-        if (handlers.isEmpty() || instrumentationFilter == InstrumentationFilters.INSTRUMENT_NONE) {
+        if (handlers.isEmpty() || InstrumentationFilters.INSTRUMENT_NONE.equals(instrumentationFilter)) {
             return delegate;
         }
 
@@ -74,7 +74,7 @@ public final class Instrumentation {
     @Deprecated
     static <T, U extends T> T wrap(
             Class<T> interfaceClass, U delegate, List<InvocationEventHandler<InvocationContext>> handlers) {
-        return wrap(interfaceClass, delegate, handlers, InstrumentationFilters.INSTRUMENT_ALL);
+        return wrap(interfaceClass, delegate, handlers, InstrumentationFilters.INSTRUMENT_PUBLIC_INTERFACE_METHODS);
     }
 
     /**
@@ -90,7 +90,7 @@ public final class Instrumentation {
     @Deprecated
     public static <T, U extends T> T instrument(Class<T> serviceInterface, U delegate, MetricRegistry metricRegistry) {
         return builder(serviceInterface, delegate)
-                .withFilter(InstrumentationFilters.INSTRUMENT_ALL)
+                .withFilter(InstrumentationFilters.INSTRUMENT_PUBLIC_INTERFACE_METHODS)
                 .withMetrics(metricRegistry)
                 .withPerformanceTraceLogging()
                 .build();
@@ -111,7 +111,7 @@ public final class Instrumentation {
         private final U delegate;
         private final ImmutableList.Builder<InvocationEventHandler<InvocationContext>> handlers =
                 ImmutableList.builder();
-        private InstrumentationFilter filter = InstrumentationFilters.INSTRUMENT_ALL;
+        private InstrumentationFilter filter = InstrumentationFilters.INSTRUMENT_PUBLIC_INTERFACE_METHODS;
 
         private Builder(Class<T> interfaceClass, U delegate) {
             this.interfaceClass = checkNotNull(interfaceClass, "class");


### PR DESCRIPTION
## Before this PR
Instrumented types were creating additional overhead observing methods that are not publicly exposed on the specified instrumented interface type. 

For example, a pre-invocation context was being generated for private method (e.g. `foo.bar.Test.somePrivateMethod(FooBar)`) invocations on an instrumented instance, even when there is no need to track these invocations.

```
InvocationContext com.palantir.tritium.event.CompositeInvocationEventHandler.preInvocation(Object, Method, Object[])
   boolean com.palantir.tritium.proxy.InstrumentedFilterPredicate$9.match(FooBar)
      boolean foo.bar.Test.somePrivateMethod(FooBar)
         void foo.bar.Test.process(FooBar)
            void com.palantir.tritium.proxy.InstrumentedTest$10.process(Collection)
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Methods that are not part of specified interface will not be instrumented by default.

==COMMIT_MSG==
Instrument only public interface methods by default
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
This is a behavior change in that previously instrumented methods that were not part of interface being instrumented would produce instrumentation events (e.g. metrics, logs, etc.) this is generally not what one might want as the instrumentation should be for the public facing methods of a given interface.

