### PR TITLE
Ensure ByteBuddy DynamicType loader resources released

### DIFF
--- a/changelog/@unreleased/pr-1758.v2.yml
+++ b/changelog/@unreleased/pr-1758.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Ensure ByteBuddy DynamicType loader resources released
+  links:
+  - https://github.com/palantir/tritium/pull/1758

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/ByteBuddyInstrumentation.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/ByteBuddyInstrumentation.java
@@ -20,7 +20,6 @@ import static com.palantir.logsafe.Preconditions.checkArgument;
 import static com.palantir.logsafe.Preconditions.checkNotNull;
 import static com.palantir.logsafe.Preconditions.checkState;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.palantir.logsafe.SafeArg;
@@ -59,7 +58,6 @@ final class ByteBuddyInstrumentation {
     // Reuse generated classes when possible
     private static final TypeCache<ImmutableList<Class<?>>> cache =
             new TypeCache.WithInlineExpunction<>(TypeCache.Sort.WEAK);
-    private static final Joiner UNDERSCORE_JOINER = Joiner.on('_');
     private static final String METHODS_FIELD = "methods";
 
     private ByteBuddyInstrumentation() {
@@ -326,7 +324,7 @@ final class ByteBuddyInstrumentation {
 
     private static String className(List<Class<?>> interfaceClasses) {
         return "com.palantir.tritium.proxy.Instrumented"
-                + UNDERSCORE_JOINER.join(Lists.transform(interfaceClasses, Class::getSimpleName))
+                + String.join("_", Lists.transform(interfaceClasses, Class::getSimpleName))
                 + '$'
                 + offset.getAndIncrement();
     }


### PR DESCRIPTION
## Before this PR
IntelliJ warning not closing `Closeable` resource:
`'Unloaded<Object>' used without 'try'-with-resources statement`. This is most likely a no-op, but want to avoid potential future leaks

![image](https://github.com/palantir/tritium/assets/54594/46a0e6fd-94ee-41b2-8553-7e1759d1adb0)


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Ensure ByteBuddy DynamicType loader resources released
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

