### PR TITLE
Use MoreElements to collect methods

### DIFF
--- a/tritium-processor/build.gradle
+++ b/tritium-processor/build.gradle
@@ -6,11 +6,11 @@ dependencies {
     api project(':tritium-registry')
     api project(':tritium-core')
 
-    api 'com.squareup:javapoet'
-    api 'com.google.guava:guava'
-    api 'com.google.code.findbugs:jsr305'
-    api 'com.palantir.safe-logging:preconditions'
-    api 'com.palantir.goethe:goethe'
+    implementation 'com.squareup:javapoet'
+    implementation 'com.google.auto:auto-common'
+    implementation 'com.google.guava:guava'
+    implementation 'com.palantir.goethe:goethe'
+    implementation 'com.palantir.safe-logging:preconditions'
 
     testImplementation 'com.google.testing.compile:compile-testing'
     testImplementation 'com.google.guava:guava'

--- a/tritium-processor/src/main/java/com/palantir/tritium/processor/Methods.java
+++ b/tritium-processor/src/main/java/com/palantir/tritium/processor/Methods.java
@@ -63,6 +63,10 @@ final class Methods {
      */
     static IdentityHashMap<MethodElements, String> methodStaticFieldName(
             List<MethodElements> instrumentedMethods, TypeSpec.Builder typeBuilder, TypeName delegateType) {
+        if (instrumentedMethods.isEmpty()) {
+            return new IdentityHashMap<>();
+        }
+
         List<CodeBlock> initializers = new ArrayList<>();
         IdentityHashMap<MethodElements, String> result = new IdentityHashMap<>();
         for (MethodElements method : instrumentedMethods) {

--- a/tritium-processor/src/test/java/com/palantir/tritium/processor/TritiumProcessorTest.java
+++ b/tritium-processor/src/test/java/com/palantir/tritium/processor/TritiumProcessorTest.java
@@ -113,8 +113,7 @@ public final class TritiumProcessorTest {
 
     @Test
     public void testEmptyInterface() {
-        Compilation compilation = compileTestClass(TEST_CLASSES_BASE_DIR, Empty.class);
-        assertThat(compilation).hadErrorContaining("The annotated interface has no methods");
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, Empty.class);
     }
 
     @Test

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedEmpty.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedEmpty.java.generated
@@ -1,0 +1,41 @@
+package com.palantir.tritium.examples;
+
+import com.palantir.tritium.annotations.internal.InstrumentationBuilder;
+import com.palantir.tritium.api.event.InstrumentationFilter;
+import com.palantir.tritium.event.InvocationContext;
+import com.palantir.tritium.event.InvocationEventHandler;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.tritium.processor.TritiumAnnotationProcessor")
+public final class InstrumentedEmpty implements Empty {
+    private final Empty delegate;
+
+    private final InvocationEventHandler<InvocationContext> handler;
+
+    private final InstrumentationFilter filter;
+
+    private InstrumentedEmpty(
+            Empty delegate, InvocationEventHandler<InvocationContext> handler, InstrumentationFilter filter) {
+        this.delegate = delegate;
+        this.handler = handler;
+        this.filter = filter;
+    }
+
+    @Override
+    public String toString() {
+        return "InstrumentedEmpty{" + delegate + '}';
+    }
+
+    public static InstrumentationBuilder<Empty, Empty> builder(Empty delegate) {
+        return new InstrumentationBuilder<Empty, Empty>(Empty.class, delegate, InstrumentedEmpty::new);
+    }
+
+    public static Empty trace(Empty delegate) {
+        return InstrumentationBuilder.trace(Empty.class, delegate, InstrumentedEmpty::new);
+    }
+
+    public static Empty instrument(Empty delegate, TaggedMetricRegistry registry) {
+        return builder(delegate).withTaggedMetrics(registry).withTracing().build();
+    }
+}

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedHasDefaultMethod.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedHasDefaultMethod.java.generated
@@ -11,14 +11,14 @@ import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.tritium.processor.TritiumAnnotationProcessor")
 public final class InstrumentedHasDefaultMethod implements HasDefaultMethod {
-    private static final Method BAR;
-
     private static final Method FOO;
+
+    private static final Method BAR;
 
     static {
         try {
-            BAR = HasDefaultMethod.class.getMethod("bar");
             FOO = HasDefaultMethod.class.getMethod("foo");
+            BAR = HasDefaultMethod.class.getMethod("bar");
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
@@ -40,6 +40,22 @@ public final class InstrumentedHasDefaultMethod implements HasDefaultMethod {
     }
 
     @Override
+    public void foo() {
+        if (this.handler.isEnabled()) {
+            InvocationContext invocationContext = Handlers.pre(this.handler, this.filter, this, FOO, new Object[] {});
+            try {
+                this.delegate.foo();
+                Handlers.onSuccess(this.handler, invocationContext);
+            } catch (Throwable throwable) {
+                Handlers.onFailure(this.handler, invocationContext, throwable);
+                throw throwable;
+            }
+        } else {
+            this.delegate.foo();
+        }
+    }
+
+    @Override
     public String bar() {
         if (this.handler.isEnabled()) {
             InvocationContext invocationContext = Handlers.pre(this.handler, this.filter, this, BAR, new Object[] {});
@@ -53,22 +69,6 @@ public final class InstrumentedHasDefaultMethod implements HasDefaultMethod {
             }
         } else {
             return this.delegate.bar();
-        }
-    }
-
-    @Override
-    public void foo() {
-        if (this.handler.isEnabled()) {
-            InvocationContext invocationContext = Handlers.pre(this.handler, this.filter, this, FOO, new Object[] {});
-            try {
-                this.delegate.foo();
-                Handlers.onSuccess(this.handler, invocationContext);
-            } catch (Throwable throwable) {
-                Handlers.onFailure(this.handler, invocationContext, throwable);
-                throw throwable;
-            }
-        } else {
-            this.delegate.foo();
         }
     }
 

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedParameterized.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedParameterized.java.generated
@@ -12,20 +12,20 @@ import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.tritium.processor.TritiumAnnotationProcessor")
 public final class InstrumentedParameterized<T> implements Parameterized<T> {
-    private static final Method CONSUME_PARAMETER;
-
     private static final Method PRODUCE_PARAMETER;
 
-    private static final Method METHOD_PARAMETER;
+    private static final Method CONSUME_PARAMETER;
 
     private static final Method CONSUME_LIST_OF_PARAMETER;
 
+    private static final Method METHOD_PARAMETER;
+
     static {
         try {
-            CONSUME_PARAMETER = Parameterized.class.getMethod("consumeParameter", Object.class);
             PRODUCE_PARAMETER = Parameterized.class.getMethod("produceParameter");
-            METHOD_PARAMETER = Parameterized.class.getMethod("methodParameter", Object.class, Object.class);
+            CONSUME_PARAMETER = Parameterized.class.getMethod("consumeParameter", Object.class);
             CONSUME_LIST_OF_PARAMETER = Parameterized.class.getMethod("consumeListOfParameter", List.class);
+            METHOD_PARAMETER = Parameterized.class.getMethod("methodParameter", Object.class, Object.class);
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
@@ -47,23 +47,6 @@ public final class InstrumentedParameterized<T> implements Parameterized<T> {
     }
 
     @Override
-    public void consumeParameter(T value) {
-        if (this.handler.isEnabled()) {
-            InvocationContext invocationContext =
-                    Handlers.pre(this.handler, this.filter, this, CONSUME_PARAMETER, new Object[] {value});
-            try {
-                this.delegate.consumeParameter(value);
-                Handlers.onSuccess(this.handler, invocationContext);
-            } catch (Throwable throwable) {
-                Handlers.onFailure(this.handler, invocationContext, throwable);
-                throw throwable;
-            }
-        } else {
-            this.delegate.consumeParameter(value);
-        }
-    }
-
-    @Override
     public T produceParameter() {
         if (this.handler.isEnabled()) {
             InvocationContext invocationContext =
@@ -82,20 +65,19 @@ public final class InstrumentedParameterized<T> implements Parameterized<T> {
     }
 
     @Override
-    public <U extends T> T methodParameter(T first, U second) {
+    public void consumeParameter(T value) {
         if (this.handler.isEnabled()) {
             InvocationContext invocationContext =
-                    Handlers.pre(this.handler, this.filter, this, METHOD_PARAMETER, new Object[] {first, second});
+                    Handlers.pre(this.handler, this.filter, this, CONSUME_PARAMETER, new Object[] {value});
             try {
-                T returnValue = this.delegate.methodParameter(first, second);
-                Handlers.onSuccess(this.handler, invocationContext, returnValue);
-                return returnValue;
+                this.delegate.consumeParameter(value);
+                Handlers.onSuccess(this.handler, invocationContext);
             } catch (Throwable throwable) {
                 Handlers.onFailure(this.handler, invocationContext, throwable);
                 throw throwable;
             }
         } else {
-            return this.delegate.methodParameter(first, second);
+            this.delegate.consumeParameter(value);
         }
     }
 
@@ -113,6 +95,24 @@ public final class InstrumentedParameterized<T> implements Parameterized<T> {
             }
         } else {
             this.delegate.consumeListOfParameter(value);
+        }
+    }
+
+    @Override
+    public <U extends T> T methodParameter(T first, U second) {
+        if (this.handler.isEnabled()) {
+            InvocationContext invocationContext =
+                    Handlers.pre(this.handler, this.filter, this, METHOD_PARAMETER, new Object[] {first, second});
+            try {
+                T returnValue = this.delegate.methodParameter(first, second);
+                Handlers.onSuccess(this.handler, invocationContext, returnValue);
+                return returnValue;
+            } catch (Throwable throwable) {
+                Handlers.onFailure(this.handler, invocationContext, throwable);
+                throw throwable;
+            }
+        } else {
+            return this.delegate.methodParameter(first, second);
         }
     }
 

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedSimple.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedSimple.java.generated
@@ -11,14 +11,14 @@ import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.tritium.processor.TritiumAnnotationProcessor")
 public final class InstrumentedSimple implements Simple {
-    private static final Method BAR;
-
     private static final Method FOO;
+
+    private static final Method BAR;
 
     static {
         try {
-            BAR = Simple.class.getMethod("bar", double.class);
             FOO = Simple.class.getMethod("foo");
+            BAR = Simple.class.getMethod("bar", double.class);
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
@@ -38,6 +38,22 @@ public final class InstrumentedSimple implements Simple {
     }
 
     @Override
+    public void foo() {
+        if (this.handler.isEnabled()) {
+            InvocationContext invocationContext = Handlers.pre(this.handler, this.filter, this, FOO, new Object[] {});
+            try {
+                this.delegate.foo();
+                Handlers.onSuccess(this.handler, invocationContext);
+            } catch (Throwable throwable) {
+                Handlers.onFailure(this.handler, invocationContext, throwable);
+                throw throwable;
+            }
+        } else {
+            this.delegate.foo();
+        }
+    }
+
+    @Override
     public short bar(double baz) {
         if (this.handler.isEnabled()) {
             InvocationContext invocationContext =
@@ -52,22 +68,6 @@ public final class InstrumentedSimple implements Simple {
             }
         } else {
             return this.delegate.bar(baz);
-        }
-    }
-
-    @Override
-    public void foo() {
-        if (this.handler.isEnabled()) {
-            InvocationContext invocationContext = Handlers.pre(this.handler, this.filter, this, FOO, new Object[] {});
-            try {
-                this.delegate.foo();
-                Handlers.onSuccess(this.handler, invocationContext);
-            } catch (Throwable throwable) {
-                Handlers.onFailure(this.handler, invocationContext, throwable);
-                throw throwable;
-            }
-        } else {
-            this.delegate.foo();
         }
     }
 

--- a/versions.lock
+++ b/versions.lock
@@ -1,5 +1,6 @@
 # Run ./gradlew --write-locks to regenerate this file
 com.github.ben-manes.caffeine:caffeine:3.1.6 (1 constraints: 0c050336)
+com.google.auto:auto-common:1.2.2 (2 constraints: ed16371a)
 com.google.auto.service:auto-service-annotations:1.1.1 (1 constraints: 0505f435)
 com.google.code.findbugs:jsr305:3.0.2 (4 constraints: 5c3586ed)
 com.google.errorprone:error_prone_annotations:2.18.0 (8 constraints: 03715564)
@@ -27,7 +28,6 @@ org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir:1.1.3 (1 constraint
 org.slf4j:slf4j-api:1.7.36 (7 constraints: d75d16df)
 
 [Test dependencies]
-com.google.auto:auto-common:1.2.2 (1 constraints: e711f5e8)
 com.google.auto.value:auto-value:1.7.4 (1 constraints: 1f1221fb)
 com.google.auto.value:auto-value-annotations:1.7.4 (1 constraints: 640a29b9)
 com.google.testing.compile:compile-testing:0.19 (1 constraints: de04f630)


### PR DESCRIPTION
We use this utility in most of our other annotation processors that generate delegating implementations, including the conjure undertow annotation processor and a number of our internal annotation processors.

This simplifies the code and will make it easier to support selective per-method instrumentation in a future PR.

The one caveat is that this annotation processor no longer handles that case when methods with the same signature are inherited from difference ancestors. This seems acceptable since 1) this case is likely rare and 2) this isn't supported by any of our other annotation processors that use `MoreElements`. If this becomes an issue we add some logic to handle this case.

```java
interface A {
    void foo();
}

interface B {
    void foo();
}

@Instrument
interface MyInterface extends A, B {}
```