### PR TITLE
Annotate metric name components as `@Safe`

### DIFF
--- a/changelog/@unreleased/pr-1428.v2.yml
+++ b/changelog/@unreleased/pr-1428.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Annotate metric name components as `@Safe`
+  links:
+  - https://github.com/palantir/tritium/pull/1428

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
@@ -21,6 +21,7 @@ import static com.palantir.logsafe.Preconditions.checkNotNull;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.palantir.logsafe.Safe;
 import com.palantir.tritium.event.AbstractInvocationEventHandler;
 import com.palantir.tritium.event.DefaultInvocationContext;
 import com.palantir.tritium.event.InstrumentationProperties;
@@ -39,16 +40,19 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
     private static final String FAILURES = "failures";
 
     private final MetricRegistry metricRegistry;
+
+    @Safe
     private final String serviceName;
 
     // consider creating annotation handlers as separate objects
     private final ImmutableMap<AnnotationHelper.MethodSignature, String> metricGroups;
 
+    @Safe
     @Nullable
     private final String globalGroupPrefix;
 
     @SuppressWarnings("WeakerAccess") // public API
-    public MetricsInvocationEventHandler(MetricRegistry metricRegistry, String serviceName) {
+    public MetricsInvocationEventHandler(MetricRegistry metricRegistry, @Safe String serviceName) {
         super(getEnabledSupplier(serviceName));
         this.metricRegistry = checkNotNull(metricRegistry, "metricRegistry");
         this.serviceName = checkNotNull(serviceName, "serviceName");
@@ -60,8 +64,8 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
     public MetricsInvocationEventHandler(
             MetricRegistry metricRegistry,
             Class<?> serviceClass,
-            String serviceName,
-            @Nullable String globalGroupPrefix) {
+            @Safe String serviceName,
+            @Safe @Nullable String globalGroupPrefix) {
         super(getEnabledSupplier(serviceName));
         this.metricRegistry = checkNotNull(metricRegistry, "metricRegistry");
         this.serviceName = checkNotNull(serviceName, "serviceName");
@@ -71,7 +75,7 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
 
     @SuppressWarnings("WeakerAccess") // public API
     public MetricsInvocationEventHandler(
-            MetricRegistry metricRegistry, Class<?> serviceClass, @Nullable String globalGroupPrefix) {
+            MetricRegistry metricRegistry, Class<?> serviceClass, @Safe @Nullable String globalGroupPrefix) {
         this(metricRegistry, serviceClass, checkNotNull(serviceClass.getName()), globalGroupPrefix);
     }
 

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandler.java
@@ -20,6 +20,7 @@ import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
+import com.palantir.logsafe.Safe;
 import com.palantir.tritium.event.AbstractInvocationEventHandler;
 import com.palantir.tritium.event.DefaultInvocationContext;
 import com.palantir.tritium.event.InstrumentationProperties;
@@ -55,12 +56,16 @@ public class TaggedMetricsServiceInvocationEventHandler extends AbstractInvocati
             MetricName.builder().safeName(FAILURES_METRIC_NAME).build();
 
     private final TaggedMetricRegistry taggedMetricRegistry;
+
+    @Safe
     private final String serviceName;
+
     private final Meter globalFailureMeter;
     private final ConcurrentMap<Method, Timer> timerCache = new ConcurrentHashMap<>();
     private final Function<Method, Timer> onSuccessTimerMappingFunction;
 
-    public TaggedMetricsServiceInvocationEventHandler(TaggedMetricRegistry taggedMetricRegistry, String serviceName) {
+    public TaggedMetricsServiceInvocationEventHandler(
+            TaggedMetricRegistry taggedMetricRegistry, @Safe String serviceName) {
         super(getEnabledSupplier(serviceName));
         this.taggedMetricRegistry = checkNotNull(taggedMetricRegistry, "metricRegistry");
         this.serviceName = checkNotNull(serviceName, "serviceName");
@@ -73,7 +78,7 @@ public class TaggedMetricsServiceInvocationEventHandler extends AbstractInvocati
     }
 
     @SuppressWarnings("NoFunctionalReturnType") // helper
-    private static BooleanSupplier getEnabledSupplier(String serviceName) {
+    private static BooleanSupplier getEnabledSupplier(@Safe String serviceName) {
         return InstrumentationProperties.getSystemPropertySupplier(serviceName);
     }
 

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsThreadFactory.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsThreadFactory.java
@@ -19,6 +19,7 @@ package com.palantir.tritium.metrics;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
 import java.util.concurrent.ThreadFactory;
 
 /**
@@ -30,7 +31,7 @@ final class TaggedMetricsThreadFactory implements ThreadFactory {
     private final Meter created;
     private final Counter running;
 
-    TaggedMetricsThreadFactory(ThreadFactory delegate, ExecutorMetrics metrics, String name) {
+    TaggedMetricsThreadFactory(ThreadFactory delegate, ExecutorMetrics metrics, @Safe String name) {
         this.delegate = Preconditions.checkNotNull(delegate, "ThreadFactory is required");
         Preconditions.checkNotNull(name, "Name is required");
         Preconditions.checkNotNull(metrics, "ExecutorMetrics is required");

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/ImmutableMetricName.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/ImmutableMetricName.java
@@ -18,6 +18,7 @@ package com.palantir.tritium.metrics.registry;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -45,13 +46,13 @@ final class ImmutableMetricName {
         }
 
         @CanIgnoreReturnValue
-        public MetricName.Builder safeName(String value) {
+        public MetricName.Builder safeName(@Safe String value) {
             this.safeName = Preconditions.checkNotNull(value, "safeName");
             return (MetricName.Builder) this;
         }
 
         @CanIgnoreReturnValue
-        public MetricName.Builder putSafeTags(String key, String value) {
+        public MetricName.Builder putSafeTags(@Safe String key, @Safe String value) {
             Preconditions.checkNotNull(key, "safeTagName");
             Preconditions.checkNotNull(value, "safeTagValue");
             tagMap = tagMap.withEntry(key, value);
@@ -59,7 +60,7 @@ final class ImmutableMetricName {
         }
 
         @CanIgnoreReturnValue
-        public MetricName.Builder putSafeTags(Map.Entry<String, ? extends String> entry) {
+        public MetricName.Builder putSafeTags(@Safe Map.Entry<String, ? extends String> entry) {
             Preconditions.checkNotNull(entry, "entry");
             tagMap = tagMap.withEntry(entry.getKey(), entry.getValue());
             return (MetricName.Builder) this;
@@ -67,7 +68,7 @@ final class ImmutableMetricName {
 
         @SuppressWarnings("unchecked")
         @CanIgnoreReturnValue
-        public MetricName.Builder safeTags(Map<String, ? extends String> entries) {
+        public MetricName.Builder safeTags(@Safe Map<String, ? extends String> entries) {
             Preconditions.checkNotNull(entries, "entries");
             tagMap = TagMap.of((Map<String, String>) entries);
             return (MetricName.Builder) this;
@@ -75,7 +76,7 @@ final class ImmutableMetricName {
 
         @SuppressWarnings("unchecked")
         @CanIgnoreReturnValue
-        public MetricName.Builder putAllSafeTags(Map<String, ? extends String> entries) {
+        public MetricName.Builder putAllSafeTags(@Safe Map<String, ? extends String> entries) {
             Preconditions.checkNotNull(entries, "entries");
             if (!entries.isEmpty()) {
                 tagMap = tagMap.isEmpty()

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/MetricName.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/MetricName.java
@@ -19,6 +19,7 @@ package com.palantir.tritium.metrics.registry;
 import com.palantir.logsafe.Safe;
 import java.util.SortedMap;
 
+@Safe
 public interface MetricName {
 
     /**
@@ -26,6 +27,7 @@ public interface MetricName {
      *
      * <p>Names must be {@link Safe} to log.
      */
+    @Safe
     String safeName();
 
     /**
@@ -33,6 +35,7 @@ public interface MetricName {
      *
      * <p>All tags and keys must be {@link Safe} to log.
      */
+    @Safe
     SortedMap<String, String> safeTags();
 
     static Builder builder() {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
@@ -22,6 +22,7 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -141,10 +142,10 @@ public interface TaggedMetricRegistry extends TaggedMetricSet {
      * @param safeTagValue a tag value which should be added to all metrics in the metrics set
      * @param metrics the metrics which should be added
      */
-    void addMetrics(String safeTagName, String safeTagValue, TaggedMetricSet metrics);
+    void addMetrics(@Safe String safeTagName, @Safe String safeTagValue, TaggedMetricSet metrics);
 
     /** Removes a TaggedMetricsSet added via addMetrics from this metrics set. */
-    Optional<TaggedMetricSet> removeMetrics(String safeTagName, String safeTagValue);
+    Optional<TaggedMetricSet> removeMetrics(@Safe String safeTagName, @Safe String safeTagValue);
 
     /**
      * Removes a TaggedMetricsSet added via addMetrics from this metrics set, if currently registered to this metric
@@ -155,5 +156,5 @@ public interface TaggedMetricRegistry extends TaggedMetricSet {
      *
      * @return true if value was removed
      */
-    boolean removeMetrics(String safeTagName, String safeTagValue, TaggedMetricSet metrics);
+    boolean removeMetrics(@Safe String safeTagName, @Safe String safeTagValue, TaggedMetricSet metrics);
 }


### PR DESCRIPTION
## Before this PR
Documentation required values to be safe, however this wasn't specified using machine-readable items.

## After this PR
Tritium methods which require safe inputs are annotated as such, allowing baseline-error-prone static analysis to guard against bugs.
==COMMIT_MSG==
Annotate metric name components as `@Safe`
==COMMIT_MSG==

