### PR TITLE
Optimize MetricName creation

### DIFF
--- a/changelog/@unreleased/pr-1365.v2.yml
+++ b/changelog/@unreleased/pr-1365.v2.yml
@@ -1,0 +1,16 @@
+type: improvement
+improvement:
+  description: |-
+    Optimize MetricName creation
+
+    RealMetricName uses pre-hashed code in equals.
+    ExtraEntrySortedMap avoids allocation in constructor.
+    Cleanup warnings in ExtraEntrySortedMap.
+
+    Add MetricName#withExtraTag(String, String).
+    We have cases where we want to append an additional tag to a MetricName
+    and would benefit from not having to pay the overhead of the MetricName
+    builder copy, so we can optimize this path to use RealMetricName's
+    access to ExtraEntrySortedMap.
+  links:
+  - https://github.com/palantir/tritium/pull/1365

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AbstractTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AbstractTaggedMetricRegistry.java
@@ -180,7 +180,7 @@ public abstract class AbstractTaggedMetricRegistry implements TaggedMetricRegist
         result.putAll(registry);
         taggedRegistries.forEach((tag, metrics) -> metrics.getMetrics()
                 .forEach((metricName, metric) ->
-                        result.put(RealMetricName.create(metricName, tag.getKey(), tag.getValue()), metric)));
+                        result.put(metricName.withExtraTag(tag.getKey(), tag.getValue()), metric)));
 
         return result.build();
     }
@@ -189,7 +189,7 @@ public abstract class AbstractTaggedMetricRegistry implements TaggedMetricRegist
     public final void forEachMetric(BiConsumer<MetricName, Metric> consumer) {
         registry.forEach(consumer);
         taggedRegistries.forEach((tag, metrics) -> metrics.forEachMetric((metricName, metric) ->
-                consumer.accept(RealMetricName.create(metricName, tag.getKey(), tag.getValue()), metric)));
+                consumer.accept(metricName.withExtraTag(tag.getKey(), tag.getValue()), metric)));
     }
 
     @Override

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/ExtraEntrySortedMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/ExtraEntrySortedMap.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @SuppressWarnings("JdkObsolete")
@@ -59,6 +60,7 @@ final class ExtraEntrySortedMap<K, V> extends AbstractMap<K, V> implements Sorte
         return base.comparator();
     }
 
+    @Nonnull
     @Override
     public SortedMap<K, V> subMap(K fromKey, K toKey) {
         SortedMap<K, V> newBase = base.subMap(fromKey, toKey);
@@ -68,6 +70,7 @@ final class ExtraEntrySortedMap<K, V> extends AbstractMap<K, V> implements Sorte
         return newBase;
     }
 
+    @Nonnull
     @Override
     public SortedMap<K, V> headMap(K toKey) {
         SortedMap<K, V> newBase = base.headMap(toKey);
@@ -77,6 +80,7 @@ final class ExtraEntrySortedMap<K, V> extends AbstractMap<K, V> implements Sorte
         return newBase;
     }
 
+    @Nonnull
     @Override
     public SortedMap<K, V> tailMap(K fromKey) {
         SortedMap<K, V> newBase = base.tailMap(fromKey);
@@ -151,9 +155,10 @@ final class ExtraEntrySortedMap<K, V> extends AbstractMap<K, V> implements Sorte
         throw new UnsupportedOperationException();
     }
 
+    @Nonnull
     @Override
     public Set<K> keySet() {
-        return new AbstractSet<K>() {
+        return new AbstractSet<>() {
             @Override
             public Iterator<K> iterator() {
                 return Iterables.mergeSorted(ImmutableList.of(base.keySet(), ImmutableList.of(extraKey)), ordering)
@@ -167,9 +172,10 @@ final class ExtraEntrySortedMap<K, V> extends AbstractMap<K, V> implements Sorte
         };
     }
 
+    @Nonnull
     @Override
     public Collection<V> values() {
-        return new AbstractCollection<V>() {
+        return new AbstractCollection<>() {
             @Override
             public Iterator<V> iterator() {
                 return Iterators.transform(keySet().iterator(), key -> get(key));
@@ -182,9 +188,10 @@ final class ExtraEntrySortedMap<K, V> extends AbstractMap<K, V> implements Sorte
         };
     }
 
+    @Nonnull
     @Override
     public Set<Entry<K, V>> entrySet() {
-        return new AbstractSet<Map.Entry<K, V>>() {
+        return new AbstractSet<>() {
             @Override
             public Iterator<Map.Entry<K, V>> iterator() {
                 return Iterators.transform(keySet().iterator(), key -> Maps.immutableEntry(key, get(key)));

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/ExtraEntrySortedMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/ExtraEntrySortedMap.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import javax.annotation.Nullable;
@@ -48,7 +49,7 @@ final class ExtraEntrySortedMap<K, V> extends AbstractMap<K, V> implements Sorte
         this.extraKey = checkNotNull(extraKey, "extraKey");
         this.extraValue = checkNotNull(extraValue, "extraValue");
         this.ordering = Ordering.from(base.comparator());
-        this.extraEntryHashCode = Maps.immutableEntry(extraKey, extraValue).hashCode();
+        this.extraEntryHashCode = Objects.hashCode(extraKey) ^ Objects.hashCode(extraValue);
         // This line of code is roughly a 50% perf regression for iterating through metrics. Remove if causing issues.
         checkArgument(!base.containsKey(extraKey), "Base must not contain the extra key that is to be added");
     }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/ExtraEntrySortedMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/ExtraEntrySortedMap.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import javax.annotation.Nonnull;
@@ -50,7 +49,7 @@ final class ExtraEntrySortedMap<K, V> extends AbstractMap<K, V> implements Sorte
         this.extraKey = checkNotNull(extraKey, "extraKey");
         this.extraValue = checkNotNull(extraValue, "extraValue");
         this.ordering = Ordering.from(base.comparator());
-        this.extraEntryHashCode = Objects.hashCode(extraKey) ^ Objects.hashCode(extraValue);
+        this.extraEntryHashCode = extraKey.hashCode() ^ extraValue.hashCode();
         // This line of code is roughly a 50% perf regression for iterating through metrics. Remove if causing issues.
         checkArgument(!base.containsKey(extraKey), "Base must not contain the extra key that is to be added");
     }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/MetricName.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/MetricName.java
@@ -39,6 +39,17 @@ public interface MetricName {
     @Value.NaturalOrder
     SortedMap<String, String> safeTags();
 
+    /**
+     * Creates a metric name with the specified extra tag name and value entry.
+     * <p>All tags and keys must be {@link Safe} to log.
+     * @param extraTagName extra tag key name
+     * @param extraTagValue extra tag value
+     * @return metric name including keys
+     */
+    default MetricName withExtraTag(@Safe String extraTagName, @Safe String extraTagValue) {
+        return RealMetricName.create(this, extraTagName, extraTagValue);
+    }
+
     static Builder builder() {
         return new Builder();
     }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/PreHashedSortedMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/PreHashedSortedMap.java
@@ -18,28 +18,42 @@ package com.palantir.tritium.metrics.registry;
 
 import com.google.common.collect.ForwardingSortedMap;
 import com.google.common.collect.ImmutableSortedMap;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * A sorted map implementation which prehashes for faster usage in hashmaps. This is only safe for immutable underlying
  * maps (both the map implementation and the entries must be immutable).
  */
-final class PrehashedSortedMap<K, V> extends ForwardingSortedMap<K, V> {
+final class PreHashedSortedMap<K, V> extends ForwardingSortedMap<K, V> {
     private final ImmutableSortedMap<K, V> delegate;
     private final int hashCode;
 
-    PrehashedSortedMap(ImmutableSortedMap<K, V> delegate) {
+    PreHashedSortedMap(ImmutableSortedMap<K, V> delegate) {
         this.delegate = delegate;
         this.hashCode = this.delegate.hashCode();
     }
 
+    @Nonnull
     @Override
     protected ImmutableSortedMap<K, V> delegate() {
         return delegate;
     }
 
-    @SuppressWarnings("checkstyle:EqualsHashCode")
     @Override
     public int hashCode() {
         return hashCode;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object instanceof PreHashedSortedMap) {
+            PreHashedSortedMap<?, ?> that = (PreHashedSortedMap<?, ?>) object;
+            return hashCode == that.hashCode && delegate.equals(that.delegate);
+        }
+        return super.equals(object);
     }
 }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/PreHashedSortedMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/PreHashedSortedMap.java
@@ -50,9 +50,8 @@ final class PreHashedSortedMap<K, V> extends ForwardingSortedMap<K, V> {
         if (this == object) {
             return true;
         }
-        if (object instanceof PreHashedSortedMap) {
-            PreHashedSortedMap<?, ?> that = (PreHashedSortedMap<?, ?>) object;
-            return hashCode == that.hashCode && delegate.equals(that.delegate);
+        if (object instanceof PreHashedSortedMap && this.hashCode != ((PreHashedSortedMap<?, ?>) object).hashCode) {
+            return false;
         }
         return super.equals(object);
     }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/RealMetricName.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/RealMetricName.java
@@ -23,7 +23,7 @@ import java.util.SortedMap;
 import javax.annotation.Nullable;
 
 final class RealMetricName implements MetricName {
-    private static final PreHashedSortedMap<String, String> EMPTY = prehash(ImmutableSortedMap.of());
+    private static final SortedMap<String, String> EMPTY = prehash(ImmutableSortedMap.of());
     private final String safeName;
     private final SortedMap<String, String> safeTags;
 
@@ -78,22 +78,22 @@ final class RealMetricName implements MetricName {
                 && safeTags().equals(otherMetric.safeTags());
     }
 
-    static RealMetricName create(String safeName) {
+    static MetricName create(String safeName) {
         return new RealMetricName(checkNotNull(safeName, "safeName"), EMPTY);
     }
 
-    static RealMetricName create(MetricName other) {
+    static MetricName create(MetricName other) {
         return new RealMetricName(other.safeName(), prehash(other.safeTags()));
     }
 
-    static RealMetricName create(MetricName other, String extraTagName, String extraTagValue) {
+    static MetricName create(MetricName other, String extraTagName, String extraTagValue) {
         return new RealMetricName(
                 other.safeName(), new ExtraEntrySortedMap<>(prehash(other.safeTags()), extraTagName, extraTagValue));
     }
 
-    private static <K, V> PreHashedSortedMap<K, V> prehash(SortedMap<K, V> map) {
+    private static <K, V> SortedMap<K, V> prehash(SortedMap<K, V> map) {
         if (map instanceof PreHashedSortedMap) {
-            return (PreHashedSortedMap<K, V>) map;
+            return map;
         }
         return new PreHashedSortedMap<>(ImmutableSortedMap.copyOfSorted(map));
     }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/RealMetricName.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/RealMetricName.java
@@ -26,7 +26,6 @@ final class RealMetricName implements MetricName {
     private static final SortedMap<String, String> EMPTY = prehash(ImmutableSortedMap.of());
     private final String safeName;
     private final SortedMap<String, String> safeTags;
-
     private final int hashCode;
 
     private RealMetricName(String safeName, SortedMap<String, String> safeTags) {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/RealMetricName.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/RealMetricName.java
@@ -23,9 +23,10 @@ import java.util.SortedMap;
 import javax.annotation.Nullable;
 
 final class RealMetricName implements MetricName {
-    private static final SortedMap<String, String> EMPTY = prehash(ImmutableSortedMap.of());
+    private static final PreHashedSortedMap<String, String> EMPTY = prehash(ImmutableSortedMap.of());
     private final String safeName;
     private final SortedMap<String, String> safeTags;
+
     private final int hashCode;
 
     private RealMetricName(String safeName, SortedMap<String, String> safeTags) {
@@ -72,26 +73,28 @@ final class RealMetricName implements MetricName {
             return true;
         }
         MetricName otherMetric = (MetricName) other;
-        return safeName().equals(otherMetric.safeName()) && safeTags().equals(otherMetric.safeTags());
+        return hashCode() == otherMetric.hashCode()
+                && safeName().equals(otherMetric.safeName())
+                && safeTags().equals(otherMetric.safeTags());
     }
 
-    static MetricName create(String safeName) {
+    static RealMetricName create(String safeName) {
         return new RealMetricName(checkNotNull(safeName, "safeName"), EMPTY);
     }
 
-    static MetricName create(MetricName other) {
+    static RealMetricName create(MetricName other) {
         return new RealMetricName(other.safeName(), prehash(other.safeTags()));
     }
 
-    static MetricName create(MetricName other, String extraTagName, String extraTagValue) {
+    static RealMetricName create(MetricName other, String extraTagName, String extraTagValue) {
         return new RealMetricName(
                 other.safeName(), new ExtraEntrySortedMap<>(prehash(other.safeTags()), extraTagName, extraTagValue));
     }
 
-    private static <K, V> SortedMap<K, V> prehash(SortedMap<K, V> map) {
-        if (map instanceof PrehashedSortedMap) {
-            return map;
+    private static <K, V> PreHashedSortedMap<K, V> prehash(SortedMap<K, V> map) {
+        if (map instanceof PreHashedSortedMap) {
+            return (PreHashedSortedMap<K, V>) map;
         }
-        return new PrehashedSortedMap<>(ImmutableSortedMap.copyOfSorted(map));
+        return new PreHashedSortedMap<>(ImmutableSortedMap.copyOfSorted(map));
     }
 }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/package-info.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@ParametersAreNonnullByDefault
+package com.palantir.tritium.metrics.registry;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/MetricNameTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/MetricNameTest.java
@@ -17,7 +17,9 @@
 package com.palantir.tritium.metrics.registry;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import org.junit.jupiter.api.Test;
 
 public class MetricNameTest {
@@ -106,5 +108,31 @@ public class MetricNameTest {
 
         assertThat(one).isNotEqualTo(two);
         assertThat(two).isNotEqualTo(one);
+    }
+
+    @Test
+    void withExtraTag() {
+        MetricName one = MetricName.builder()
+                .safeName("test")
+                .putSafeTags("key", "value")
+                .putSafeTags("key1", "value1")
+                .build();
+        MetricName two = MetricName.builder()
+                .safeName("test")
+                .putSafeTags("key2", "value2")
+                .putSafeTags("key", "value")
+                .putSafeTags("key1", "value1")
+                .build();
+        MetricName three = one.withExtraTag("key2", "value2");
+
+        assertThat(three)
+                .hasSameHashCodeAs(two)
+                .isEqualTo(two)
+                .doesNotHaveSameHashCodeAs(one)
+                .isNotEqualTo(one);
+
+        assertThatThrownBy(() -> two.withExtraTag("key", "value"))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Base must not contain the extra key that is to be added");
     }
 }

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/PreHashedSortedMapTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/PreHashedSortedMapTest.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.registry;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import com.google.common.collect.ImmutableSortedMap;
+import org.junit.jupiter.api.Test;
+
+class PreHashedSortedMapTest {
+
+    @Test
+    void testEqualsHashCode() {
+        ImmutableSortedMap<String, Integer> map = generate(1_000);
+        PreHashedSortedMap<String, Integer> preHashedSortedMap = new PreHashedSortedMap<>(map);
+        assertThat(preHashedSortedMap)
+                .hasSameHashCodeAs(map)
+                .isEqualTo(map)
+                .containsExactlyEntriesOf(map)
+                .usingDefaultComparator()
+                .isEqualTo(map);
+    }
+
+    private static ImmutableSortedMap<String, Integer> generate(int count) {
+        ImmutableSortedMap.Builder<String, Integer> builder = ImmutableSortedMap.naturalOrder();
+        for (int i = 0; i < count; i++) {
+            builder.put(Integer.toString(i), i);
+        }
+        return builder.build();
+    }
+}

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/RealMetricNameTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/RealMetricNameTest.java
@@ -1,0 +1,72 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.registry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class RealMetricNameTest {
+
+    @Test
+    void testEquals() {
+        MetricName a1 = RealMetricName.create("a");
+        MetricName a2 = RealMetricName.create("a");
+        MetricName a3 = RealMetricName.create(a1, "tag1", "value1");
+        MetricName a4 = RealMetricName.create(a3, "tag2", "value2");
+        MetricName b1 = RealMetricName.create("b");
+
+        assertThat(a1)
+                .hasSameHashCodeAs(a2)
+                .isEqualTo(a2)
+                .doesNotHaveSameHashCodeAs(a3)
+                .isNotEqualTo(a3)
+                .doesNotHaveSameHashCodeAs(a4)
+                .isNotEqualTo(a4)
+                .isEqualTo(a1)
+                .doesNotHaveSameHashCodeAs(b1)
+                .isNotEqualTo(b1)
+                .isEqualTo(MetricName.builder().safeName("a").build());
+
+        MetricName a5 = MetricName.builder()
+                .safeName("a")
+                .putSafeTags("tag1", "value1")
+                .putSafeTags("tag2", "value2")
+                .build();
+
+        assertThat(a4).hasSameHashCodeAs(a5).isEqualTo(a5);
+    }
+
+    @Test
+    void name() {
+        MetricName one =
+                MetricName.builder().safeName("one").putSafeTags("one", "two").build();
+        MetricName two =
+                MetricName.builder().safeName("two").putSafeTags("one", "two").build();
+
+        assertThat(one)
+                .isInstanceOf(RealMetricName.class)
+                .doesNotHaveSameHashCodeAs(two)
+                .isNotEqualTo(two);
+
+        for (int i = 0; i < 1_000; i++) {
+            int oneHash = one.hashCode();
+            int twoHash = two.hashCode();
+            assertThat(oneHash).isNotEqualTo(twoHash);
+        }
+    }
+}


### PR DESCRIPTION
## Before this PR
MetricName creation can be expensive

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Optimize MetricName creation

RealMetricName uses pre-hashed code in equals.
ExtraEntrySortedMap avoids allocation in constructor.
Cleanup warnings in ExtraEntrySortedMap.

Add MetricName#withExtraTag(String, String).
We have cases where we want to append an additional tag to a MetricName
and would benefit from not having to pay the overhead of the MetricName
builder copy, so we can optimize this path to use RealMetricName's
access to ExtraEntrySortedMap.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

