### PR TITLE
Gradle spring cleaning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ allprojects {
     apply plugin: 'com.palantir.baseline-null-away'
     apply plugin: 'com.palantir.jakarta-package-alignment'
     apply plugin: 'com.palantir.java-format'
+    apply plugin: 'com.palantir.revapi'
 
     configurations {
         testImplementationClasspath {
@@ -111,22 +112,10 @@ allprojects {
 
     tasks.withType(Javadoc).configureEach {
         // suppress Javadoc doclint warnings in Java 8+
-        if (!System.getProperty("java.version").startsWith("1.7")) {
-            options.addStringOption('Xdoclint:none', '-quiet')
-        }
+        options.addStringOption('Xdoclint:none', '-quiet')
     }
     tasks.check.dependsOn(javadoc)
-
-    checkImplicitDependencies {
-        // avoid spurious flags on dropwizard metrics
-        ignore 'io.dropwizard.metrics', 'metrics-core'
-    }
-    checkUnusedDependencies {
-        // avoid spurious flags on junit-jupiter
-        ignore 'org.junit.jupiter', 'junit-jupiter'
-    }
     tasks.check.dependsOn(checkImplicitDependencies)
     tasks.check.dependsOn(checkUnusedDependencies)
     tasks.check.dependsOn(checkUnusedConstraints)
 }
-

--- a/tritium-api/build.gradle
+++ b/tritium-api/build.gradle
@@ -1,8 +1,5 @@
 apply plugin: 'com.palantir.external-publish-jar'
-apply plugin: 'com.palantir.revapi'
 
 dependencies {
-
     implementation 'com.google.code.findbugs:jsr305'
 }
-

--- a/tritium-caffeine/build.gradle
+++ b/tritium-caffeine/build.gradle
@@ -1,12 +1,10 @@
 apply plugin: 'com.palantir.external-publish-jar'
-apply plugin: 'com.palantir.revapi'
 
 dependencies {
-
-    api project(':tritium-metrics')
-    api project(':tritium-registry')
     api 'com.github.ben-manes.caffeine:caffeine'
     api 'io.dropwizard.metrics:metrics-core'
+    api project(':tritium-metrics')
+    api project(':tritium-registry')
 
     implementation 'com.google.guava:guava'
     implementation 'com.palantir.safe-logging:logger'
@@ -21,4 +19,3 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'
 }
-

--- a/tritium-core/build.gradle
+++ b/tritium-core/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'com.palantir.external-publish-jar'
-apply plugin: 'com.palantir.revapi'
 
 dependencies {
-
     api project(':tritium-api')
 
     implementation 'com.google.code.findbugs:jsr305'
@@ -12,10 +10,10 @@ dependencies {
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
 
-    testImplementation project(':tritium-test')
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.awaitility:awaitility'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.mockito:mockito-core'
+    testImplementation project(':tritium-test')
 }

--- a/tritium-lib/build.gradle
+++ b/tritium-lib/build.gradle
@@ -1,9 +1,8 @@
 apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.metric-schema'
-apply plugin: 'com.palantir.revapi'
 
 dependencies {
-
+    api 'io.dropwizard.metrics:metrics-core'
     api project(':tritium-api')
     api project(':tritium-core')
     api project(':tritium-metrics')
@@ -12,9 +11,7 @@ dependencies {
     api project(':tritium-slf4j')
     api project(':tritium-time')
     api project(':tritium-tracing')
-    api 'io.dropwizard.metrics:metrics-core'
 
-    implementation 'net.bytebuddy:byte-buddy'
     implementation 'com.google.code.findbugs:jsr305'
     implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.google.guava:guava'
@@ -22,14 +19,14 @@ dependencies {
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'io.dropwizard.metrics:metrics-core'
+    implementation 'net.bytebuddy:byte-buddy'
     implementation 'org.slf4j:slf4j-api'
 
-    testImplementation project(':tritium-test')
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.slf4j:slf4j-simple'
+    testImplementation project(':tritium-test')
 }
-

--- a/tritium-metrics-jvm/build.gradle
+++ b/tritium-metrics-jvm/build.gradle
@@ -1,13 +1,10 @@
 apply plugin: 'com.palantir.external-publish-jar'
-apply plugin: 'com.palantir.revapi'
 apply plugin: 'com.palantir.metric-schema'
 
 dependencies {
-
-    api project(':tritium-registry')
     api 'io.dropwizard.metrics:metrics-core'
+    api project(':tritium-registry')
 
-    implementation project(':tritium-metrics')
     implementation 'com.google.code.findbugs:jsr305'
     implementation 'com.google.guava:guava'
     implementation 'com.palantir.jvm.diagnostics:jvm-diagnostics'
@@ -16,9 +13,9 @@ dependencies {
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'io.dropwizard.metrics:metrics-core'
     implementation 'io.dropwizard.metrics:metrics-jvm'
+    implementation project(':tritium-metrics')
 
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
 }
-

--- a/tritium-metrics/build.gradle
+++ b/tritium-metrics/build.gradle
@@ -1,26 +1,23 @@
 apply plugin: 'com.palantir.external-publish-jar'
-apply plugin: 'com.palantir.revapi'
 apply plugin: 'com.palantir.metric-schema'
 
 dependencies {
-
+    api 'io.dropwizard.metrics:metrics-core'
     api project(':tritium-api')
     api project(':tritium-core')
     api project(':tritium-registry')
-    api 'io.dropwizard.metrics:metrics-core'
 
     implementation 'com.google.code.findbugs:jsr305'
     implementation 'com.google.guava:guava'
     implementation 'com.palantir.safe-logging:logger'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
+    implementation 'org.hdrhistogram:HdrHistogram'
     implementation ('org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir') {
         exclude group: 'io.dropwizard.metrics', module: 'metrics-core'
         exclude group: 'org.hdrhistogram', module: 'HdrHistogram'
     }
-    implementation 'org.hdrhistogram:HdrHistogram'
 
-    testImplementation project(':tritium-test')
     testImplementation 'com.squareup.okhttp3:okhttp'
     testImplementation 'io.undertow:undertow-core'
     testImplementation 'org.assertj:assertj-core'
@@ -31,5 +28,5 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'
+    testImplementation project(':tritium-test')
 }
-

--- a/tritium-proxy/build.gradle
+++ b/tritium-proxy/build.gradle
@@ -1,11 +1,8 @@
 apply plugin: 'com.palantir.external-publish-jar'
-apply plugin: 'com.palantir.revapi'
 
 dependencies {
-
-    testImplementation project(':tritium-test')
-
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation project(':tritium-test')
 }

--- a/tritium-registry/build.gradle
+++ b/tritium-registry/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'com.palantir.external-publish-jar'
-apply plugin: 'com.palantir.revapi'
 
 dependencies {
-
     annotationProcessor 'com.google.auto.service:auto-service'
     compileOnly 'com.google.auto.service:auto-service-annotations'
 
@@ -24,4 +22,3 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.mockito:mockito-core'
 }
-

--- a/tritium-slf4j/build.gradle
+++ b/tritium-slf4j/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'com.palantir.external-publish-jar'
-apply plugin: 'com.palantir.revapi'
 
 dependencies {
-
     api project(':tritium-api')
     api project(':tritium-core')
 
@@ -12,11 +10,10 @@ dependencies {
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'org.slf4j:slf4j-api'
 
-    testImplementation project(':tritium-test')
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.slf4j:slf4j-simple'
+    testImplementation project(':tritium-test')
 }
-

--- a/tritium-time/build.gradle
+++ b/tritium-time/build.gradle
@@ -1,9 +1,7 @@
 apply plugin: 'com.palantir.external-publish-jar'
-apply plugin: 'com.palantir.revapi'
 apply plugin: 'me.champeau.jmh'
 
 dependencies {
-
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/tritium-tracing/build.gradle
+++ b/tritium-tracing/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'com.palantir.external-publish-jar'
-apply plugin: 'com.palantir.revapi'
 
 dependencies {
-
     api project(':tritium-api')
     api project(':tritium-core')
 
@@ -13,7 +11,6 @@ dependencies {
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'com.palantir.tracing:tracing'
 
-    testImplementation project(':tritium-test')
     testImplementation 'com.palantir.tracing:tracing-api'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
@@ -21,4 +18,5 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.slf4j:slf4j-api'
+    testImplementation project(':tritium-test')
 }


### PR DESCRIPTION
## Before this PR
Some gradle config was duplicative of what is provided by gradle-baseline or can be applied to all projects.

Dependency sorting was inconsistent, applied `sort -f -u` to all `build.gradle`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Gradle spring cleaning
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

