### PR TITLE
TagMap uses ImmutableList

### DIFF
--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/RealMetricName.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/RealMetricName.java
@@ -18,9 +18,11 @@ package com.palantir.tritium.metrics.registry;
 
 import static com.palantir.logsafe.Preconditions.checkNotNull;
 
+import com.google.errorprone.annotations.Immutable;
 import java.util.SortedMap;
 import javax.annotation.Nullable;
 
+@Immutable
 final class RealMetricName implements MetricName {
 
     private final String safeName;

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
@@ -56,14 +56,14 @@ final class TagMap implements SortedMap<String, String> {
         if (data instanceof TagMap) {
             return (TagMap) data;
         }
-        return new TagMap(toValues(data));
+        return new TagMap(toSortedKeyValues(data));
     }
 
     private TagMap(ImmutableList<String> values) {
         this.values = values;
     }
 
-    private static ImmutableList<String> toValues(Map<String, String> data) {
+    private static ImmutableList<String> toSortedKeyValues(Map<String, String> data) {
         ImmutableList.Builder<String> values = ImmutableList.builderWithExpectedSize(data.size() * 2);
         List<String> keys = ImmutableSortedSet.copyOf(data.keySet()).asList();
         for (String key : keys) {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
@@ -51,7 +51,6 @@ final class TagMap implements SortedMap<String, String> {
     static final TagMap EMPTY = TagMap.of(ImmutableMap.of());
 
     private final ImmutableList<String> values;
-    private final int hash;
 
     static TagMap of(Map<String, String> data) {
         if (data instanceof TagMap) {
@@ -62,7 +61,6 @@ final class TagMap implements SortedMap<String, String> {
 
     private TagMap(ImmutableList<String> values) {
         this.values = values;
-        this.hash = values.hashCode();
     }
 
     private static ImmutableList<String> toValues(Map<String, String> data) {
@@ -126,7 +124,7 @@ final class TagMap implements SortedMap<String, String> {
         }
         if (other instanceof TagMap) {
             TagMap that = (TagMap) other;
-            return this.hash == that.hash && values.equals(that.values);
+            return values.equals(that.values);
         }
         if (!(other instanceof Map)) {
             return false;
@@ -146,7 +144,7 @@ final class TagMap implements SortedMap<String, String> {
 
     @Override
     public int hashCode() {
-        return hash;
+        return values.hashCode();
     }
 
     /* Misc methods to support the SortedMap interface. */

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
@@ -88,9 +88,8 @@ final class TagMap implements SortedMap<String, String> {
     }
 
     private int indexOfKey(Object key) {
-        ImmutableList<String> local = values;
-        for (int i = 0; i < local.size(); i += 2) {
-            if (Objects.equals(key, local.get(i))) {
+        for (int i = 0; i < values.size(); i += 2) {
+            if (Objects.equals(key, values.get(i))) {
                 return i;
             }
         }
@@ -99,19 +98,17 @@ final class TagMap implements SortedMap<String, String> {
 
     @Override
     public void forEach(BiConsumer<? super String, ? super String> action) {
-        ImmutableList<String> local = this.values;
-        for (int i = 0; i < local.size(); i += 2) {
-            action.accept(local.get(i), local.get(i + 1));
+        for (int i = 0; i < values.size(); i += 2) {
+            action.accept(values.get(i), values.get(i + 1));
         }
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder().append("{");
-        ImmutableList<String> local = this.values;
-        for (int i = 0; i < local.size(); i += 2) {
-            String key = local.get(i);
-            String value = local.get(i + 1);
+        for (int i = 0; i < values.size(); i += 2) {
+            String key = values.get(i);
+            String value = values.get(i + 1);
             if (i != 0) {
                 sb.append(", ");
             }
@@ -128,7 +125,8 @@ final class TagMap implements SortedMap<String, String> {
             return true;
         }
         if (other instanceof TagMap) {
-            return values.equals(((TagMap) other).values);
+            TagMap that = (TagMap) other;
+            return this.hash == that.hash && values.equals(that.values);
         }
         if (!(other instanceof Map)) {
             return false;
@@ -177,21 +175,19 @@ final class TagMap implements SortedMap<String, String> {
     @Nullable
     @Override
     public String firstKey() {
-        ImmutableList<String> local = this.values;
-        if (local.isEmpty()) {
+        if (values.isEmpty()) {
             throw new NoSuchElementException();
         }
-        return local.get(0);
+        return values.get(0);
     }
 
     @Nullable
     @Override
     public String lastKey() {
-        ImmutableList<String> local = this.values;
-        if (local.isEmpty()) {
+        if (values.isEmpty()) {
             throw new NoSuchElementException();
         }
-        return local.get(local.size() - 2);
+        return values.get(values.size() - 2);
     }
 
     @Override
@@ -211,9 +207,8 @@ final class TagMap implements SortedMap<String, String> {
 
     @Override
     public boolean containsValue(Object value) {
-        ImmutableList<String> local = this.values;
-        for (int i = 1; i < local.size(); i += 2) {
-            if (Objects.equals(value, local.get(i))) {
+        for (int i = 1; i < values.size(); i += 2) {
+            if (Objects.equals(value, values.get(i))) {
                 return true;
             }
         }
@@ -243,10 +238,9 @@ final class TagMap implements SortedMap<String, String> {
     @Nonnull
     @Override
     public Set<String> keySet() {
-        ImmutableList<String> local = this.values;
-        Set<String> set = new LinkedHashSet<>(local.size() / 2);
-        for (int i = 0; i < local.size(); i += 2) {
-            set.add(local.get(i));
+        Set<String> set = new LinkedHashSet<>(values.size() / 2);
+        for (int i = 0; i < values.size(); i += 2) {
+            set.add(values.get(i));
         }
         return Collections.unmodifiableSet(set);
     }
@@ -254,10 +248,9 @@ final class TagMap implements SortedMap<String, String> {
     @Nonnull
     @Override
     public Collection<String> values() {
-        ImmutableList<String> local = this.values;
-        List<String> list = new ArrayList<>(local.size() / 2);
-        for (int i = 1; i < local.size(); i += 2) {
-            list.add(local.get(i));
+        List<String> list = new ArrayList<>(values.size() / 2);
+        for (int i = 1; i < values.size(); i += 2) {
+            list.add(values.get(i));
         }
         return Collections.unmodifiableCollection(list);
     }

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/MetricNameTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/MetricNameTest.java
@@ -68,10 +68,12 @@ public class MetricNameTest {
     @Test
     public void compareName() {
         assertThat(MetricName.builder().safeName("a").build())
-                .isEqualTo(MetricName.builder().safeName("a").build());
+                .isEqualTo(MetricName.builder().safeName("a").build())
+                .hasSameHashCodeAs(MetricName.builder().safeName("a").build());
 
         assertThat(MetricName.builder().safeName("a").build())
-                .isNotEqualTo(MetricName.builder().safeName("b").build());
+                .isNotEqualTo(MetricName.builder().safeName("b").build())
+                .doesNotHaveSameHashCodeAs(MetricName.builder().safeName("b").build());
     }
 
     @Test
@@ -87,8 +89,8 @@ public class MetricNameTest {
                 .putSafeTags("key3", "value2")
                 .build();
 
-        assertThat(one).isNotEqualTo(two);
-        assertThat(two).isNotEqualTo(one);
+        assertThat(one).isNotEqualTo(two).doesNotHaveSameHashCodeAs(two);
+        assertThat(two).isNotEqualTo(one).doesNotHaveSameHashCodeAs(one);
     }
 
     @Test
@@ -104,7 +106,30 @@ public class MetricNameTest {
                 .putSafeTags("key2", "valueZ")
                 .build();
 
-        assertThat(one).isNotEqualTo(two);
-        assertThat(two).isNotEqualTo(one);
+        assertThat(one).isNotEqualTo(two).doesNotHaveSameHashCodeAs(two);
+        assertThat(two).isNotEqualTo(one).doesNotHaveSameHashCodeAs(one);
+    }
+
+    @Test
+    void withExtraTag() {
+        MetricName one = MetricName.builder()
+                .safeName("test")
+                .putSafeTags("key", "value")
+                .putSafeTags("key1", "value1")
+                .build();
+        MetricName two = MetricName.builder()
+                .safeName("test")
+                .putSafeTags("key2", "value2")
+                .putSafeTags("key", "value")
+                .putSafeTags("key1", "value1")
+                .build();
+        MetricName three =
+                MetricName.builder().from(one).putSafeTags("key2", "value2").build();
+
+        assertThat(three)
+                .hasSameHashCodeAs(two)
+                .isEqualTo(two)
+                .doesNotHaveSameHashCodeAs(one)
+                .isNotEqualTo(one);
     }
 }


### PR DESCRIPTION
## Before this PR
RealMetricName and TagMap weren't using error-prone `Immutable` checker (though were effectively immutable)

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
TagMap uses ImmutableList
==COMMIT_MSG==

## Possible downsides?
There's some potential overhead in using `ImmutableList<String>` over raw `String[]`

