### PR TITLE
Enable gradle incremental annotation processing for tritium-processor

### DIFF
--- a/changelog/@unreleased/pr-1085.v2.yml
+++ b/changelog/@unreleased/pr-1085.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Enable gradle incremental annotation processing for tritium-processor
+  links:
+  - https://github.com/palantir/tritium/pull/1085

--- a/tritium-processor/build.gradle
+++ b/tritium-processor/build.gradle
@@ -14,9 +14,6 @@ dependencies {
     compile 'com.google.code.findbugs:jsr305'
     compile 'com.palantir.safe-logging:preconditions'
 
-    annotationProcessor 'com.google.auto.service:auto-service'
-    compileOnly 'com.google.auto.service:auto-service-annotations'
-
     testImplementation 'com.google.testing.compile:compile-testing'
     testImplementation 'com.google.guava:guava'
     testImplementation 'org.assertj:assertj-core'

--- a/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessor.java
+++ b/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessor.java
@@ -329,7 +329,9 @@ public final class TritiumAnnotationProcessor extends AbstractProcessor {
 
         if (specBuilder.originatingElements.size() != 1) {
             messager.printMessage(
-                    Kind.ERROR, "The generated type must have exactly one originating element", typeElement);
+                    Kind.ERROR,
+                    "The generated type must have exactly one originating element: " + specBuilder.originatingElements,
+                    typeElement);
         }
         return JavaFile.builder(packageName, specBuilder.build())
                 .skipJavaLangImports(true)

--- a/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessor.java
+++ b/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessor.java
@@ -17,7 +17,6 @@
 package com.palantir.tritium.processor;
 
 import com.google.auto.common.GeneratedAnnotations;
-import com.google.auto.service.AutoService;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -53,7 +52,6 @@ import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
@@ -72,7 +70,6 @@ import javax.lang.model.util.SimpleElementVisitor8;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
 
-@AutoService(Processor.class)
 public final class TritiumAnnotationProcessor extends AbstractProcessor {
 
     private static final String DELEGATE_NAME = "delegate";

--- a/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessor.java
+++ b/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessor.java
@@ -210,7 +210,9 @@ public final class TritiumAnnotationProcessor extends AbstractProcessor {
             }
         }
 
-        TypeSpec.Builder specBuilder = TypeSpec.classBuilder(className).addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+        TypeSpec.Builder specBuilder = TypeSpec.classBuilder(className)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addOriginatingElement(typeElement);
 
         GeneratedAnnotations.generatedAnnotation(elements, SourceVersion.latest())
                 .ifPresent(te -> specBuilder.addAnnotation(AnnotationSpec.builder(ClassName.get(te))

--- a/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessor.java
+++ b/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessor.java
@@ -327,6 +327,10 @@ public final class TritiumAnnotationProcessor extends AbstractProcessor {
                         .addStatement("return builder(delegate).withTaggedMetrics(registry).withTracing().build()")
                         .build());
 
+        if (specBuilder.originatingElements.size() != 1) {
+            messager.printMessage(
+                    Kind.ERROR, "The generated type must have exactly one originating element", typeElement);
+        }
         return JavaFile.builder(packageName, specBuilder.build())
                 .skipJavaLangImports(true)
                 .indent("    ")

--- a/tritium-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/tritium-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+com.palantir.tritium.processor.TritiumAnnotationProcessor,ISOLATING

--- a/tritium-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/tritium-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+com.palantir.tritium.processor.TritiumAnnotationProcessor


### PR DESCRIPTION
Based on https://github.com/palantir/dialogue/pull/1231

I opted against using annotation processors for simplicity. I
had minor issues with intellij, and generally find META-INF files
easier to reason about that annotation processors which write
one-line files.

Documentation for incremental processing can be found here:
https://docs.gradle.org/current/userguide/java_plugin.html#sec:incremental_annotation_processing

==COMMIT_MSG==
Enable gradle incremental annotation processing for tritium-processor
==COMMIT_MSG==

## Possible downsides?
It's possible that this feature may cause issues if we attempt to
instrument types that are genereated from other annotation processors,
however that is somewhat unlikely, and the docs describe that
as a valid case for `isolating` configuration.

