### PR TITLE
EqualsMissingNullable Add @Nullable to equals

### DIFF
--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/annotations/AnnotationHelper.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/annotations/AnnotationHelper.java
@@ -132,7 +132,7 @@ public final class AnnotationHelper {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             if (this == other) {
                 return true;
             }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslContext.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslContext.java
@@ -19,6 +19,7 @@ package com.palantir.tritium.metrics;
 import java.security.KeyManagementException;
 import java.security.SecureRandom;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLContextSpi;
@@ -46,7 +47,7 @@ final class InstrumentedSslContext extends SSLContext {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         if (this == other) {
             return true;
         }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslEngine.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslEngine.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
@@ -263,7 +264,7 @@ final class InstrumentedSslEngine extends SSLEngine {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         if (this == other) {
             return true;
         }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslServerSocketFactory.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslServerSocketFactory.java
@@ -24,6 +24,7 @@ import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.channels.ServerSocketChannel;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
@@ -78,7 +79,7 @@ final class InstrumentedSslServerSocketFactory extends SSLServerSocketFactory {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         if (this == other) {
             return true;
         }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslSocketFactory.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/InstrumentedSslSocketFactory.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -89,7 +90,7 @@ final class InstrumentedSslSocketFactory extends SSLSocketFactory {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         if (this == other) {
             return true;
         }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/ExtraEntrySortedMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/ExtraEntrySortedMap.java
@@ -197,7 +197,7 @@ final class ExtraEntrySortedMap<K, V> extends AbstractMap<K, V> implements Sorte
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         if (other instanceof ExtraEntrySortedMap) {
             ExtraEntrySortedMap<?, ?> otherMap = (ExtraEntrySortedMap<?, ?>) other;
             if (extraKey.equals(otherMap.extraKey) && extraValue.equals(otherMap.extraValue)) {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/MetricName.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/MetricName.java
@@ -32,7 +32,7 @@ public interface MetricName {
     String safeName();
 
     /**
-     * Metadata/coordinates for where a particular measure came from. Used for filtering & grouping.
+     * Metadata/coordinates for where a particular measure came from. Used for filtering and grouping.
      *
      * <p>All tags and keys must be {@link Safe} to log.
      */

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/RealMetricName.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/RealMetricName.java
@@ -20,6 +20,7 @@ import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableSortedMap;
 import java.util.SortedMap;
+import javax.annotation.Nullable;
 
 final class RealMetricName implements MetricName {
     private static final SortedMap<String, String> EMPTY = prehash(ImmutableSortedMap.of());
@@ -63,7 +64,7 @@ final class RealMetricName implements MetricName {
 
     @Override
     @SuppressWarnings("JdkObsolete") // SortedMap is part of Metrics API
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         if (!(other instanceof MetricName)) {
             return false;
         }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Upgrade to error-prone 2.8.0 will fail to build due to several warnings for [EqualsMissingNullable](https://errorprone.info/bugpattern/EqualsMissingNullable) in excavator https://github.com/palantir/tritium/pull/1158

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
EqualsMissingNullable Add @Nullable to equals
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

