### PR TITLE
CaffeineCacheStats.record for Caffeine stats recording

### DIFF
--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStats.java
@@ -110,7 +110,6 @@ public final class CaffeineCacheStats {
      * @return stats counter
      */
     public static StatsCounter record(TaggedMetricRegistry registry, @Safe String name) {
-        //        return CaffeineCacheTaggedMetrics.statsCounter(registry, name);
         Function<String, MetricName> nameFunction = InternalCacheMetrics.taggedMetricName(name);
         return new TaggedCaffeineStatsCounter(
                 registry.counter(nameFunction.apply("cache.hit.count")),


### PR DESCRIPTION
## Before this PR
Setting up Caffeine stats recording was slightly awkward and required enabling `Caffeine#recordStats()` then `CaffeineCacheStats#registerCache`.

## After this PR
Similar to https://github.com/palantir/tritium/pull/1041

==COMMIT_MSG==
CaffeineCacheStats.record for Caffeine stats recording

This streamlines providing a `StatsCounter` with tagged metrics for use with `Caffeine#recordStats(Supplier<? extends StatsCounter>)` during cache building, for example

```
Caffeine.newBuilder()
    .recordStats(() -> CaffeineCacheStats.record(taggedMetricRegistry, "cacheName")
    .build()
```

==COMMIT_MSG==

## Possible downsides?
Haven't provided similar for Guava caches, but those should be migrated to Caffeine anyway

