### PR TITLE
[non urgent] uptime metric tracks whether --enable-preview is set

### DIFF
--- a/changelog/@unreleased/pr-1548.v2.yml
+++ b/changelog/@unreleased/pr-1548.v2.yml
@@ -4,3 +4,4 @@ feature:
     signifies if the `--enable-preview` flag is passed to java at runtime or not.
   links:
   - https://github.com/palantir/tritium/pull/1548
+  - https://openjdk.org/jeps/12

--- a/changelog/@unreleased/pr-1548.v2.yml
+++ b/changelog/@unreleased/pr-1548.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: The `uptime` metric now has an additional tag `enablePreview` which
+    signifies if the `--enable-preview` flag is passed to java at runtime or not.
+  links:
+  - https://github.com/palantir/tritium/pull/1548

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -26,6 +26,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.tritium.metrics.MetricRegistries;
+import com.palantir.tritium.metrics.jvm.InternalJvmMetrics.AttributeUptime_EnablePreview;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.lang.management.ClassLoadingMXBean;
 import java.lang.management.ManagementFactory;
@@ -80,6 +81,10 @@ public final class JvmMetrics {
                 .javaRuntimeVersion(System.getProperty("java.runtime.version", "unknown"))
                 .javaVendorVersion(System.getProperty("java.vendor.version", "unknown"))
                 .javaVmVendor(System.getProperty("java.vm.vendor", "unknown"))
+                .enablePreview(
+                        runtimeMxBean.getInputArguments().contains("--enable-preview")
+                                ? AttributeUptime_EnablePreview.TRUE
+                                : AttributeUptime_EnablePreview.FALSE)
                 .build(runtimeMxBean::getUptime);
     }
 

--- a/tritium-metrics-jvm/src/main/metrics/metrics.yml
+++ b/tritium-metrics-jvm/src/main/metrics/metrics.yml
@@ -46,7 +46,7 @@ namespaces:
         - name: javaVmVendor
           docs: "Example: Azul Systems, Inc."
         - name: enablePreview
-          docs: "Whether the JVM is running with --enable-preview (see JEP 12)"
+          docs: "Whether the JVM is running with --enable-preview (see https://openjdk.org/jeps/12 )"
           values: [true, false]
       classloader.loaded:
         type: gauge

--- a/tritium-metrics-jvm/src/main/metrics/metrics.yml
+++ b/tritium-metrics-jvm/src/main/metrics/metrics.yml
@@ -31,16 +31,23 @@ namespaces:
       attribute.uptime:
         type: gauge
         docs: |
-          Provides the Java virtual machine uptime value in milliseconds. Example tags:
-          javaSpecificationVersion = 11, javaVersion = 11.0.3, javaVersionDate = 2019-04-16,
-          javaRuntimeVersion = 11.0.3+7-LTS, javaVendorVersion = Zulu11.31+11-CA, javaVmVendor = Azul Systems, Inc.
+          Provides the Java virtual machine uptime value in milliseconds.
         tags:
-        - javaSpecificationVersion
-        - javaVersion
-        - javaVersionDate
-        - javaRuntimeVersion
-        - javaVendorVersion
-        - javaVmVendor
+        - name: javaSpecificationVersion
+          docs: "Example: 11"
+        - name: javaVersion
+          docs: "Example: 11.0.3"
+        - name: javaVersionDate
+          docs: "Example: 2019-04-16"
+        - name: javaRuntimeVersion
+          docs: "Example: 11.0.3+7-LTS"
+        - name: javaVendorVersion
+          docs: "Example: Zulu11.31+11-CA"
+        - name: javaVmVendor
+          docs: "Example: Azul Systems, Inc."
+        - name: enablePreview
+          docs: "Whether the JVM is running with --enable-preview (see JEP 12)"
+          values: [true, false]
       classloader.loaded:
         type: gauge
         docs: Total number of classes that have been loaded since the jvm started.


### PR DESCRIPTION
## Before this PR

I've been slowly trying to enable folks to use pattern-matching switch expressions instead of visitors for their conjure unions (see `#hackweek-2022-sealed-unions`), and one of the requirements for this is to add the `--enable-preview` flag at runtime (https://github.com/palantir/sls-packaging/pull/1365).

It occurred to me that if folks ever actually started _using this_ in production, we'd probably want a convenient way to be able to eyeball precisely which installations are using it... especially if we found some undesirable behaviour that only manifested in the --enable-preview case and we wanted to find usages and warn/remediate them.

## After this PR
==COMMIT_MSG==
The `uptime` metric now has an additional tag `enablePreview` which signifies if the `--enable-preview` flag is passed to java at runtime or not.
==COMMIT_MSG==

## Possible downsides?
- I'm not using a typed accessor to detect if this is enabled, so if java maintainers changed their mind about how the flag could be enabled (e.g. using a config file) then my attribute could incorrectly report false.

