### PR TITLE
Simplify TritiumAnnotationProcessor annotation selection

### DIFF
--- a/changelog/@unreleased/pr-1108.v2.yml
+++ b/changelog/@unreleased/pr-1108.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Simplify TritiumAnnotationProcessor `@Generated` annotation selection
+  links:
+  - https://github.com/palantir/tritium/pull/1108

--- a/tritium-processor/build.gradle
+++ b/tritium-processor/build.gradle
@@ -8,9 +8,6 @@ dependencies {
 
     compile 'com.squareup:javapoet'
     compile 'com.google.guava:guava'
-    // Used for 'GeneratedAnnotations.generatedAnnotation' to select the correct annotation
-    // based on source compatibility. This can be simplified once java 8 support is removed.
-    compile 'com.google.auto:auto-common'
     compile 'com.google.code.findbugs:jsr305'
     compile 'com.palantir.safe-logging:preconditions'
 

--- a/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessor.java
+++ b/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessor.java
@@ -16,7 +16,6 @@
 
 package com.palantir.tritium.processor;
 
-import com.google.auto.common.GeneratedAnnotations;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -50,6 +49,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
+import javax.annotation.processing.Generated;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
@@ -212,12 +212,10 @@ public final class TritiumAnnotationProcessor extends AbstractProcessor {
 
         TypeSpec.Builder specBuilder = TypeSpec.classBuilder(className)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addOriginatingElement(typeElement);
-
-        GeneratedAnnotations.generatedAnnotation(elements, SourceVersion.latest())
-                .ifPresent(te -> specBuilder.addAnnotation(AnnotationSpec.builder(ClassName.get(te))
+                .addOriginatingElement(typeElement)
+                .addAnnotation(AnnotationSpec.builder(Generated.class)
                         .addMember("value", "$S", getClass().getName())
-                        .build()));
+                        .build());
 
         if (typeElement.getAnnotation(Deprecated.class) != null) {
             specBuilder.addAnnotation(Deprecated.class);

--- a/versions.lock
+++ b/versions.lock
@@ -5,7 +5,6 @@ com.fasterxml.jackson.core:jackson-databind:2.11.3 (3 constraints: 4a3a2999)
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.3 (1 constraints: cf0c0316)
 com.fasterxml.jackson.module:jackson-module-afterburner:2.11.3 (1 constraints: cf0c0316)
 com.github.ben-manes.caffeine:caffeine:3.0.2 (1 constraints: 0705fc35)
-com.google.auto:auto-common:1.0.1 (2 constraints: ea169a19)
 com.google.auto.service:auto-service-annotations:1.0 (1 constraints: a5041a2c)
 com.google.code.findbugs:jsr305:3.0.2 (4 constraints: 5c3586ed)
 com.google.errorprone:error_prone_annotations:2.7.1 (6 constraints: 2247b888)
@@ -29,6 +28,7 @@ org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir:1.1.3 (1 constraint
 org.slf4j:slf4j-api:1.7.30 (6 constraints: 6f4d418a)
 
 [Test dependencies]
+com.google.auto:auto-common:1.0.1 (1 constraints: e711f5e8)
 com.google.auto.value:auto-value:1.7.4 (1 constraints: 1f1221fb)
 com.google.auto.value:auto-value-annotations:1.7.4 (1 constraints: 640a29b9)
 com.google.testing.compile:compile-testing:0.19 (1 constraints: de04f630)


### PR DESCRIPTION
Now that we require java11, there's no need to support the legacy
annotation.

==COMMIT_MSG==
Simplify TritiumAnnotationProcessor `@Generated` annotation selection
==COMMIT_MSG==

