### PR TITLE
Add `🤖 fix nits` label to `/versions.*`

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,1 +1,2 @@
 'autorelease': ['*/src/main/**/*.java']
+'🤖 fix nits': ['/versions.*']


### PR DESCRIPTION
## Before this PR
Excavators, elevators, and other PRs that touch `versions.props` and `versions.lock` may hit conflicts.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add `🤖 fix nits` label to `/versions.*`

Let the robots handle the grunt work keeping PRs up-to-date
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

