### PR TITLE
Clarify UtcTimestamp relation to https://bugs.openjdk.org/browse/JDK-8283681 fixed in JDK19+

### DIFF
--- a/tritium-time/src/main/java/com/palantir/tritium/time/UtcTimestamp.java
+++ b/tritium-time/src/main/java/com/palantir/tritium/time/UtcTimestamp.java
@@ -30,6 +30,8 @@ public final class UtcTimestamp {
      * Returns an {@link OffsetDateTime} from the system clock in the {@link ZoneOffset#UTC UTC} time zone.
      * Effectively the same as {@link OffsetDateTime#now(java.time.ZoneId)} with argument {@link ZoneOffset#UTC
      * ZoneOffset.UTC}, but optimized to avoid zone rules lookup given UTC zone offset is zero.
+     * <p>
+     * Superseded by <a href="https://bugs.openjdk.org/browse/JDK-8283681">JDK-8283681</a> in JDK 19+.
      *
      * @return OffsetDateTime representing now in {@link ZoneOffset#UTC UTC} zone
      */
@@ -42,6 +44,8 @@ public final class UtcTimestamp {
      * Effectively the same as {@link OffsetDateTime#ofInstant(Instant, ZoneId)} with arguments
      * {@code clock.instant()}, {@link ZoneOffset#UTC ZoneOffset.UTC}, but optimized to avoid zone rules lookup
      * given UTC zone offset is zero.
+     * <p>
+     * Superseded by <a href="https://bugs.openjdk.org/browse/JDK-8283681">JDK-8283681</a> in JDK 19+.
      *
      * @return OffsetDateTime representing clock's instant in {@link ZoneOffset#UTC UTC} zone
      */
@@ -53,6 +57,8 @@ public final class UtcTimestamp {
      * Returns an {@link OffsetDateTime} at the specified instant in the {@link ZoneOffset#UTC UTC} time zone.
      * Effectively the same as {@link OffsetDateTime#ofInstant(Instant, ZoneId)}  with arguments instant and
      * {@link ZoneOffset#UTC ZoneOffset.UTC}, but optimized to avoid zone rules lookup given UTC zone offset is zero.
+     * <p>
+     * Superseded by <a href="https://bugs.openjdk.org/browse/JDK-8283681">JDK-8283681</a> in JDK 19+.
      *
      * @return OffsetDateTime representing instant in {@link ZoneOffset#UTC UTC} zone
      */


### PR DESCRIPTION
## Before this PR
UtcTimestamp JavaDoc did not include link to [JDK-8283681](https://bugs.openjdk.org/browse/JDK-8283681) that addresses the overhead of creating `OffsetDateTime` instances in JDK19+.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Clarify UtcTimestamp relation to https://bugs.openjdk.org/browse/JDK-8283681 fixed in JDK19+
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

