### PR TITLE
Avoid increasing the minimum error-prone version for consumers

### DIFF
--- a/versions.props
+++ b/versions.props
@@ -4,7 +4,6 @@ com.google.auto:* = 1.2.1
 com.google.auto.service:* = 1.0.1
 com.google.code.findbugs:jFormatString = 3.0.0
 com.google.code.findbugs:jsr305 = 3.0.2
-com.google.errorprone:* = 2.10.0
 com.google.guava:guava = 31.0.1-jre
 com.google.testing.compile:compile-testing = 0.19
 com.palantir.goethe:* = 0.6.0
@@ -31,4 +30,6 @@ org.slf4j:* = 1.7.35
 # dependency-upgrader:OFF
 # Explicitly pinning to minimum dropwizard metrics version defined by Apache Spark
 io.dropwizard.metrics:* = 4.1.1
+# Avoid increasing the minimum error-prone version for consumers
+com.google.errorprone:* = 2.10.0
 # dependency-upgrader:ON


### PR DESCRIPTION
==COMMIT_MSG==
Avoid increasing the minimum error-prone version for consumers
==COMMIT_MSG==

