### PR TITLE
Add ability to register custom cache stats

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,0 +1,14 @@
+acceptedBreaks:
+  "0.18.8":
+    com.palantir.tritium:tritium-metrics:
+    - code: "java.class.removed"
+      old: "interface com.palantir.tritium.metrics.InternalCacheMetrics.Stats"
+      justification: "Changed internal methods"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter <K> com.google.common.collect.ImmutableMap<K, com.codahale.metrics.Gauge<?>>\
+        \ com.palantir.tritium.metrics.InternalCacheMetrics::createMetrics(===com.palantir.tritium.metrics.InternalCacheMetrics.Stats===,\
+        \ java.util.function.Function<java.lang.String, K>)"
+      new: "parameter <K> com.google.common.collect.ImmutableMap<K, com.codahale.metrics.Gauge<?>>\
+        \ com.palantir.tritium.metrics.InternalCacheMetrics::createMetrics(===com.palantir.tritium.metrics.CacheMetrics.Stats===,\
+        \ java.util.function.Function<java.lang.String, K>)"
+      justification: "Changed internal methods"

--- a/changelog/@unreleased/pr-1041.v2.yml
+++ b/changelog/@unreleased/pr-1041.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add ability to register custom cache stats.
+  links:
+  - https://github.com/palantir/tritium/pull/1041

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineStats.java
@@ -23,12 +23,12 @@ import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.Streams;
-import com.palantir.tritium.metrics.InternalCacheMetrics;
+import com.palantir.tritium.metrics.CacheMetrics;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-final class CaffeineStats implements InternalCacheMetrics.Stats {
+final class CaffeineStats implements CacheMetrics.Stats {
 
     private final Cache<?, ?> cache;
     private final Supplier<CacheStats> stats;
@@ -39,7 +39,7 @@ final class CaffeineStats implements InternalCacheMetrics.Stats {
         this.stats = stats;
     }
 
-    static InternalCacheMetrics.Stats create(Cache<?, ?> cache, long duration, TimeUnit timeUnit) {
+    static CacheMetrics.Stats create(Cache<?, ?> cache, long duration, TimeUnit timeUnit) {
         Supplier<CacheStats> statsSupplier = Suppliers.memoizeWithExpiration(cache::stats, duration, timeUnit);
         return new CaffeineStats(cache, statsSupplier);
     }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/CacheMetricSet.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/CacheMetricSet.java
@@ -55,7 +55,7 @@ final class CacheMetricSet implements MetricSet {
                 GuavaStats.create(cache, 1, TimeUnit.SECONDS), metricName -> cacheName + '.' + metricName));
     }
 
-    static class GuavaStats implements InternalCacheMetrics.Stats {
+    static class GuavaStats implements CacheMetrics.Stats {
         private final Cache<?, ?> cache;
         private final Supplier<CacheStats> stats;
 
@@ -65,7 +65,7 @@ final class CacheMetricSet implements MetricSet {
             this.stats = stats;
         }
 
-        static InternalCacheMetrics.Stats create(Cache<?, ?> cache, long duration, TimeUnit timeUnit) {
+        static CacheMetrics.Stats create(Cache<?, ?> cache, long duration, TimeUnit timeUnit) {
             Supplier<CacheStats> statsSupplier = Suppliers.memoizeWithExpiration(cache::stats, duration, timeUnit);
             return new GuavaStats(cache, statsSupplier);
         }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/CacheMetrics.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/CacheMetrics.java
@@ -1,0 +1,93 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.RatioGauge;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+public final class CacheMetrics {
+
+    private CacheMetrics() {}
+
+    public static void register(TaggedMetricRegistry taggedMetrics, Stats stats, String cacheName) {
+        InternalCacheMetrics.createMetrics(stats, InternalCacheMetrics.taggedMetricName(cacheName))
+                .forEach(taggedMetrics::registerWithReplacement);
+    }
+
+    static void forEachMetric(CacheMetrics.Stats stats, BiConsumer<String, Gauge<?>> consumer) {
+        consumer.accept("cache.estimated.size", stats.estimatedSize());
+        consumer.accept("cache.request.count", stats.requestCount());
+        consumer.accept("cache.hit.count", stats.hitCount());
+        consumer.accept("cache.hit.ratio", stats.hitRatio());
+        consumer.accept("cache.miss.count", stats.missCount());
+        consumer.accept("cache.miss.ratio", stats.missRatio());
+        consumer.accept("cache.eviction.count", stats.evictionCount());
+        consumer.accept("cache.load.success.count", stats.loadSuccessCount());
+        consumer.accept("cache.load.failure.count", stats.loadFailureCount());
+        consumer.accept("cache.load.average.millis", stats.loadAverageMillis());
+        stats.maximumSize().ifPresent(maximumSizeGauge -> consumer.accept("cache.maximum.size", maximumSizeGauge));
+        stats.weightedSize().ifPresent(weightedSizeGauge -> consumer.accept("cache.weighted.size", weightedSizeGauge));
+    }
+
+    public interface Stats {
+
+        Gauge<Long> estimatedSize();
+
+        Optional<Gauge<Long>> weightedSize();
+
+        Optional<Gauge<Long>> maximumSize();
+
+        Gauge<Long> requestCount();
+
+        Gauge<Long> hitCount();
+
+        Gauge<Long> missCount();
+
+        Gauge<Long> evictionCount();
+
+        Gauge<Long> loadSuccessCount();
+
+        Gauge<Long> loadFailureCount();
+
+        Gauge<Double> loadAverageMillis();
+
+        default Gauge<Double> hitRatio() {
+            return new RatioGauge() {
+                @Override
+                protected Ratio getRatio() {
+                    return Ratio.of(
+                            hitCount().getValue().doubleValue(),
+                            requestCount().getValue().doubleValue());
+                }
+            };
+        }
+
+        default Gauge<Double> missRatio() {
+            return new RatioGauge() {
+                @Override
+                protected Ratio getRatio() {
+                    return Ratio.of(
+                            missCount().getValue().doubleValue(),
+                            requestCount().getValue().doubleValue());
+                }
+            };
+        }
+    }
+}

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InternalCacheMetrics.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InternalCacheMetrics.java
@@ -18,14 +18,11 @@ package com.palantir.tritium.metrics;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.RatioGauge;
 import com.google.common.annotations.Beta;
 import com.google.common.cache.Cache;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import java.util.Optional;
-import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 /**
@@ -38,9 +35,10 @@ import java.util.function.Function;
 public final class InternalCacheMetrics {
     private InternalCacheMetrics() {}
 
-    public static <K> ImmutableMap<K, Gauge<?>> createMetrics(Stats stats, Function<String, K> metricNamer) {
+    public static <K> ImmutableMap<K, Gauge<?>> createMetrics(
+            CacheMetrics.Stats stats, Function<String, K> metricNamer) {
         ImmutableMap.Builder<K, Gauge<?>> builder = ImmutableMap.builder();
-        stats.forEach((name, gauge) -> builder.put(metricNamer.apply(name), gauge));
+        CacheMetrics.forEachMetric(stats, (name, gauge) -> builder.put(metricNamer.apply(name), gauge));
         return builder.build();
     }
 
@@ -50,66 +48,5 @@ public final class InternalCacheMetrics {
                 .safeName(name)
                 .putSafeTags("cache", cacheName)
                 .build();
-    }
-
-    @SuppressWarnings("SummaryJavadoc")
-    public interface Stats {
-
-        default void forEach(BiConsumer<String, Gauge<?>> consumer) {
-            consumer.accept("cache.estimated.size", estimatedSize());
-            consumer.accept("cache.request.count", requestCount());
-            consumer.accept("cache.hit.count", hitCount());
-            consumer.accept("cache.hit.ratio", hitRatio());
-            consumer.accept("cache.miss.count", missCount());
-            consumer.accept("cache.miss.ratio", missRatio());
-            consumer.accept("cache.eviction.count", evictionCount());
-            consumer.accept("cache.load.success.count", loadSuccessCount());
-            consumer.accept("cache.load.failure.count", loadFailureCount());
-            consumer.accept("cache.load.average.millis", loadAverageMillis());
-            maximumSize().ifPresent(maximumSizeGauge -> consumer.accept("cache.maximum.size", maximumSizeGauge));
-            weightedSize().ifPresent(weightedSizeGauge -> consumer.accept("cache.weighted.size", weightedSizeGauge));
-        }
-
-        Gauge<Long> estimatedSize();
-
-        Optional<Gauge<Long>> weightedSize();
-
-        Optional<Gauge<Long>> maximumSize();
-
-        Gauge<Long> requestCount();
-
-        Gauge<Long> hitCount();
-
-        Gauge<Long> missCount();
-
-        Gauge<Long> evictionCount();
-
-        Gauge<Long> loadSuccessCount();
-
-        Gauge<Long> loadFailureCount();
-
-        Gauge<Double> loadAverageMillis();
-
-        default Gauge<Double> hitRatio() {
-            return new RatioGauge() {
-                @Override
-                protected Ratio getRatio() {
-                    return Ratio.of(
-                            hitCount().getValue().doubleValue(),
-                            requestCount().getValue().doubleValue());
-                }
-            };
-        }
-
-        default Gauge<Double> missRatio() {
-            return new RatioGauge() {
-                @Override
-                protected Ratio getRatio() {
-                    return Ratio.of(
-                            missCount().getValue().doubleValue(),
-                            requestCount().getValue().doubleValue());
-                }
-            };
-        }
     }
 }

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/InternalCacheMetricsTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/InternalCacheMetricsTest.java
@@ -34,7 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 final class InternalCacheMetricsTest {
 
     @Mock
-    InternalCacheMetrics.Stats stats;
+    CacheMetrics.Stats stats;
 
     @Test
     void createMetrics() {
@@ -84,8 +84,8 @@ final class InternalCacheMetricsTest {
                         .build());
     }
 
-    private static InternalCacheMetrics.Stats emptyStats() {
-        return new InternalCacheMetrics.Stats() {
+    private static CacheMetrics.Stats emptyStats() {
+        return new CacheMetrics.Stats() {
             @Override
             public Gauge<Long> estimatedSize() {
                 return () -> 0L;


### PR DESCRIPTION
After profiling an internal product, we noticed that a non-negligible amount of CPU time was spent updating the `LongAdder` fields in Caffeine's `ConcurrentStatsCounter`. To improve performance, we changed the implementation to count stats per-request in a non-thread-safe way and then batch update the registered counters after handling the request.

Unfortunately this required using some methods in the internal but public `InternalCacheMetrics`. We needed to implement `Stats` and use the static methods to register our metrics with the canonical names.

For details, see https://g.p.b/foundry/multipass/pull/11551

This PR is an attempt to expose the ability to use custom `Stats` implementations without using internal classes.

There are a lot of cache-related classes in Tritium and the division of responsibility is not obvious. I attempted to implement this in a way I thought was most inline with the current design, but please let me know if you'd prefer to structure this differently - I have no real preference on the design here.