### PR TITLE
Remove quotes to fix org.gradle.jvmargs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 javaVersion=11
 org.gradle.parallel=true
 com.palantir.gradle.versions.publishLocalConstraints=true
-org.gradle.jvmargs="-XX:+IgnoreUnrecognizedVMOptions --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+org.gradle.jvmargs=-XX:+IgnoreUnrecognizedVMOptions --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED


### PR DESCRIPTION
## Before this PR
Fixup #1450 which mistakenly left Gradle JVM args quoted so it was interpreted as a single JVM argument rather than multiple separate arguments, resulting in:
```
Unrecognized VM option 'IgnoreUnrecognizedVMOptions --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED'
Did you mean '(+/-)IgnoreUnrecognizedVMOptions'? Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove quotes to fix org.gradle.jvmargs
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

