### PR TITLE
Share single DefaultTaggedMetricRegistry backed by LockFreeExponentiallyDecayingReservoir

### DIFF
--- a/changelog/@unreleased/pr-1135.v2.yml
+++ b/changelog/@unreleased/pr-1135.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: SharedTaggedMetricRegistries.getSingleton() uses DefaultTaggedMetricRegistry
+    backed by LockFreeExponentiallyDecayingReservoir
+  links:
+  - https://github.com/palantir/tritium/pull/1135

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/DefaultTaggedMetricRegistry.java
@@ -20,6 +20,7 @@ import com.google.auto.service.AutoService;
 
 @AutoService(TaggedMetricRegistry.class)
 public final class DefaultTaggedMetricRegistry extends AbstractTaggedMetricRegistry {
+    private static final TaggedMetricRegistry DEFAULT = new DefaultTaggedMetricRegistry();
 
     public DefaultTaggedMetricRegistry() {
         super(() -> LockFreeExponentiallyDecayingReservoir.builder().build());
@@ -33,6 +34,6 @@ public final class DefaultTaggedMetricRegistry extends AbstractTaggedMetricRegis
     @SuppressWarnings("unused") // public API
     @Deprecated
     public static TaggedMetricRegistry getDefault() {
-        return SharedTaggedMetricRegistries.getSingleton();
+        return DEFAULT;
     }
 }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/SharedTaggedMetricRegistries.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/SharedTaggedMetricRegistries.java
@@ -17,21 +17,11 @@
 package com.palantir.tritium.metrics.registry;
 
 import com.codahale.metrics.SharedMetricRegistries;
-import java.util.concurrent.TimeUnit;
 
-/** Analogous to codahale's {@link SharedMetricRegistries}. */
+/**
+ * Analogous to codahale's {@link SharedMetricRegistries}.
+ */
 public final class SharedTaggedMetricRegistries {
-
-    /**
-     * With a window size of 35 seconds, metric loggers should dump this registry more frequently (e.g. every 30
-     * seconds). Reading from this registry on a slower interval (e.g. every 5 minutes) is not recommended because the
-     * sample would only represent the last 35seconds, and information from the preceding 4m25 would be lost.
-     *
-     * <p>Increasing the window size would also increase the memory footprint. SlidingTimeWindowArrayReservoir takes
-     * ~128 bits per stored measurement, 10K measurements / sec with reservoir storing time of 35s is: 10_000 * 35 * 128
-     * / 8 = 5600000 bytes ~ 5 megabytes.
-     */
-    private static final TaggedMetricRegistry DEFAULT = new SlidingWindowTaggedMetricRegistry(35, TimeUnit.SECONDS);
 
     /**
      * Single shared instance for use when it is infeasible to plumb through a user supplied instance.
@@ -40,7 +30,7 @@ public final class SharedTaggedMetricRegistries {
      */
     @Deprecated
     public static TaggedMetricRegistry getSingleton() {
-        return DEFAULT;
+        return DefaultTaggedMetricRegistry.getDefault();
     }
 
     private SharedTaggedMetricRegistries() {}

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/SharedTaggedMetricRegistriesTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/SharedTaggedMetricRegistriesTest.java
@@ -27,6 +27,6 @@ final class SharedTaggedMetricRegistriesTest {
         TaggedMetricRegistry defaultRegistry = SharedTaggedMetricRegistries.getSingleton();
         assertThat(DefaultTaggedMetricRegistry.getDefault()).isSameAs(defaultRegistry);
         assertThat(SharedTaggedMetricRegistries.getSingleton()).isSameAs(defaultRegistry);
-        assertThat(defaultRegistry).isInstanceOf(SlidingWindowTaggedMetricRegistry.class);
+        assertThat(defaultRegistry).isInstanceOf(DefaultTaggedMetricRegistry.class);
     }
 }


### PR DESCRIPTION
## Before this PR
Default deprecated `SharedTaggedMetricRegistries.getSingleton()` was concurrency bottleneck as it uses `SlidingTimeWindowArrayReservoir`.

```
   java.lang.Thread.State: BLOCKED (on object monitor)
        at com.codahale.metrics.ChunkedAssociativeLongArray.put(ChunkedAssociativeLongArray.java:59)
        - waiting to lock <0x000000020379b6c0> (a com.codahale.metrics.ChunkedAssociativeLongArray)
        at com.codahale.metrics.SlidingTimeWindowArrayReservoir.update(SlidingTimeWindowArrayReservoir.java:69)
        at com.codahale.metrics.Histogram.update(Histogram.java:41)
        at com.codahale.metrics.Timer.update(Timer.java:185)
        at com.codahale.metrics.Timer.update(Timer.java:89)
        at com.palantir.tritium.event.metrics.TaggedMetricsServiceInvocationEventHandler.onSuccess(TaggedMetricsServiceInvocationEventHandler.java:91)
        at com.palantir.tritium.event.Handlers.onSuccess(Handlers.java:100)
        at com.palantir.tritium.event.CompositeInvocationEventHandler.success(CompositeInvocationEventHandler.java:72)
        at com.palantir.tritium.event.CompositeInvocationEventHandler.onSuccess(CompositeInvocationEventHandler.java:66)
        at com.palantir.tritium.event.Handlers.onSuccess(Handlers.java:100)
        at com.palantir.tritium.proxy.InstrumentedKeyFileStore$8.readWithMetadata(Unknown Source)
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
SharedTaggedMetricRegistries.getSingleton() uses DefaultTaggedMetricRegistry backed by LockFreeExponentiallyDecayingReservoir
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
This is a behavior change in how metrics are recorded, but most everything switched over to `DefaultTaggedMetricRegistry` using `LockFreeExponentiallyDecayingReservoir` back in #860 in September 2020.

