### PR TITLE
Remove unnecessary executor metrics

### DIFF
--- a/changelog/@unreleased/pr-1230-pt2.v2.yml
+++ b/changelog/@unreleased/pr-1230-pt2.v2.yml
@@ -1,0 +1,9 @@
+type: break
+break:
+  description: >
+    Remove unnecessary `executor.threads.terminated` metric which can be estimated by subtracting
+    running threads from created threads. The rate that threads terminate is generally less
+    interesting than the rate that they're created because termination most often occurs after
+    some timeout.
+  links:
+  - https://github.com/palantir/tritium/pull/1230

--- a/changelog/@unreleased/pr-1230.v2.yml
+++ b/changelog/@unreleased/pr-1230.v2.yml
@@ -4,9 +4,8 @@ break:
     identical to the `count` value of the `executor.duration` timer. Dashboards will
     need to replace the former with the latter.\n* `executor.scheduled.percent-of-period`
     is unused, our pipeline has filtered out the metric for a while now to reduce
-    bloat.\n* `executor.scheduled.once` and `executor.scheduled.repetitively` have
-    been collapsed into `executor.submitted` because they measure the same thing.
-    This should allow more existing dashboards to handle scheduled executors without
-    updates."
+    bloat.\n*  Scheduled executors no longer produce `executor.scheduled.once`,
+    `executor.scheduled.repetitively`, or `executor.submitted` because they are not
+    meaningful when some tasks recur."
   links:
   - https://github.com/palantir/tritium/pull/1230

--- a/changelog/@unreleased/pr-1230.v2.yml
+++ b/changelog/@unreleased/pr-1230.v2.yml
@@ -1,0 +1,12 @@
+type: break
+break:
+  description: "Remove unnecessary executor metrics. \n\n* `executor.completed` is
+    identical to the `count` value of the `executor.duration` timer. Dashboards will
+    need to replace the former with the latter.\n* `executor.scheduled.percent-of-period`
+    is unused, our pipeline has filtered out the metric for a while now to reduce
+    bloat.\n* `executor.scheduled.once` and `executor.scheduled.repetitively` have
+    been collapsed into `executor.submitted` because they measure the same thing.
+    This should allow more existing dashboards to handle scheduled executors without
+    updates."
+  links:
+  - https://github.com/palantir/tritium/pull/1230

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsExecutorService.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsExecutorService.java
@@ -34,7 +34,6 @@ final class TaggedMetricsExecutorService extends AbstractExecutorService {
 
     private final Meter submitted;
     private final Counter running;
-    private final Meter completed;
     private final Timer duration;
 
     @Nullable
@@ -46,7 +45,6 @@ final class TaggedMetricsExecutorService extends AbstractExecutorService {
         this.name = name;
         this.submitted = metrics.submitted(name);
         this.running = metrics.running(name);
-        this.completed = metrics.completed(name);
         this.duration = metrics.duration(name);
         this.queuedDuration = reportQueuedDuration ? metrics.queuedDuration(name) : null;
     }
@@ -141,7 +139,6 @@ final class TaggedMetricsExecutorService extends AbstractExecutorService {
                 task.run();
             } finally {
                 running.dec();
-                completed.mark();
             }
         }
 
@@ -172,7 +169,6 @@ final class TaggedMetricsExecutorService extends AbstractExecutorService {
                 return task.call();
             } finally {
                 running.dec();
-                completed.mark();
             }
         }
 

--- a/tritium-metrics/src/main/metrics/metrics.yml
+++ b/tritium-metrics/src/main/metrics/metrics.yml
@@ -72,10 +72,6 @@ namespaces:
         type: timer
         tags: [executor]
         docs: A timer of the time it took a task to start running after it was submitted.
-      scheduled.repetitively:
-        type: meter
-        tags: [executor]
-        docs: A meter of the number of repetitive scheduled tasks. Applies only to scheduled executors.
       scheduled.overrun:
         type: counter
         tags: [executor]

--- a/tritium-metrics/src/main/metrics/metrics.yml
+++ b/tritium-metrics/src/main/metrics/metrics.yml
@@ -64,10 +64,6 @@ namespaces:
         type: counter
         tags: [executor]
         docs: A gauge of the number of running tasks.
-      completed:
-        type: meter
-        tags: [executor]
-        docs: A meter of the number of completed tasks.
       duration:
         type: timer
         tags: [executor]
@@ -76,10 +72,6 @@ namespaces:
         type: timer
         tags: [executor]
         docs: A timer of the time it took a task to start running after it was submitted.
-      scheduled.once:
-        type: meter
-        tags: [executor]
-        docs: A meter of the number of one-shot scheduled tasks. Applies only to scheduled executors.
       scheduled.repetitively:
         type: meter
         tags: [executor]
@@ -88,10 +80,6 @@ namespaces:
         type: counter
         tags: [executor]
         docs: A gauge of the number of fixed-rate scheduled tasks that overran the scheduled rate. Applies only to scheduled executors.
-      scheduled.percent-of-period:
-        type: histogram
-        tags: [executor]
-        docs: A histogram of the time it took to run a fixed-rate scheduled task as a percentage of the scheduled rate. Applies only to scheduled executors.
       # ThreadFactory metrics
       threads.created:
         type: meter

--- a/tritium-metrics/src/main/metrics/metrics.yml
+++ b/tritium-metrics/src/main/metrics/metrics.yml
@@ -81,10 +81,6 @@ namespaces:
         type: meter
         tags: [executor]
         docs: Rate that new threads are created for this executor.
-      threads.terminated:
-        type: meter
-        tags: [executor]
-        docs: Rate that executor threads are terminated.
       threads.running:
         type: counter
         tags: [executor]

--- a/tritium-metrics/src/main/metrics/metrics.yml
+++ b/tritium-metrics/src/main/metrics/metrics.yml
@@ -63,7 +63,7 @@ namespaces:
       running:
         type: counter
         tags: [executor]
-        docs: A gauge of the number of running tasks.
+        docs: The number of running tasks.
       duration:
         type: timer
         tags: [executor]

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsExecutorServiceTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsExecutorServiceTest.java
@@ -43,7 +43,6 @@ final class TaggedMetricsExecutorServiceTest {
 
         assertThat(metrics.submitted(NAME).getCount()).isZero();
         assertThat(metrics.running(NAME).getCount()).isZero();
-        assertThat(metrics.completed(NAME).getCount()).isZero();
         assertThat(metrics.duration(NAME).getCount()).isZero();
         assertThat(metrics.queuedDuration(NAME).getCount()).isZero();
 
@@ -60,7 +59,6 @@ final class TaggedMetricsExecutorServiceTest {
 
         assertThat(metrics.submitted(NAME).getCount()).isOne();
         assertThat(metrics.running(NAME).getCount()).isOne();
-        assertThat(metrics.completed(NAME).getCount()).isZero();
         assertThat(metrics.duration(NAME).getCount()).isZero();
         assertThat(metrics.queuedDuration(NAME).getCount()).isOne();
 
@@ -69,7 +67,6 @@ final class TaggedMetricsExecutorServiceTest {
 
         assertThat(metrics.submitted(NAME).getCount()).isOne();
         assertThat(metrics.running(NAME).getCount()).isZero();
-        assertThat(metrics.completed(NAME).getCount()).isOne();
         assertThat(metrics.duration(NAME).getCount()).isOne();
         assertThat(metrics.queuedDuration(NAME).getCount()).isOne();
     }
@@ -87,7 +84,6 @@ final class TaggedMetricsExecutorServiceTest {
 
         assertThat(metrics.submitted(NAME).getCount()).isZero();
         assertThat(metrics.running(NAME).getCount()).isZero();
-        assertThat(metrics.completed(NAME).getCount()).isZero();
         assertThat(metrics.duration(NAME).getCount()).isZero();
         assertThat(metrics.queuedDuration(NAME).getCount()).isZero();
 
@@ -104,7 +100,6 @@ final class TaggedMetricsExecutorServiceTest {
 
         assertThat(metrics.submitted(NAME).getCount()).isOne();
         assertThat(metrics.running(NAME).getCount()).isOne();
-        assertThat(metrics.completed(NAME).getCount()).isZero();
         assertThat(metrics.duration(NAME).getCount()).isZero();
         assertThat(metrics.queuedDuration(NAME).getCount()).isZero();
 
@@ -113,7 +108,6 @@ final class TaggedMetricsExecutorServiceTest {
 
         assertThat(metrics.submitted(NAME).getCount()).isOne();
         assertThat(metrics.running(NAME).getCount()).isZero();
-        assertThat(metrics.completed(NAME).getCount()).isOne();
         assertThat(metrics.duration(NAME).getCount()).isOne();
         assertThat(metrics.queuedDuration(NAME).getCount()).isZero();
     }

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsScheduledExecutorServiceTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsScheduledExecutorServiceTest.java
@@ -45,7 +45,6 @@ final class TaggedMetricsScheduledExecutorServiceTest {
 
         assertThat(metrics.submitted(NAME).getCount()).isZero();
         assertThat(metrics.running(NAME).getCount()).isZero();
-        assertThat(metrics.completed(NAME).getCount()).isZero();
         assertThat(metrics.duration(NAME).getCount()).isZero();
 
         CountDownLatch startLatch = new CountDownLatch(1);
@@ -61,7 +60,6 @@ final class TaggedMetricsScheduledExecutorServiceTest {
 
         assertThat(metrics.submitted(NAME).getCount()).isOne();
         assertThat(metrics.running(NAME).getCount()).isOne();
-        assertThat(metrics.completed(NAME).getCount()).isZero();
         assertThat(metrics.duration(NAME).getCount()).isZero();
 
         finishLatch.countDown();
@@ -69,7 +67,6 @@ final class TaggedMetricsScheduledExecutorServiceTest {
 
         assertThat(metrics.submitted(NAME).getCount()).isOne();
         assertThat(metrics.running(NAME).getCount()).isZero();
-        assertThat(metrics.completed(NAME).getCount()).isOne();
         assertThat(metrics.duration(NAME).getCount()).isOne();
     }
 
@@ -80,25 +77,25 @@ final class TaggedMetricsScheduledExecutorServiceTest {
                 MetricRegistries.instrument(registry, Executors.newSingleThreadScheduledExecutor(), NAME);
         ExecutorMetrics metrics = ExecutorMetrics.of(registry);
 
-        assertThat(metrics.scheduledOnce(NAME).getCount()).isZero();
+        assertThat(metrics.submitted(NAME).getCount()).isZero();
         assertThat(metrics.scheduledRepetitively(NAME).getCount()).isZero();
 
         assertThat((Future<?>) executorService.schedule(() -> {}, 1L, TimeUnit.DAYS))
                 .isNotNull();
 
-        assertThat(metrics.scheduledOnce(NAME).getCount()).isOne();
+        assertThat(metrics.submitted(NAME).getCount()).isOne();
         assertThat(metrics.scheduledRepetitively(NAME).getCount()).isZero();
 
         assertThat((Future<?>) executorService.scheduleAtFixedRate(() -> {}, 1L, 1L, TimeUnit.DAYS))
                 .isNotNull();
 
-        assertThat(metrics.scheduledOnce(NAME).getCount()).isOne();
+        assertThat(metrics.submitted(NAME).getCount()).isOne();
         assertThat(metrics.scheduledRepetitively(NAME).getCount()).isOne();
 
         assertThat((Future<?>) executorService.scheduleWithFixedDelay(() -> {}, 1L, 1L, TimeUnit.DAYS))
                 .isNotNull();
 
-        assertThat(metrics.scheduledOnce(NAME).getCount()).isOne();
+        assertThat(metrics.submitted(NAME).getCount()).isOne();
         assertThat(metrics.scheduledRepetitively(NAME).getCount()).isEqualTo(2);
     }
 
@@ -110,7 +107,6 @@ final class TaggedMetricsScheduledExecutorServiceTest {
         ExecutorMetrics metrics = ExecutorMetrics.of(registry);
 
         assertThat(metrics.scheduledOverrun(NAME).getCount()).isZero();
-        assertThat(metrics.scheduledPercentOfPeriod(NAME).getCount()).isZero();
 
         Semaphore startSemaphore = new Semaphore(0);
         Semaphore finishSemaphore = new Semaphore(1);
@@ -128,14 +124,12 @@ final class TaggedMetricsScheduledExecutorServiceTest {
         startSemaphore.acquire(2);
 
         assertThat(metrics.scheduledOverrun(NAME).getCount()).isZero();
-        assertThat(metrics.scheduledPercentOfPeriod(NAME).getCount()).isOne();
 
         TimeUnit.MILLISECONDS.sleep(2);
         finishSemaphore.release();
         startSemaphore.acquire();
 
         assertThat(metrics.scheduledOverrun(NAME).getCount()).isOne();
-        assertThat(metrics.scheduledPercentOfPeriod(NAME).getCount()).isEqualTo(2);
     }
 
     @ParameterizedTest

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsScheduledExecutorServiceTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsScheduledExecutorServiceTest.java
@@ -78,25 +78,21 @@ final class TaggedMetricsScheduledExecutorServiceTest {
         ExecutorMetrics metrics = ExecutorMetrics.of(registry);
 
         assertThat(metrics.submitted(NAME).getCount()).isZero();
-        assertThat(metrics.scheduledRepetitively(NAME).getCount()).isZero();
 
         assertThat((Future<?>) executorService.schedule(() -> {}, 1L, TimeUnit.DAYS))
                 .isNotNull();
 
         assertThat(metrics.submitted(NAME).getCount()).isOne();
-        assertThat(metrics.scheduledRepetitively(NAME).getCount()).isZero();
 
         assertThat((Future<?>) executorService.scheduleAtFixedRate(() -> {}, 1L, 1L, TimeUnit.DAYS))
                 .isNotNull();
 
-        assertThat(metrics.submitted(NAME).getCount()).isOne();
-        assertThat(metrics.scheduledRepetitively(NAME).getCount()).isOne();
+        assertThat(metrics.submitted(NAME).getCount()).isEqualTo(2);
 
         assertThat((Future<?>) executorService.scheduleWithFixedDelay(() -> {}, 1L, 1L, TimeUnit.DAYS))
                 .isNotNull();
 
-        assertThat(metrics.submitted(NAME).getCount()).isOne();
-        assertThat(metrics.scheduledRepetitively(NAME).getCount()).isEqualTo(2);
+        assertThat(metrics.submitted(NAME).getCount()).isEqualTo(3);
     }
 
     @ParameterizedTest

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsThreadFactoryTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/TaggedMetricsThreadFactoryTest.java
@@ -46,28 +46,23 @@ class TaggedMetricsThreadFactoryTest {
         ExecutorMetrics metrics = ExecutorMetrics.of(registry);
         Counter running = metrics.threadsRunning(name);
         Meter created = metrics.threadsCreated(name);
-        Meter terminated = metrics.threadsTerminated(name);
         assertThat(running.getCount()).isZero();
         assertThat(created.getCount()).isZero();
-        assertThat(terminated.getCount()).isZero();
         CountDownLatch latch = new CountDownLatch(1);
         Thread thread = instrumented.newThread(() -> Uninterruptibles.awaitUninterruptibly(latch));
         assertThat(created.getCount()).isOne();
         // thread has not started yet
         assertThat(running.getCount()).isZero();
-        assertThat(terminated.getCount()).isZero();
         thread.start();
         // Allow the thread to start in the background
         Awaitility.waitAtMost(Duration.ofSeconds(3)).untilAsserted(() -> {
             assertThat(created.getCount()).isOne();
             assertThat(running.getCount()).isOne();
-            assertThat(terminated.getCount()).isZero();
         });
         latch.countDown();
         Awaitility.waitAtMost(Duration.ofSeconds(3)).untilAsserted(() -> {
             assertThat(created.getCount()).isOne();
             assertThat(running.getCount()).isZero();
-            assertThat(terminated.getCount()).isOne();
         });
         Awaitility.waitAtMost(Duration.ofSeconds(1))
                 .untilAsserted(() -> assertThat(thread.isAlive()).isFalse());


### PR DESCRIPTION
*`executor.completed` is identical to the `count` value of the `executor.duration` timer. Dashboards will need to replace the former with the latter.
* `executor.scheduled.percent-of-period` is unused, our pipeline has filtered out the metric for a while now to reduce bloat.
* Scheduled executors no longer produce `executor.scheduled.once`, `executor.scheduled.repetitively`, or `executor.submitted` because the data isn't meaningful when load on the executor may be based on recurring tasks.
==COMMIT_MSG==
Remove unnecessary executor metrics. 
==COMMIT_MSG==

## Possible downsides?
This is a metrics _break_ which shouldn't be taken lightly.
