### PR TITLE
Tritium registry 'getMetrics()' doesn't throw on duplicate names

### DIFF
--- a/changelog/@unreleased/pr-1589.v2.yml
+++ b/changelog/@unreleased/pr-1589.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Tritium registry 'getMetrics()' doesn't throw on duplicate names
+  links:
+  - https://github.com/palantir/tritium/pull/1589

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AbstractTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AbstractTaggedMetricRegistry.java
@@ -182,7 +182,7 @@ public abstract class AbstractTaggedMetricRegistry implements TaggedMetricRegist
                 .forEach((metricName, metric) ->
                         result.put(RealMetricName.create(metricName, tag.getKey(), tag.getValue()), metric)));
 
-        return result.build();
+        return result.buildKeepingLast();
     }
 
     @Override


### PR DESCRIPTION
It's better to provide what information we can rather than failing when this method is called, especially as it's not used in most production code in favor of the simpler `forEachMetric` method.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Tritium registry 'getMetrics()' doesn't throw on duplicate names
==COMMIT_MSG==

I haven't run into this recently, just something I thought to do when I used `buildKeepingLast` elsewhere.
