### PR TITLE
InstrumentationProperties avoids string concat when no instrument properties are set

### DIFF
--- a/changelog/@unreleased/pr-1717.v2.yml
+++ b/changelog/@unreleased/pr-1717.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: InstrumentationProperties avoids string concat when no instrument properties
+    are set
+  links:
+  - https://github.com/palantir/tritium/pull/1717


### PR DESCRIPTION
## Before this PR
In a few JFR from service that heavily uses dynamic instrumentation, noticed some unnecessary indy string concatenation allocations. We can avoid these in the common case where there are no `instrument`* system properties set.

![image](https://github.com/palantir/tritium/assets/54594/78e30c70-fcc5-48f1-ae67-7fb286c877a6)


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
InstrumentationProperties avoids string concat when no instrument properties are set
==COMMIT_MSG==

## Possible downsides?
At some future point (1.0?) we should probably remove the system property based controls to simplify things

