### PR TITLE
MetricName TagMap supports replacement of existing entries

### DIFF
--- a/changelog/@unreleased/pr-1537.v2.yml
+++ b/changelog/@unreleased/pr-1537.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: MetricName TagMap supports replacement of existing entries
+  links:
+  - https://github.com/palantir/tritium/pull/1537

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
@@ -18,7 +18,6 @@ package com.palantir.tritium.metrics.registry;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Ordering;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -122,7 +121,12 @@ final class TagMap implements SortedMap<String, String> {
             String current = local[newPosition];
             int comparisonResult = current.compareTo(key);
             if (comparisonResult == 0) {
-                throw new SafeIllegalArgumentException("Base must not contain the extra key that is to be added");
+                if (Objects.equals(local[newPosition + 1], value)) {
+                    return this;
+                }
+                String[] newArray = local.clone();
+                newArray[newPosition + 1] = value;
+                return new TagMap(newArray);
             }
             if (comparisonResult > 0) {
                 break;

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
@@ -113,7 +113,7 @@ final class TagMap implements SortedMap<String, String> {
         return values;
     }
 
-    /** Returns a new {@link TagMap} with on additional entry. */
+    /** Returns a new {@link TagMap} with on additional or updated entry. */
     TagMap withEntry(String key, String value) {
         String[] local = this.values;
         int newPosition = 0;

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
@@ -113,7 +113,7 @@ final class TagMap implements SortedMap<String, String> {
         return values;
     }
 
-    /** Returns a new {@link TagMap} with on additional or updated entry. */
+    /** Returns a new {@link TagMap} with an additional or updated entry. */
     TagMap withEntry(String key, String value) {
         String[] local = this.values;
         int newPosition = 0;

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TagMapTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TagMapTest.java
@@ -56,9 +56,17 @@ class TagMapTest {
         TagMap original = TagMap.of(Collections.singletonMap("foo", "bar"));
         TagMap updated = original.withEntry("foo", "baz");
         assertThat(updated)
+                .hasSize(1)
+                .containsEntry("foo", "baz")
                 .isEqualTo(ImmutableMap.of("foo", "baz"))
                 .as("Original must not be mutated")
-                .isNotSameAs(original);
+                .isNotSameAs(original)
+                .isNotEqualTo(original);
+        assertThat(original)
+                .hasSize(1)
+                .as("Original must not be mutated")
+                .containsEntry("foo", "bar")
+                .isNotEqualTo(updated);
     }
 
     @Test

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TagMapTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TagMapTest.java
@@ -17,8 +17,8 @@
 package com.palantir.tritium.metrics.registry;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Ordering;
 import java.util.AbstractMap.SimpleImmutableEntry;
@@ -53,12 +53,22 @@ class TagMapTest {
 
     @Test
     void testExtraEntryKeyAlreadyExists() {
-        TagMap map = TagMap.of(Collections.singletonMap("foo", "bar"));
-        assertThatThrownBy(() -> map.withEntry("foo", "baz")).isInstanceOf(IllegalArgumentException.class);
+        TagMap original = TagMap.of(Collections.singletonMap("foo", "bar"));
+        TagMap updated = original.withEntry("foo", "baz");
+        assertThat(updated)
+                .isEqualTo(ImmutableMap.of("foo", "baz"))
+                .as("Original must not be mutated")
+                .isNotSameAs(original);
     }
 
     @Test
-    public void testNaturalOrder() {
+    void testUpdateWithExisting() {
+        TagMap map = TagMap.EMPTY.withEntry("foo", "bar");
+        assertThat(map.withEntry("foo", "bar")).isSameAs(map);
+    }
+
+    @Test
+    void testNaturalOrder() {
         assertThat(TagMap.isNaturalOrder(Ordering.natural())).isTrue();
         assertThat(TagMap.isNaturalOrder(Comparator.naturalOrder())).isTrue();
 


### PR DESCRIPTION
## Why?
I've been thinking about adding additional data to our metrics describing the jvm runtime.
Some potential approaches would introduce risk that existing tags are repeated, although I suspect we'd use an approach including validation within metric-schema. In the event that there's some risk of key overriding, we'd want tritium to support it gracefully long before anything else relied on the functionality.

## Before this PR
```
SafeIllegalArgumentException: Base must not contain the extra key that is to be added
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
MetricName TagMap supports replacement of existing entries
==COMMIT_MSG==

## Possible downsides?
Slightly more code in `withEntry` could be harder for the jvm to optimize
