### PR TITLE
ExtraEntrySortedMap constructor does not allocate entry to compute hashCode

### DIFF
--- a/changelog/@unreleased/pr-1366.v2.yml
+++ b/changelog/@unreleased/pr-1366.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: ExtraEntrySortedMap constructor does not allocate entry to compute
+    hashCode
+  links:
+  - https://github.com/palantir/tritium/pull/1366

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/ExtraEntrySortedMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/ExtraEntrySortedMap.java
@@ -48,7 +48,7 @@ final class ExtraEntrySortedMap<K, V> extends AbstractMap<K, V> implements Sorte
         this.extraKey = checkNotNull(extraKey, "extraKey");
         this.extraValue = checkNotNull(extraValue, "extraValue");
         this.ordering = Ordering.from(base.comparator());
-        this.extraEntryHashCode = Maps.immutableEntry(extraKey, extraValue).hashCode();
+        this.extraEntryHashCode = extraKey.hashCode() ^ extraValue.hashCode();
         // This line of code is roughly a 50% perf regression for iterating through metrics. Remove if causing issues.
         checkArgument(!base.containsKey(extraKey), "Base must not contain the extra key that is to be added");
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`ExtraEntrySortedMap` constructor allocated immutable entry to compute hashCode, creating unnecessary TLAB allocation pressure

## After this PR
==COMMIT_MSG==
ExtraEntrySortedMap constructor does not allocate entry to compute hashCode
==COMMIT_MSG==

Small subset of https://github.com/palantir/tritium/pull/1365

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

