### PR TITLE
Enforce 'PreferSafeLogger'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,8 @@ allprojects {
                         'PreferCollectionTransform',
                         'PreferListsPartition',
                         'PreferSafeLoggingPreconditions',
-                        'PreferSafeLoggableExceptions'
+                        'PreferSafeLoggableExceptions',
+                        'PreferSafeLogger'
 
                 // increase strictness for built-in error-prone checks
                 error((com.google.errorprone.scanner.BuiltInCheckerSuppliers.ENABLED_WARNINGS +


### PR DESCRIPTION
PreferSafeLogger is defined in gradle-baseline and leveraged by
the excavator automation (see #1168). We plan to begin enforcing
this check in the coming weeks/months, however it can be enabled
earlier in projects that have taken the migration.

==COMMIT_MSG==
Enforce 'PreferSafeLogger'
==COMMIT_MSG==

