### PR TITLE
Add metric for bytes collected by the garbage collector

### DIFF
--- a/changelog/@unreleased/pr-1765.v2.yml
+++ b/changelog/@unreleased/pr-1765.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add metric for bytes collected by the garbage collector
+  links:
+  - https://github.com/palantir/tritium/pull/1765

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/GarbageCollectorMetrics.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/GarbageCollectorMetrics.java
@@ -25,8 +25,8 @@ import com.sun.management.GcInfo;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.management.NotificationEmitter;
 import javax.management.NotificationListener;
 import javax.management.openmbean.CompositeData;
@@ -40,7 +40,7 @@ final class GarbageCollectorMetrics {
 
     private static final SafeLogger log = SafeLoggerFactory.get(GarbageCollectorMetrics.class);
 
-    private static Map<String, Map<String, Long>> collectorBytesCollected = new HashMap<>();
+    private static Map<String, Map<String, Long>> collectorBytesCollected = new ConcurrentHashMap<>();
 
     /**
      * Registers gauges {@code jvm.gc.count} and {@code jvm.gc.time} tagged with {@code {collector: NAME}}.
@@ -69,7 +69,7 @@ final class GarbageCollectorMetrics {
                                     }
                                 }
                             }
-                            return null;
+                            return 0L;
                         });
             }
         }
@@ -109,7 +109,7 @@ final class GarbageCollectorMetrics {
             }
             String canonicalMemoryPool = canonicalName(memoryPool);
             if (!collectorBytesCollected.containsKey(canonicalCollector)) {
-                collectorBytesCollected.put(canonicalCollector, new HashMap<>());
+                collectorBytesCollected.put(canonicalCollector, new ConcurrentHashMap<>());
             }
             Map<String, Long> memoryPoolBytesCollected = collectorBytesCollected.get(canonicalCollector);
             if (!memoryPoolBytesCollected.containsKey(canonicalMemoryPool)) {

--- a/tritium-metrics/src/main/metrics/metrics.yml
+++ b/tritium-metrics/src/main/metrics/metrics.yml
@@ -13,6 +13,10 @@ namespaces:
         type: gauge
         tags: [collector]
         docs: The accumulated collection elapsed time in milliseconds.
+      bytes.collected:
+        type: gauge
+        tags: [collector, memoryPool]
+        docs: The total bytes collected by this collector from this memory pool since the JVM started.  This can be negative if the collector moved objects into the pool.
       finalizer.queue.size:
         type: gauge
         docs: Estimate of the number of objects pending finalization. Finalizers are executed in serial on a single


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Adds a metric for bytes collected by each collector and memory pool. These metrics can be used to determine the allocation rate and promotion rate by the GC. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add metric for bytes collected by the garbage collector
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

