### PR TITLE
Avoid flakes with memoized gauges in CaffeineCacheStatsTest

### DIFF
--- a/changelog/@unreleased/pr-1707.v2.yml
+++ b/changelog/@unreleased/pr-1707.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Avoid flakes with memoized gauges in CaffeineCacheStatsTest
+  links:
+  - https://github.com/palantir/tritium/pull/1707


### PR DESCRIPTION
## Before this PR
`develop` [build flaked](https://app.circleci.com/pipelines/github/palantir/tritium/2808/workflows/60822035-767d-4ea5-a14a-3522daa083f6/jobs/19652/tests#failed-test-0) on `com.palantir.tritium.metrics.caffeine.CaffeineCacheStatsTest`

```
expected: 1L
 but was: 0L
	at java.base@17.0.6/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base@17.0.6/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base@17.0.6/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base@17.0.6/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at app//com.palantir.tritium.metrics.caffeine.CaffeineCacheStatsTest.registerCacheTaggedMetrics(CaffeineCacheStatsTest.java:157)
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Avoid flakes with memoized gauges in CaffeineCacheStatsTest
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

