### PR TITLE
Test Tritium on Java 17 (only)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,35 +97,6 @@ jobs:
       - store_test_results: { path: ~/junit }
       - store_artifacts: { path: ~/artifacts }
 
-  unit-test-15:
-    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
-    resource_class: large
-    environment:
-      CIRCLE_TEST_REPORTS: /home/circleci/junit
-      CIRCLE_ARTIFACTS: /home/circleci/artifacts
-      GRADLE_OPTS: -Dorg.gradle.jvmargs='-Xmx2g' -Dorg.gradle.workers.max=2
-      _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -XX:MaxRAM=8g  -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
-      JAVA_HOME: /opt/java15
-    steps:
-      - checkout
-      - run:
-          name: Install Java
-          command: |
-            sudo mkdir -p /opt/java && cd /opt/java && sudo chown -R circleci:circleci .
-            curl https://cdn.azul.com/zulu/bin/zulu15.32.15-ca-jdk15.0.3-linux_x64.tar.gz | tar -xzf - -C /opt/java
-            sudo ln -s /opt/java/zulu*/ /opt/java15
-      - restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
-      - restore_cache: { key: 'unit-test-15-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
-      - run: ./gradlew --parallel --stacktrace --continue test -Pcom.palantir.baseline-error-prone.disable -Porg.gradle.java.installations.fromEnv=JAVA_8_HOME,JAVA_11_HOME,JAVA_15_HOME,JAVA_17_HOME,JAVA_HOME
-      - save_cache:
-          key: 'unit-test-15-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'
-          paths: [ ~/.gradle/caches ]
-      - run:
-          command: mkdir -p ~/junit && find . -type f -regex ".*/build/.*TEST.*xml" -exec cp --parents {} ~/junit/ \;
-          when: always
-      - store_test_results: { path: ~/junit }
-      - store_artifacts: { path: ~/artifacts }
-
   trial-publish:
     docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
     resource_class: medium
@@ -189,9 +160,6 @@ workflows:
           requires: [ compile ]
           filters: { tags: { only: /.*/ } }
 
-      - unit-test-15:
-          filters: { tags: { only: /.*/ } }
-
       - check:
           requires: [ compile ]
           filters: { tags: { only: /.*/ } }
@@ -204,5 +172,5 @@ workflows:
           filters: { branches: { ignore: develop } }
 
       - publish:
-          requires: [ unit-test, unit-test-15, check, trial-publish ]
+          requires: [ unit-test, check, trial-publish ]
           filters: { tags: { only: /.*/ }, branches: { only: develop } }

--- a/.circleci/template.sh
+++ b/.circleci/template.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 export CIRCLECI_TEMPLATE=java-library-oss
 export JDK=11
-export UNIT_TEST_15=true

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,12 @@ apply plugin: 'java'
 apply plugin: 'com.palantir.baseline'
 apply plugin: 'com.palantir.consistent-versions'
 apply plugin: 'com.palantir.git-version'
+apply plugin: 'com.palantir.baseline-java-versions'
+
+javaVersions {
+    libraryTarget = 11
+    runtime = 17
+}
 
 allprojects {
     group 'com.palantir.tritium'
@@ -33,11 +39,6 @@ allprojects {
     apply plugin: 'com.palantir.baseline-class-uniqueness'
     apply plugin: 'com.palantir.baseline-exact-dependencies'
     apply plugin: 'com.palantir.java-format'
-
-    java {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
-    }
 
     configurations {
         testImplementationClasspath {
@@ -122,6 +123,10 @@ allprojects {
     checkImplicitDependencies {
         // avoid spurious flags on dropwizard metrics
         ignore 'io.dropwizard.metrics', 'metrics-core'
+    }
+    checkUnusedDependencies {
+        // avoid spurious flags on junit-jupiter
+        ignore 'org.junit.jupiter', 'junit-jupiter'
     }
     tasks.check.dependsOn(checkImplicitDependencies)
     tasks.check.dependsOn(checkUnusedDependencies)


### PR DESCRIPTION
## Before this PR
Previously we tested on both Java 11 and Java 15.

I've got a note on my backlog to improve the baseline-java-versions
plugin such that arbitrarily many library test targets may be
provided, but haven't gotten around to it yet.

## After this PR
==COMMIT_MSG==
Test Tritium on Java 17 
==COMMIT_MSG==

## Possible downsides?
Fewer test targets.

