### PR TITLE
Remove metric-schema gradle 8 workaround

### DIFF
--- a/changelog/@unreleased/pr-1871.v2.yml
+++ b/changelog/@unreleased/pr-1871.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |-
+    Remove metric-schema gradle 8 workaround
+
+    See https://github.com/palantir/metric-schema/pull/1092
+  links:
+  - https://github.com/palantir/tritium/pull/1871

--- a/tritium-lib/build.gradle
+++ b/tritium-lib/build.gradle
@@ -1,10 +1,6 @@
 apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.metric-schema'
 
-// work around metric-schema gradle 8 task dependency
-tasks.sourcesJar.dependsOn(generateMetrics)
-tasks.sourcesJar.dependsOn(compileMetricSchema)
-
 dependencies {
     api 'io.dropwizard.metrics:metrics-core'
     api project(':tritium-api')

--- a/tritium-metrics-jvm/build.gradle
+++ b/tritium-metrics-jvm/build.gradle
@@ -1,10 +1,6 @@
 apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.metric-schema'
 
-// work around metric-schema gradle 8 task dependency
-tasks.sourcesJar.dependsOn(generateMetrics)
-tasks.sourcesJar.dependsOn(compileMetricSchema)
-
 dependencies {
     api 'io.dropwizard.metrics:metrics-core'
     api project(':tritium-registry')

--- a/tritium-metrics/build.gradle
+++ b/tritium-metrics/build.gradle
@@ -1,10 +1,6 @@
 apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.metric-schema'
 
-// work around metric-schema gradle 8 task dependency
-tasks.sourcesJar.dependsOn(generateMetrics)
-tasks.sourcesJar.dependsOn(compileMetricSchema)
-
 dependencies {
     api 'io.dropwizard.metrics:metrics-core'
     api project(':tritium-api')


### PR DESCRIPTION
## Before this PR

https://github.com/palantir/tritium/pull/1861 worked around metric-schema not declaring `sourcesJar` task dependency on `generateMetrics` or `compileMetricSchema` tasks

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove metric-schema gradle 8 workaround

See https://github.com/palantir/metric-schema/pull/1092
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

