### PR TITLE
Add autorelease autolabeler for java changes

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,0 +1,1 @@
+'autorelease': ['*/src/main/**/*.java']


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Changes involving `*.java` files were not autolabeled for autorelease.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add autorelease autolabeler for java changes
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

