### PR TITLE
JavaDoc uses UTF-8 encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,7 @@ allprojects {
     }
 
     tasks.withType(Javadoc) {
+        options.addStringOption('encoding', 'UTF-8')
         // suppress Javadoc doclint warnings in Java 8+
         if (!System.getProperty("java.version").startsWith("1.7")) {
             options.addStringOption('Xdoclint:none', '-quiet')


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

https://github.com/palantir/tritium/issues/1192 JavaDoc is failing to generate on system using default US-ASCII encoding

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
JavaDoc uses UTF-8 encoding
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

