### PR TITLE
@Instrument generates static trace method

### DIFF
--- a/changelog/@unreleased/pr-1679.v2.yml
+++ b/changelog/@unreleased/pr-1679.v2.yml
@@ -1,0 +1,10 @@
+type: improvement
+improvement:
+  description: |-
+    @Instrument generates static trace method
+
+    Provide a `trace` method for generated Instrumented* classes to simplify and optimize the cases where one only wants tracing instrumentation on dynamic instances (e.g. when tracing individual transactions).
+
+    Remove a few excess allocations when using InstrumentationBuilder
+  links:
+  - https://github.com/palantir/tritium/pull/1679

--- a/tritium-annotations/src/main/java/com/palantir/tritium/annotations/internal/InstrumentationBuilder.java
+++ b/tritium-annotations/src/main/java/com/palantir/tritium/annotations/internal/InstrumentationBuilder.java
@@ -37,10 +37,13 @@ import org.slf4j.LoggerFactory;
 
 public final class InstrumentationBuilder<T, U extends T> {
 
+    // pre-allocate enough space for up to 4 handlers so that we don't have to dynamically grow,
+    // though most consumers use between 1 and 3 handlers
+    private static final int ESTIMATED_HANDLERS = 4;
     private final Class<? super T> interfaceClass;
     private final T delegate;
     private final InstrumentedTypeFactory<T, U> factory;
-    private final List<InvocationEventHandler<InvocationContext>> handlers = new ArrayList<>();
+    private final List<InvocationEventHandler<InvocationContext>> handlers = new ArrayList<>(ESTIMATED_HANDLERS);
     private InstrumentationFilter filter = InstrumentationFilters.INSTRUMENT_ALL;
 
     public InstrumentationBuilder(Class<? super T> interfaceClass, T delegate, InstrumentedTypeFactory<T, U> factory) {

--- a/tritium-annotations/src/main/java/com/palantir/tritium/annotations/internal/InstrumentationBuilder.java
+++ b/tritium-annotations/src/main/java/com/palantir/tritium/annotations/internal/InstrumentationBuilder.java
@@ -116,4 +116,14 @@ public final class InstrumentationBuilder<T, U extends T> {
     public U build() {
         return factory.create(delegate, CompositeInvocationEventHandler.of(handlers), filter);
     }
+
+    public static <T, U extends T> U trace(
+            Class<? super T> interfaceClass, T delegate, InstrumentedTypeFactory<T, U> factory) {
+        return checkNotNull(factory, "factory")
+                .create(
+                        checkNotNull(delegate, "delegate"),
+                        TracingInvocationEventHandler.create(
+                                checkNotNull(interfaceClass, "class").getName()),
+                        InstrumentationFilters.INSTRUMENT_ALL);
+    }
 }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
@@ -26,11 +26,15 @@ import javax.annotation.Nullable;
 
 public final class CompositeInvocationEventHandler extends AbstractInvocationEventHandler<InvocationContext> {
 
+    // most instances will have very small number of handlers (typically 2-3)
+    // see https://shipilev.net/blog/2016/arrays-wisdom-ancients/#_caching_the_array
+    @SuppressWarnings("unchecked")
+    private static final InvocationEventHandler<InvocationContext>[] EMPTY = new InvocationEventHandler[] {};
+
     private final InvocationEventHandler<InvocationContext>[] handlers;
 
-    @SuppressWarnings("unchecked")
     private CompositeInvocationEventHandler(List<InvocationEventHandler<InvocationContext>> handlers) {
-        this.handlers = checkNotNull(handlers, "handlers").toArray(new InvocationEventHandler[0]);
+        this.handlers = checkNotNull(handlers, "handlers").toArray(EMPTY);
         for (InvocationEventHandler<InvocationContext> handler : handlers) {
             checkNotNull(handler, "Null handlers are not allowed");
         }

--- a/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessor.java
+++ b/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessor.java
@@ -304,6 +304,18 @@ public final class TritiumAnnotationProcessor extends AbstractProcessor {
                                 TypeNames.erased(delegateType),
                                 className)
                         .build())
+                .addMethod(MethodSpec.methodBuilder("trace")
+                        .addTypeVariables(typeVarNames)
+                        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                        .returns(annotatedType)
+                        .addParameter(ParameterSpec.builder(delegateType, DELEGATE_NAME)
+                                .build())
+                        .addStatement(
+                                "return $T.trace($T.class, delegate, $N::new)",
+                                InstrumentationBuilder.class,
+                                TypeNames.erased(delegateType),
+                                className)
+                        .build())
                 .addMethod(MethodSpec.methodBuilder("instrument")
                         .addTypeVariables(typeVarNames)
                         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedBindsParameter.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedBindsParameter.java.generated
@@ -61,6 +61,10 @@ public final class InstrumentedBindsParameter implements BindsParameter {
                 BindsParameter.class, delegate, InstrumentedBindsParameter::new);
     }
 
+    public static BindsParameter trace(BindsParameter delegate) {
+        return InstrumentationBuilder.trace(BindsParameter.class, delegate, InstrumentedBindsParameter::new);
+    }
+
     public static BindsParameter instrument(BindsParameter delegate, TaggedMetricRegistry registry) {
         return builder(delegate).withTaggedMetrics(registry).withTracing().build();
     }

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedDelegateToCallable.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedDelegateToCallable.java.generated
@@ -62,6 +62,10 @@ public final class InstrumentedDelegateToCallable<T> implements DelegateToCallab
                 Callable.class, delegate, InstrumentedDelegateToCallable::new);
     }
 
+    public static <T> DelegateToCallable<T> trace(Callable<T> delegate) {
+        return InstrumentationBuilder.trace(Callable.class, delegate, InstrumentedDelegateToCallable::new);
+    }
+
     public static <T> DelegateToCallable<T> instrument(Callable<T> delegate, TaggedMetricRegistry registry) {
         return builder(delegate).withTaggedMetrics(registry).withTracing().build();
     }

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedDelegateToRunnable.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedDelegateToRunnable.java.generated
@@ -60,6 +60,10 @@ public final class InstrumentedDelegateToRunnable implements DelegateToRunnable 
                 Runnable.class, delegate, InstrumentedDelegateToRunnable::new);
     }
 
+    public static DelegateToRunnable trace(Runnable delegate) {
+        return InstrumentationBuilder.trace(Runnable.class, delegate, InstrumentedDelegateToRunnable::new);
+    }
+
     public static DelegateToRunnable instrument(Runnable delegate, TaggedMetricRegistry registry) {
         return builder(delegate).withTaggedMetrics(registry).withTracing().build();
     }

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedDeprecatedInterface.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedDeprecatedInterface.java.generated
@@ -64,6 +64,10 @@ public final class InstrumentedDeprecatedInterface implements DeprecatedInterfac
                 DeprecatedInterface.class, delegate, InstrumentedDeprecatedInterface::new);
     }
 
+    public static DeprecatedInterface trace(DeprecatedInterface delegate) {
+        return InstrumentationBuilder.trace(DeprecatedInterface.class, delegate, InstrumentedDeprecatedInterface::new);
+    }
+
     public static DeprecatedInterface instrument(DeprecatedInterface delegate, TaggedMetricRegistry registry) {
         return builder(delegate).withTaggedMetrics(registry).withTracing().build();
     }

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedDeprecatedMethod.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedDeprecatedMethod.java.generated
@@ -63,6 +63,10 @@ public final class InstrumentedDeprecatedMethod implements DeprecatedMethod {
                 DeprecatedMethod.class, delegate, InstrumentedDeprecatedMethod::new);
     }
 
+    public static DeprecatedMethod trace(DeprecatedMethod delegate) {
+        return InstrumentationBuilder.trace(DeprecatedMethod.class, delegate, InstrumentedDeprecatedMethod::new);
+    }
+
     public static DeprecatedMethod instrument(DeprecatedMethod delegate, TaggedMetricRegistry registry) {
         return builder(delegate).withTaggedMetrics(registry).withTracing().build();
     }

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedHasDefaultMethod.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedHasDefaultMethod.java.generated
@@ -82,6 +82,10 @@ public final class InstrumentedHasDefaultMethod implements HasDefaultMethod {
                 HasDefaultMethod.class, delegate, InstrumentedHasDefaultMethod::new);
     }
 
+    public static HasDefaultMethod trace(HasDefaultMethod delegate) {
+        return InstrumentationBuilder.trace(HasDefaultMethod.class, delegate, InstrumentedHasDefaultMethod::new);
+    }
+
     public static HasDefaultMethod instrument(HasDefaultMethod delegate, TaggedMetricRegistry registry) {
         return builder(delegate).withTaggedMetrics(registry).withTracing().build();
     }

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedHasToString.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedHasToString.java.generated
@@ -60,6 +60,10 @@ public final class InstrumentedHasToString implements HasToString {
                 HasToString.class, delegate, InstrumentedHasToString::new);
     }
 
+    public static HasToString trace(HasToString delegate) {
+        return InstrumentationBuilder.trace(HasToString.class, delegate, InstrumentedHasToString::new);
+    }
+
     public static HasToString instrument(HasToString delegate, TaggedMetricRegistry registry) {
         return builder(delegate).withTaggedMetrics(registry).withTracing().build();
     }

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedOverlappingNames.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedOverlappingNames.java.generated
@@ -78,6 +78,10 @@ public final class InstrumentedOverlappingNames implements OverlappingNames {
                 OverlappingNames.class, delegate, InstrumentedOverlappingNames::new);
     }
 
+    public static OverlappingNames trace(OverlappingNames delegate) {
+        return InstrumentationBuilder.trace(OverlappingNames.class, delegate, InstrumentedOverlappingNames::new);
+    }
+
     public static OverlappingNames instrument(OverlappingNames delegate, TaggedMetricRegistry registry) {
         return builder(delegate).withTaggedMetrics(registry).withTracing().build();
     }

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedOverloaded.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedOverloaded.java.generated
@@ -141,6 +141,10 @@ public final class InstrumentedOverloaded implements Overloaded {
                 Overloaded.class, delegate, InstrumentedOverloaded::new);
     }
 
+    public static Overloaded trace(Overloaded delegate) {
+        return InstrumentationBuilder.trace(Overloaded.class, delegate, InstrumentedOverloaded::new);
+    }
+
     public static Overloaded instrument(Overloaded delegate, TaggedMetricRegistry registry) {
         return builder(delegate).withTaggedMetrics(registry).withTracing().build();
     }

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedParameterized.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedParameterized.java.generated
@@ -126,6 +126,10 @@ public final class InstrumentedParameterized<T> implements Parameterized<T> {
                 Parameterized.class, delegate, InstrumentedParameterized::new);
     }
 
+    public static <T> Parameterized<T> trace(Parameterized<T> delegate) {
+        return InstrumentationBuilder.trace(Parameterized.class, delegate, InstrumentedParameterized::new);
+    }
+
     public static <T> Parameterized<T> instrument(Parameterized<T> delegate, TaggedMetricRegistry registry) {
         return builder(delegate).withTaggedMetrics(registry).withTracing().build();
     }

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedSimple.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedSimple.java.generated
@@ -80,6 +80,10 @@ public final class InstrumentedSimple implements Simple {
         return new InstrumentationBuilder<Simple, Simple>(Simple.class, delegate, InstrumentedSimple::new);
     }
 
+    public static Simple trace(Simple delegate) {
+        return InstrumentationBuilder.trace(Simple.class, delegate, InstrumentedSimple::new);
+    }
+
     public static Simple instrument(Simple delegate, TaggedMetricRegistry registry) {
         return builder(delegate).withTaggedMetrics(registry).withTracing().build();
     }


### PR DESCRIPTION
## Before this PR
Noticed in some JFR that `@Instrument` generated classes were `grow()` the
`InstrumentationBuilder.handlers` list when there were only 1 or 2 handlers being used per instance. Many of these were only adding tracing instrumentation, but eating the overhead assumed by InstrumentationBuilder where multiple `InvocationEventHandler` would be registered. This becomes expensive when instrumenting high volumes of dynamic instances (e.g. per transaction).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
@Instrument generates static trace method

Provide a `trace` method for generated Instrumented* classes to simplify and optimize the cases where one only wants tracing instrumentation on dynamic instances (e.g. when tracing individual transactions).

Remove a few excess allocations when using InstrumentationBuilder
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

