### PR TITLE
Memory gauges report null when data is unavailable

### DIFF
--- a/changelog/@unreleased/pr-1392.v2.yml
+++ b/changelog/@unreleased/pr-1392.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Memory gauges report null when data is unavailable
+  links:
+  - https://github.com/palantir/tritium/pull/1392

--- a/tritium-metrics-jvm/build.gradle
+++ b/tritium-metrics-jvm/build.gradle
@@ -8,13 +8,14 @@ dependencies {
     api 'io.dropwizard.metrics:metrics-core'
 
     implementation project(':tritium-metrics')
-    implementation 'com.palantir.jvm.diagnostics:jvm-diagnostics'
-    implementation 'io.dropwizard.metrics:metrics-core'
-    implementation 'io.dropwizard.metrics:metrics-jvm'
+    implementation 'com.google.code.findbugs:jsr305'
     implementation 'com.google.guava:guava'
+    implementation 'com.palantir.jvm.diagnostics:jvm-diagnostics'
     implementation 'com.palantir.safe-logging:logger'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
+    implementation 'io.dropwizard.metrics:metrics-core'
+    implementation 'io.dropwizard.metrics:metrics-jvm'
 
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -192,6 +192,7 @@ public final class JvmMetrics {
 
     /** Gauge which replaces negative values with null to avoid confusing data when metrics are unavailable. */
     @FunctionalInterface
+    @SuppressWarnings("FunctionalInterfaceMethodChanged")
     private interface NonNegativeGauge extends Gauge<Long> {
         @Nullable
         @Override

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 /** {@link JvmMetrics} provides a standard set of metrics for debugging java services. */
 public final class JvmMetrics {
@@ -192,6 +193,7 @@ public final class JvmMetrics {
     /** Gauge which replaces negative values with null to avoid confusing data when metrics are unavailable. */
     @FunctionalInterface
     private interface NonNegativeGauge extends Gauge<Long> {
+        @Nullable
         @Override
         default Long getValue() {
             long value = getValueAsLong();

--- a/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
+++ b/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
@@ -184,9 +184,11 @@ final class JvmMetricsTest {
     void testUnavailableJvmMemoryMetrics() {
         TaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
         JvmMetrics.registerJvmMemory(registry, UnavailableMemoryBean.INSTANCE);
-        registry.forEachMetric((_name, metric) -> assertThat(metric)
-                .isInstanceOfSatisfying(
-                        Gauge.class, gauge -> assertThat(gauge.getValue()).isIn(null, Double.NaN)));
+        registry.forEachMetric(
+                (_name, metric) -> assertThat(metric).isInstanceOf(Gauge.class).satisfies(instance -> {
+                    Gauge<?> gauge = (Gauge<?>) instance;
+                    assertThat(gauge.getValue()).isIn(null, Double.NaN);
+                }));
     }
 
     @SuppressWarnings("JdkObsolete")


### PR DESCRIPTION
Previously the default `-1` values were used, resulting in
confusing dashboards that didn't make it obvious the data was
unavailable.

==COMMIT_MSG==
Memory gauges report null when data is unavailable
==COMMIT_MSG==

