### PR TITLE
Tritium SSLEngine handshake instrumentation avoids reflection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   unit-test-11:
-    docker: [{ image: 'circleci/openjdk:11-node' }]
+    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
     resource_class: large
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -120,7 +120,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   unit-test-15:
-    docker: [{ image: 'circleci/openjdk:11-node' }]
+    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
     resource_class: large
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2.1
 jobs:
   compile:
-    docker: [{ image: 'circleci/openjdk:8u222-stretch-node' }]
+    docker: [{ image: 'cimg/openjdk:8.0.282-node' }]
     resource_class: large
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -54,7 +54,7 @@ jobs:
           paths: [ project, .gradle/init.gradle ]
 
   check:
-    docker: [{ image: 'circleci/openjdk:8u222-stretch-node' }]
+    docker: [{ image: 'cimg/openjdk:8.0.282-node' }]
     resource_class: medium
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -76,7 +76,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   unit-test:
-    docker: [{ image: 'circleci/openjdk:8u222-stretch-node' }]
+    docker: [{ image: 'cimg/openjdk:8.0.282-node' }]
     resource_class: large
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -149,7 +149,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   trial-publish:
-    docker: [{ image: 'circleci/openjdk:8u222-stretch-node' }]
+    docker: [{ image: 'cimg/openjdk:8.0.282-node' }]
     resource_class: medium
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -171,7 +171,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   publish:
-    docker: [{ image: 'circleci/openjdk:8u222-stretch-node' }]
+    docker: [{ image: 'cimg/openjdk:8.0.282-node' }]
     resource_class: medium
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit

--- a/changelog/@unreleased/pr-1072.v2.yml
+++ b/changelog/@unreleased/pr-1072.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Tritium SSLEngine handshake instrumentation avoids reflection
+  links:
+  - https://github.com/palantir/tritium/pull/1072

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/InstrumentedSslContextTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/InstrumentedSslContextTest.java
@@ -130,9 +130,6 @@ final class InstrumentedSslContextTest {
 
     @Test
     void testClientInstrumentationOkHttpHttp2() throws Exception {
-        assumeThat(IS_JAVA_8)
-                .describedAs("Java 8 does not support ALPN without additional help")
-                .isFalse();
         TaggedMetricRegistry metrics = new DefaultTaggedMetricRegistry();
         SSLSocketFactory socketFactory =
                 MetricRegistries.instrument(metrics, newClientContext().getSocketFactory(), "okhttp-client");


### PR DESCRIPTION
Checking for older java 8 releases was necessary when ALPN support
was initially backported, however at this point it's incredibly
dangerous to run outdated runtimes, and our environments upgraded
long ago. Furthermore, the risk of introducing bugs when using
an old JRE is incredibly low, and requires a framework which
attempts to reflectively discover SSLEngine methods.

## After this PR
==COMMIT_MSG==
Tritium SSLEngine handshake instrumentation avoids reflection
==COMMIT_MSG==

