### PR TITLE
Tritium modules provide constraints on other tritium modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.google.errorprone:error_prone_core:2.10.0'
         classpath 'com.palantir.baseline:gradle-baseline-java:4.50.0'
-        classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:2.4.0'
+        classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:2.5.0'
         classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.6.0'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.3'
         classpath 'com.palantir.gradle.revapi:gradle-revapi:1.5.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
-javaVersion = 1.8
+javaVersion=11
 org.gradle.parallel=true
+com.palantir.gradle.versions.publishLocalConstraints=true


### PR DESCRIPTION
This way it's impossible to resolve different versions of say,
tritium-jvm and tritium-caffeine resulting in unexpected runtime
failures that cannot be tested in this repository.

This opts into an experimental GCV feature:
https://github.com/palantir/gradle-consistent-versions/releases/tag/2.5.0

==COMMIT_MSG==
Tritium modules provide constraints on other tritium modules
==COMMIT_MSG==

