### PR TITLE
JMH gradle plugin 0.6.4

### DIFF
--- a/changelog/@unreleased/pr-1088.v2.yml
+++ b/changelog/@unreleased/pr-1088.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: JMH gradle plugin 0.6.4
+  links:
+  - https://github.com/palantir/tritium/pull/1088

--- a/tritium-jmh/build.gradle
+++ b/tritium-jmh/build.gradle
@@ -5,11 +5,11 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'me.champeau.gradle:jmh-gradle-plugin:0.5.3'
+        classpath 'me.champeau.jmh:jmh-gradle-plugin:0.6.4'
     }
 }
 
-apply plugin: 'me.champeau.gradle.jmh'
+apply plugin: 'me.champeau.jmh'
 
 jmh {
     // Use profilers to collect additional data. Supported profilers:


### PR DESCRIPTION
## Before this PR
Excavator gradle plugin bumps stopped for the JMH gradle plugin due to migration from gradle plugin ID `me.champeau.gradle.jmh` to `me.champeau.jmh` in [version 0.6.0](https://github.com/melix/jmh-gradle-plugin/blob/master/CHANGELOG.txt#L18).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
JMH gradle plugin 0.6.4
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

