### PR TITLE
Fix typo in docs for cpu.shares gauge

### DIFF
--- a/changelog/@unreleased/pr-1620.v2.yml
+++ b/changelog/@unreleased/pr-1620.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix typo in docs for cpu.shares gauge
+  links:
+  - https://github.com/palantir/tritium/pull/1620

--- a/tritium-metrics-jvm/src/main/metrics/metrics.yml
+++ b/tritium-metrics-jvm/src/main/metrics/metrics.yml
@@ -16,7 +16,7 @@ namespaces:
     metrics:
       cpu.shares:
         type: gauge
-        docs: Gauge based on the detected CPU shares, if supported by the platform. Note that `-1` is reported if CPU shares are not being used, and hte metric will not be available if cpu shares are unsupported on this system.
+        docs: Gauge based on the detected CPU shares, if supported by the platform. Note that `-1` is reported if CPU shares are not being used, and the metric will not be available if CPU shares are unsupported on this system.
   process:
     docs: JVM Process Metrics
     metrics:


### PR DESCRIPTION
## Before this PR
Typos in the documentation for the `cpu.shares` guage.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix typo in docs for cpu.shares gauge
==COMMIT_MSG==

