### PR TITLE
Report the number of loaded classes as an isolated metric

### DIFF
--- a/changelog/@unreleased/pr-1142.v2.yml
+++ b/changelog/@unreleased/pr-1142.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Report the number of loaded classes as an isolated metric
+  links:
+  - https://github.com/palantir/tritium/pull/1142

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -82,6 +82,7 @@ public final class JvmMetrics {
     private static void registerClassLoading(InternalJvmMetrics metrics) {
         ClassLoadingMXBean classLoadingBean = ManagementFactory.getClassLoadingMXBean();
         metrics.classloaderLoaded(classLoadingBean::getTotalLoadedClassCount);
+        metrics.classloaderLoadedCurrent(classLoadingBean::getLoadedClassCount);
         metrics.classloaderUnloaded(classLoadingBean::getUnloadedClassCount);
     }
 

--- a/tritium-metrics-jvm/src/main/metrics/metrics.yml
+++ b/tritium-metrics-jvm/src/main/metrics/metrics.yml
@@ -43,10 +43,13 @@ namespaces:
         - javaVmVendor
       classloader.loaded:
         type: gauge
-        docs: Total number of classes that have been loaded.
+        docs: Total number of classes that have been loaded since the jvm started.
       classloader.unloaded:
         type: gauge
-        docs: Total number of classes that have been unloaded.
+        docs: Total number of classes that have been unloaded since the jvm started.
+      classloader.loaded.current:
+        type: gauge
+        docs: Number of classes that are currently loaded.
       threads.count:
         type: gauge
         docs: Total number of live threads.


### PR DESCRIPTION
## Before this PR
Previously we reported both the total loaded and unloaded classes,
the latter of which could be subtracted from the former to derive
the current value. Our monitoring/alerting framework doesn't
support math, so another metric is required to alert on
excessive class loading.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Report the number of loaded classes as an isolated metric
==COMMIT_MSG==

## Possible downsides?
More metrics to describe things we already know.
