### PR TITLE
Reduce executor allocation overhead from Timer.Context

### DIFF
--- a/changelog/@unreleased/pr-1686.v2.yml
+++ b/changelog/@unreleased/pr-1686.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Reduce executor allocation overhead from Timer.Context
+  links:
+  - https://github.com/palantir/tritium/pull/1686

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsExecutorService.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsExecutorService.java
@@ -136,9 +136,11 @@ final class TaggedMetricsExecutorService extends AbstractExecutorService {
         public void run() {
             stopQueueTimer();
             running.inc();
-            try (Timer.Context ignored = duration.time()) {
+            long startNanos = System.nanoTime();
+            try {
                 task.run();
             } finally {
+                duration.update(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
                 running.dec();
             }
         }
@@ -169,9 +171,11 @@ final class TaggedMetricsExecutorService extends AbstractExecutorService {
         public T call() throws Exception {
             stopQueueTimer();
             running.inc();
-            try (Timer.Context ignored = duration.time()) {
+            long startNanos = System.nanoTime();
+            try {
                 return task.call();
             } finally {
+                duration.update(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
                 running.dec();
             }
         }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsScheduledExecutorService.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsScheduledExecutorService.java
@@ -132,9 +132,11 @@ final class TaggedMetricsScheduledExecutorService extends AbstractExecutorServic
         @Override
         public void run() {
             running.inc();
-            try (Timer.Context ignored = duration.time()) {
+            long startNanos = System.nanoTime();
+            try {
                 task.run();
             } finally {
+                duration.update(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
                 running.dec();
             }
         }
@@ -153,11 +155,12 @@ final class TaggedMetricsScheduledExecutorService extends AbstractExecutorServic
         @Override
         public void run() {
             running.inc();
-            Timer.Context context = duration.time();
+            long startNanos = System.nanoTime();
             try {
                 task.run();
             } finally {
-                long elapsed = context.stop();
+                long elapsed = System.nanoTime() - startNanos;
+                duration.update(elapsed, TimeUnit.NANOSECONDS);
                 running.dec();
                 if (elapsed > periodInNanos) {
                     scheduledOverrun.inc();
@@ -177,9 +180,11 @@ final class TaggedMetricsScheduledExecutorService extends AbstractExecutorServic
         @Override
         public T call() throws Exception {
             running.inc();
-            try (Timer.Context ignored = duration.time()) {
+            long startNanos = System.nanoTime();
+            try {
                 return task.call();
             } finally {
+                duration.update(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
                 running.dec();
             }
         }


### PR DESCRIPTION
Prompted by https://github.com/palantir/atlasdb/pull/6490 (regardless of whether or not we keep the atlas metrics, we might as well optimize the instrumentation)

==COMMIT_MSG==
Reduce executor allocation overhead from Timer.Context
==COMMIT_MSG==

