### PR TITLE
Don't include performance logging in the Tritium.instrument method

### DIFF
--- a/changelog/@unreleased/pr-1021.v2.yml
+++ b/changelog/@unreleased/pr-1021.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Don't include performance logging in the Tritium.instrument method
+  links:
+  - https://github.com/palantir/tritium/pull/1021

--- a/tritium-lib/src/main/java/com/palantir/tritium/Tritium.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/Tritium.java
@@ -30,7 +30,11 @@ public final class Tritium {
 
     /**
      * Return an instrumented proxy of the specified service interface and delegate that records aggregated invocation
-     * metrics, Zipkin style traces, and performance trace logging.
+     * metrics, and Zipkin style traces.
+     *
+     * NB: Previous versions of this method included performance logging. With changes in Java9+ the method
+     * of constructing performance logs became a slow operation. So this is no longer included.
+     * See: https://github.com/apache/logging-log4j2/pull/475 for details
      *
      * @param serviceInterface service interface
      * @param delegate delegate to instrument
@@ -40,14 +44,17 @@ public final class Tritium {
     public static <T, U extends T> T instrument(Class<T> serviceInterface, U delegate, MetricRegistry metricRegistry) {
         return Instrumentation.builder(serviceInterface, delegate)
                 .withMetrics(metricRegistry)
-                .withPerformanceTraceLogging()
                 .withHandler(TracingInvocationEventHandler.create(serviceInterface.getName()))
                 .build();
     }
 
     /**
      * Return an instrumented proxy of the specified service interface, and delegate that records aggregated invocation
-     * metrics, Zipkin style traces and performance trace logging.
+     * metrics, and Zipkin style traces.
+     *
+     * NB: Previous versions of this method included performance logging. With changes in Java9+ the method
+     * of constructing performance logs became a slow operation. So this is no longer included.
+     * See: https://github.com/apache/logging-log4j2/pull/475 for details
      *
      * @param serviceInterface The service class to instrument
      * @param delegate Delegate to instrument
@@ -58,7 +65,6 @@ public final class Tritium {
             Class<T> serviceInterface, U delegate, TaggedMetricRegistry metricRegistry) {
         return Instrumentation.builder(serviceInterface, delegate)
                 .withTaggedMetrics(metricRegistry)
-                .withPerformanceTraceLogging()
                 .withHandler(TracingInvocationEventHandler.create(serviceInterface.getName()))
                 .build();
     }


### PR DESCRIPTION

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Java9+ have a performance regression when constructing loggers
with dynamic names. Until the upstream Log4j bug is fixed
we probably want to remove this.


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==

Don't include performance logging in the Tritium.instrument method
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

This performance logging was used and needed by some user.

