### PR TITLE
Enforce NullAway for Guava packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ allprojects {
             ]
 
             options.errorprone {
-                option('NullAway:AnnotatedPackages', 'com.palantir')
+                option('NullAway:AnnotatedPackages', 'com.palantir,com.google.common')
                 option('NullAway:CheckOptionalEmptiness', 'true')
                 option('AllSuggestionsAsWarnings') // https://github.com/google/error-prone/pull/3301
 

--- a/changelog/@unreleased/pr-1570.v2.yml
+++ b/changelog/@unreleased/pr-1570.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Enforce NullAway for Guava packages
+  links:
+  - https://github.com/palantir/tritium/pull/1570

--- a/tritium-processor/src/main/java/com/palantir/tritium/processor/Methods.java
+++ b/tritium-processor/src/main/java/com/palantir/tritium/processor/Methods.java
@@ -17,7 +17,7 @@
 package com.palantir.tritium.processor;
 
 import com.google.common.base.CaseFormat;
-import com.google.common.base.Strings;
+import com.palantir.logsafe.Preconditions;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.TypeName;
@@ -67,9 +67,11 @@ final class Methods {
         IdentityHashMap<MethodElements, String> result = new IdentityHashMap<>();
         for (MethodElements method : instrumentedMethods) {
             String methodName = method.element().getSimpleName().toString();
-            String originalMethodFieldName = Strings.nullToEmpty(CaseFormat.LOWER_CAMEL
-                    .converterTo(CaseFormat.UPPER_UNDERSCORE)
-                    .convert(methodName));
+            String originalMethodFieldName = Preconditions.checkNotNull(
+                    CaseFormat.LOWER_CAMEL
+                            .converterTo(CaseFormat.UPPER_UNDERSCORE)
+                            .convert(methodName),
+                    "methodName cannot be null");
             String methodFieldName = originalMethodFieldName;
             for (int i = 1; true; i++) {
                 String finalName = methodFieldName;

--- a/tritium-processor/src/main/java/com/palantir/tritium/processor/Methods.java
+++ b/tritium-processor/src/main/java/com/palantir/tritium/processor/Methods.java
@@ -17,6 +17,7 @@
 package com.palantir.tritium.processor;
 
 import com.google.common.base.CaseFormat;
+import com.google.common.base.Strings;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.TypeName;
@@ -66,9 +67,9 @@ final class Methods {
         IdentityHashMap<MethodElements, String> result = new IdentityHashMap<>();
         for (MethodElements method : instrumentedMethods) {
             String methodName = method.element().getSimpleName().toString();
-            String originalMethodFieldName = CaseFormat.LOWER_CAMEL
+            String originalMethodFieldName = Strings.nullToEmpty(CaseFormat.LOWER_CAMEL
                     .converterTo(CaseFormat.UPPER_UNDERSCORE)
-                    .convert(methodName);
+                    .convert(methodName));
             String methodFieldName = originalMethodFieldName;
             for (int i = 1; true; i++) {
                 String finalName = methodFieldName;


### PR DESCRIPTION
## Before this PR
`NullAway` was not checking Guava `com.google.common` annotated packages. When enabling as a test for https://github.com/palantir/gradle-baseline/pull/2382 it flagged one likely false positive that we can check.

```
> Task :tritium-processor:compileJava
/home/circleci/project/tritium-processor/src/main/java/com/palantir/tritium/processor/Methods.java:78: error: [NullAway] unboxing of a @Nullable value
                methodFieldName = originalMethodFieldName + i;
                                  ^
    (see http://t.uber.com/nullaway )
1 error
```

## After this PR
==COMMIT_MSG==
Enforce NullAway for Guava packages
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

