### PR TITLE
The Instrument annotation uses source retention

### DIFF
--- a/changelog/@unreleased/pr-1116.v2.yml
+++ b/changelog/@unreleased/pr-1116.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The `@Instrument` annotation uses source retention (down from class
+    retention)
+  links:
+  - https://github.com/palantir/tritium/pull/1116

--- a/tritium-annotations/src/main/java/com/palantir/tritium/annotations/Instrument.java
+++ b/tritium-annotations/src/main/java/com/palantir/tritium/annotations/Instrument.java
@@ -31,5 +31,5 @@ import java.lang.annotation.Target;
  * exactly match the target interface.
  */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.SOURCE)
 public @interface Instrument {}


### PR DESCRIPTION
It's unnecessary to retain the annotation in the CLASS, it's only
used by the annotation processor.

==COMMIT_MSG==
The `@Instrument` annotation uses source retention (down from class retention)
==COMMIT_MSG==

