### PR TITLE
Instrumented executors report the correct 'submitted' value after rejection

### DIFF
--- a/changelog/@unreleased/pr-1209.v2.yml
+++ b/changelog/@unreleased/pr-1209.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Instrumented executors report the correct `submitted` metric value
+    after tasks have been rejected
+  links:
+  - https://github.com/palantir/tritium/pull/1209


### PR DESCRIPTION
## Before this PR
Previously the 'submitted' metric was updated prior to interactions
with the delegate executor, producing data which suggested the
underlying thread pool or queue may be much larger than they are
in practice.

## After this PR
Now the meter is updated after tasks are submitted. The data may
be skewed/delayed in the case of a direct (same-thread) implementation,
however those are much rarer than thread pool shutdown, and generally
aren't instrumented.
==COMMIT_MSG==
Instrumented executors report the correct `submitted` metric value after tasks have been rejected
==COMMIT_MSG==

