### PR TITLE
Tritium cpu shares metric reports -2 when unsupported

### DIFF
--- a/changelog/@unreleased/pr-1829.v2.yml
+++ b/changelog/@unreleased/pr-1829.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Tritium cpu shares metric reports -2 when unsupported
+  links:
+  - https://github.com/palantir/tritium/pull/1829

--- a/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
+++ b/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
@@ -206,7 +206,8 @@ final class JvmMetricsTest {
     void testCpuSharesUnavailable() {
         TaggedMetricRegistry metrics = new DefaultTaggedMetricRegistry();
         JvmMetrics.registerCpuShares(metrics, Optional.empty());
-        assertThat(metrics.getMetrics()).isEmpty();
+        assertThat(metrics.gauge(ContainerMetrics.cpuSharesMetricName()))
+                .hasValueSatisfying(gauge -> assertThat(gauge.getValue()).isEqualTo(-2L));
     }
 
     @Test


### PR DESCRIPTION
This makes the data easier to search. The -2 result matches the result of `jdk.internal.platform.Metrics.getCpuShares` when shares are not supported.

==COMMIT_MSG==
Tritium cpu shares metric reports -2 when unsupported
==COMMIT_MSG==
