### PR TITLE
Remove log placeholders

### DIFF
--- a/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
@@ -80,9 +80,9 @@ public abstract class AbstractInvocationEventHandler<C extends InvocationContext
      * @param context invocation context
      */
     protected final void debugIfNullContext(@Nullable InvocationContext context) {
-        if (context == null) {
+        if (context == null && log.isDebugEnabled()) {
             log.debug(
-                    "{} encountered null metric context, likely due to exception in preInvocation",
+                    "Encountered null metric context, likely due to exception in preInvocation",
                     safeClassName(getClass()));
         }
     }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/Handlers.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/Handlers.java
@@ -80,7 +80,7 @@ public final class Handlers {
             Throwable throwable) {
         if (log.isWarnEnabled()) {
             log.warn(
-                    "Exception handling preInvocation({}): invocation of {}.{} on {} threw",
+                    "Exception handling preInvocation: invocation threw",
                     UnsafeArg.of("handler", handler),
                     SafeArg.of("class", method.getDeclaringClass().getCanonicalName()),
                     SafeArg.of("method", method.getName()),
@@ -111,7 +111,7 @@ public final class Handlers {
             Throwable throwable) {
         if (log.isWarnEnabled()) {
             log.warn(
-                    "Exception {}.onSuccess({}, {})",
+                    "Exception in onSuccess",
                     UnsafeArg.of("handler", handler),
                     UnsafeArg.of("context", context),
                     SafeArg.of(
@@ -139,7 +139,7 @@ public final class Handlers {
             Throwable throwable) {
         if (log.isWarnEnabled()) {
             log.warn(
-                    "Exception {}.onFailure({}, {})",
+                    "Exception in onFailure",
                     UnsafeArg.of("handler", handler),
                     UnsafeArg.of("context", context),
                     SafeArg.of(

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/ByteBuddyInstrumentation.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/ByteBuddyInstrumentation.java
@@ -78,7 +78,7 @@ final class ByteBuddyInstrumentation {
 
         if (!isAccessible(interfaceClass)) {
             log.warn(
-                    "Interface {} is not accessible. Delegate {} of type {} will not be instrumented",
+                    "Interface is not accessible. Delegate of type will not be instrumented",
                     SafeArg.of("interface", interfaceClass),
                     UnsafeArg.of("delegate", delegate),
                     SafeArg.of("delegateType", delegate.getClass()));
@@ -90,8 +90,8 @@ final class ByteBuddyInstrumentation {
         ClassLoader classLoader = getClassLoader(interfaceClass);
         if (!isClassLoadable(classLoader, InvocationEventHandler.class)) {
             log.warn(
-                    "Unable to find a classloader with access to both the service interface {} and Tritium. "
-                            + "Delegate {} of type {} will not be instrumented",
+                    "Unable to find a classloader with access to both the service interface and Tritium. "
+                            + "Delegate of type will not be instrumented",
                     SafeArg.of("interface", interfaceClass),
                     UnsafeArg.of("delegate", delegate),
                     SafeArg.of("delegateType", delegate.getClass()));
@@ -107,7 +107,7 @@ final class ByteBuddyInstrumentation {
                     .newInstance(delegate, CompositeInvocationEventHandler.of(handlers), instrumentationFilter);
         } catch (ReflectiveOperationException | RuntimeException e) {
             log.error(
-                    "Failed to instrument interface {}. Delegate {} of type {} will not be instrumented",
+                    "Failed to instrument interface. Delegate of type will not be instrumented",
                     SafeArg.of("interface", interfaceClass),
                     UnsafeArg.of("delegate", delegate),
                     SafeArg.of("delegateType", delegate.getClass()),
@@ -215,7 +215,7 @@ final class ByteBuddyInstrumentation {
                 additionalInterfaces.add(additionalInterface);
             } else {
                 log.debug(
-                        "Instrumented service of type {} cannot implement {} because the interface is not accessible",
+                        "Instrumented service of type cannot implement because the interface is not accessible",
                         SafeArg.of("delegateType", delegateClass),
                         SafeArg.of("inaccessibleInterface", additionalInterface));
             }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AbstractTaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/AbstractTaggedMetricRegistry.java
@@ -135,7 +135,7 @@ public abstract class AbstractTaggedMetricRegistry implements TaggedMetricRegist
     public final void registerWithReplacement(MetricName metricName, Gauge<?> gauge) {
         Metric existing = registry.put(metricName, gauge);
         if (existing instanceof Gauge) {
-            log.get().debug("Removed previously registered gauge {}", SafeArg.of("metricName", metricName));
+            log.get().debug("Removed previously registered gauge", SafeArg.of("metricName", metricName));
         } else if (existing != null) {
             // Existing should be a gauge
             registry.replace(metricName, existing);


### PR DESCRIPTION
## Before this PR
A few log messages still included `{}` placeholders

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove log placeholders
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

