### PR TITLE
Initial Caffeine CacheStats recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,23 @@ Service instrumentedService = Tritium.instrument(Service.class,
         interestingService, environment.metrics());
 ```
 
+## Instrumenting a [Caffeine cache](https://github.com/ben-manes/caffeine/)
+
+```java
+import com.palantir.tritium.metrics.caffeine.CacheStats;
+
+TaggedMetricRegistry taggedMetricRegistry = ...
+CacheStats cacheStats = CacheStats.of(taggedMetricRegistry, "unique-cache-name");
+Cache<Integer, String> cache = cacheStats.register(Caffeine.newBuilder()
+        .recordStats(cacheStats.recorder())
+        .build());
+
+CacheStats loadingCacheStats = CacheStats.of(taggedMetricRegistry, "unique-loading-cache-name");
+LoadingCache<String, Integer> loadingCache = loadingCacheStats.register(Caffeine.newBuilder()
+        .recordStats(loadingCacheStats.recorder())
+        .build(key::length));
+```
+
 ## Creating a metric registry with reservoirs backed by [HDR Histograms](https://hdrhistogram.github.io/HdrHistogram/).
 
 HDR histograms are more useful if the service is long running, so the stats represents the lifetime of the server rather than using default exponential decay which can lead to some mis-interpretations of timings (especially higher percentiles and things like max dropping over time) if the consumer isn't aware of these assumptions.

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ Service instrumentedService = Tritium.instrument(Service.class,
 import com.palantir.tritium.metrics.caffeine.CacheStats;
 
 TaggedMetricRegistry taggedMetricRegistry = ...
-Cache<Integer, String> cache = cacheStats.register(Caffeine.newBuilder()
+Cache<Integer, String> cache = Caffeine.newBuilder()
         .recordStats(CacheStats.of(taggedMetricRegistry, "unique-cache-name"))
-        .build());
+        .build();
 
-LoadingCache<String, Integer> loadingCache = loadingCacheStats.register(Caffeine.newBuilder()
+LoadingCache<String, Integer> loadingCache = Caffeine.newBuilder()
         .recordStats(CacheStats.of(taggedMetricRegistry, "unique-loading-cache-name"))
-        .build(key::length));
+        .build(key::length);
 ```
 
 ## Creating a metric registry with reservoirs backed by [HDR Histograms](https://hdrhistogram.github.io/HdrHistogram/).

--- a/README.md
+++ b/README.md
@@ -86,14 +86,12 @@ Service instrumentedService = Tritium.instrument(Service.class,
 import com.palantir.tritium.metrics.caffeine.CacheStats;
 
 TaggedMetricRegistry taggedMetricRegistry = ...
-CacheStats cacheStats = CacheStats.of(taggedMetricRegistry, "unique-cache-name");
 Cache<Integer, String> cache = cacheStats.register(Caffeine.newBuilder()
-        .recordStats(cacheStats)
+        .recordStats(CacheStats.of(taggedMetricRegistry, "unique-cache-name"))
         .build());
 
-CacheStats loadingCacheStats = CacheStats.of(taggedMetricRegistry, "unique-loading-cache-name");
 LoadingCache<String, Integer> loadingCache = loadingCacheStats.register(Caffeine.newBuilder()
-        .recordStats(loadingCacheStats)
+        .recordStats(CacheStats.of(taggedMetricRegistry, "unique-loading-cache-name"))
         .build(key::length));
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ import com.palantir.tritium.metrics.caffeine.CacheStats;
 TaggedMetricRegistry taggedMetricRegistry = ...
 CacheStats cacheStats = CacheStats.of(taggedMetricRegistry, "unique-cache-name");
 Cache<Integer, String> cache = cacheStats.register(Caffeine.newBuilder()
-        .recordStats(cacheStats.recorder())
+        .recordStats(cacheStats)
         .build());
 
 CacheStats loadingCacheStats = CacheStats.of(taggedMetricRegistry, "unique-loading-cache-name");
 LoadingCache<String, Integer> loadingCache = loadingCacheStats.register(Caffeine.newBuilder()
-        .recordStats(loadingCacheStats.recorder())
+        .recordStats(loadingCacheStats)
         .build(key::length));
 ```
 

--- a/changelog/@unreleased/pr-1897.v2.yml
+++ b/changelog/@unreleased/pr-1897.v2.yml
@@ -1,5 +1,18 @@
 type: improvement
 improvement:
-  description: Initial Caffeine CacheStats recorder
+  description: |
+    Initial Caffeine CacheStats recorder
+    
+    Example usage:
+    ```
+    TaggedMetricRegistry taggedMetricRegistry = ...
+    Cache<Integer, String> cache = Caffeine.newBuilder()
+            .recordStats(CacheStats.of(taggedMetricRegistry, "unique-cache-name"))
+            .build();
+
+    LoadingCache<String, Integer> loadingCache = Caffeine.newBuilder()
+            .recordStats(CacheStats.of(taggedMetricRegistry, "unique-loading-cache-name"))
+            .build(key::length);
+    ```
   links:
   - https://github.com/palantir/tritium/pull/1897

--- a/changelog/@unreleased/pr-1897.v2.yml
+++ b/changelog/@unreleased/pr-1897.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Initial Caffeine CacheStats recorder
+  links:
+  - https://github.com/palantir/tritium/pull/1897

--- a/tritium-caffeine/build.gradle
+++ b/tritium-caffeine/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.palantir.external-publish-jar'
+apply plugin: 'com.palantir.metric-schema'
 
 dependencies {
     api 'com.github.ben-manes.caffeine:caffeine'

--- a/tritium-caffeine/build.gradle
+++ b/tritium-caffeine/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'io.dropwizard.metrics:metrics-core'
+    implementation 'org.checkerframework:checker-qual'
 
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.awaitility:awaitility'

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
@@ -31,7 +31,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.checkerframework.checker.index.qual.NonNegative;
 
-public final class CacheStats implements StatsCounter {
+public final class CacheStats implements StatsCounter, Supplier<StatsCounter> {
     private final CacheMetrics metrics;
     private final String name;
     private final Counter hitCounter;
@@ -112,8 +112,9 @@ public final class CacheStats implements StatsCounter {
         return (LoadingCache<K, V>) register((Cache<K, V>) cache);
     }
 
-    public Supplier<? extends StatsCounter> recorder() {
-        return () -> this;
+    @Override
+    public StatsCounter get() {
+        return this;
     }
 
     @Override

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
@@ -42,12 +42,12 @@ public final class CacheStats implements StatsCounter, Supplier<StatsCounter> {
     /**
      * Creates a {@link CacheStats} instance that registers metrics for Caffeine cache statistics.
      * <p>
-     * Example method
+     * Example usage for a {@link com.github.benmanes.caffeine.cache.Cache} or
+     * {@link com.github.benmanes.caffeine.cache.LoadingCache}:
      * <pre>
-     *         CacheStats cacheStats = CacheStats.of(taggedMetricRegistry, "your-cache-name");
-     *         LoadingCache&lt;Integer, String> cache = cacheStats.register(Caffeine.newBuilder()
-     *                 .recordStats(cacheStats.record())
-     *                 .build(key -> computeSomethingExpensive(key));
+     *     LoadingCache&lt;Integer, String> cache = Caffeine.newBuilder()
+     *             .recordStats(CacheStats.of(taggedMetricRegistry, "your-cache-name"))
+     *             .build(key -> computeSomethingExpensive(key));
      * </pre>
      * @param taggedMetricRegistry tagged metric registry to add cache metrics
      * @param name cache name
@@ -58,6 +58,22 @@ public final class CacheStats implements StatsCounter, Supplier<StatsCounter> {
         return new CacheStats(CacheMetrics.of(taggedMetricRegistry), name);
     }
 
+    /**
+     * Creates a {@link CacheStats} instance that registers metrics for Caffeine cache statistics.
+     * <p>
+     * Example usage for a {@link com.github.benmanes.caffeine.cache.Cache} or
+     * {@link com.github.benmanes.caffeine.cache.LoadingCache}:
+     * <pre>
+     *     CacheMetrics metrics = CacheMetrics.of(taggedMetricRegistry);
+     *     LoadingCache&lt;Integer, String> cache = Caffeine.newBuilder()
+     *             .recordStats(CacheStats.of(metrics, "your-cache-name"))
+     *             .build(key -> computeSomethingExpensive(key));
+     * </pre>
+     * @param metrics metric instance to use for cache metrics
+     * @param name cache name
+     * @return Caffeine stats instance to register via
+     * {@link com.github.benmanes.caffeine.cache.Caffeine#recordStats(Supplier)}.
+     */
     public static CacheStats of(CacheMetrics metrics, String name) {
         return new CacheStats(metrics, name);
     }

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
@@ -1,0 +1,166 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.caffeine;
+
+import com.codahale.metrics.Counter;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Policy;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.stats.StatsCounter;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.tritium.metrics.cache.CacheMetrics;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.util.Arrays;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.checkerframework.checker.index.qual.NonNegative;
+
+public final class CacheStats implements StatsCounter {
+    private final CacheMetrics metrics;
+    private final String name;
+    private final Counter hitCounter;
+    private final Counter missCounter;
+
+    private final LongAdder totalLoadNanos = new LongAdder();
+    private final Counter loadSuccessCounter;
+    private final Counter loadFailureCounter;
+    private final Counter evictionsTotalCounter;
+    private final ImmutableMap<RemovalCause, Counter> evictionCounters;
+
+    /**
+     * Creates a {@link CacheStats} instance that registers metrics for Caffeine cache statistics.
+     * <p>
+     * Example method
+     * <pre>
+     *         CacheStats cacheStats = CacheStats.of(taggedMetricRegistry, "your-cache-name");
+     *         LoadingCache&lt;Integer, String> cache = cacheStats.register(Caffeine.newBuilder()
+     *                 .recordStats(cacheStats.record())
+     *                 .build(key -> computeSomethingExpensive(key));
+     * </pre>
+     * @param taggedMetricRegistry tagged metric registry to add cache metrics
+     * @param name cache name
+     * @return Caffeine stats instance to register via
+     * {@link com.github.benmanes.caffeine.cache.Caffeine#recordStats(Supplier)}.
+     */
+    public static CacheStats of(TaggedMetricRegistry taggedMetricRegistry, String name) {
+        return new CacheStats(CacheMetrics.of(taggedMetricRegistry), name);
+    }
+
+    public static CacheStats of(CacheMetrics metrics, String name) {
+        return new CacheStats(metrics, name);
+    }
+
+    private CacheStats(CacheMetrics metrics, String name) {
+        this.metrics = metrics;
+        this.name = name;
+        this.hitCounter = metrics.hitCount(name);
+        this.missCounter = metrics.missCount(name);
+        this.loadSuccessCounter = metrics.loadSuccessCount(name);
+        this.loadFailureCounter = metrics.loadFailureCount(name);
+        this.evictionsTotalCounter = metrics.evictionCount(name);
+        this.evictionCounters = Arrays.stream(RemovalCause.values())
+                .collect(ImmutableMap.toImmutableMap(Function.identity(), cause -> metrics.evictions()
+                        .cache(name)
+                        .cause(cause.toString())
+                        .build()));
+        metrics.requestCount().cache(name).build(() -> hitCounter.getCount() + missCounter.getCount());
+    }
+
+    public <K, V, C extends Cache<K, V>> C register(C cache) {
+        metrics.estimatedSize().cache(name).build(cache::estimatedSize);
+        metrics.maximumSize().cache(name).build(() -> cache.policy()
+                .eviction()
+                .map(Policy.Eviction::getMaximum)
+                .orElse(-1L));
+        metrics.weightedSize().cache(name).build(() -> cache.policy()
+                .eviction()
+                .flatMap(e -> e.weightedSize().stream().boxed().findFirst())
+                .orElse(0L));
+        metrics.hitRatio().cache(name).build(() -> {
+            double hitCount = hitCounter.getCount();
+            return hitCount / (hitCount + missCounter.getCount());
+        });
+        metrics.missRatio().cache(name).build(() -> {
+            double missCount = missCounter.getCount();
+            return missCount / (hitCounter.getCount() + missCount);
+        });
+        metrics.loadAverageMillis()
+                .cache(name)
+                .build(() ->
+                        // convert nanoseconds to milliseconds
+                        totalLoadNanos.sum() / 1_000_000.0d);
+        return cache;
+    }
+
+    public <K, V> LoadingCache<K, V> register(LoadingCache<K, V> cache) {
+        return (LoadingCache<K, V>) register((Cache<K, V>) cache);
+    }
+
+    public Supplier<? extends StatsCounter> recorder() {
+        return () -> this;
+    }
+
+    @Override
+    public void recordHits(@NonNegative int count) {
+        hitCounter.inc(count);
+    }
+
+    @Override
+    public void recordMisses(@NonNegative int count) {
+        missCounter.inc(count);
+    }
+
+    @Override
+    public void recordLoadSuccess(@NonNegative long loadTime) {
+        loadSuccessCounter.inc();
+        totalLoadNanos.add(loadTime);
+    }
+
+    @Override
+    public void recordLoadFailure(@NonNegative long loadTime) {
+        loadFailureCounter.inc();
+        totalLoadNanos.add(loadTime);
+    }
+
+    @Override
+    public void recordEviction(@NonNegative int weight, RemovalCause cause) {
+        Counter counter = evictionCounters.get(cause);
+        if (counter != null) {
+            counter.inc(weight);
+        }
+        evictionsTotalCounter.inc(weight);
+    }
+
+    @Override
+    public com.github.benmanes.caffeine.cache.stats.CacheStats snapshot() {
+        return com.github.benmanes.caffeine.cache.stats.CacheStats.of(
+                hitCounter.getCount(),
+                missCounter.getCount(),
+                loadSuccessCounter.getCount(),
+                loadFailureCounter.getCount(),
+                totalLoadNanos.sum(),
+                evictionsTotalCounter.getCount(),
+                evictionCounters.values().stream().mapToLong(Counter::getCount).sum());
+    }
+
+    @Override
+    public String toString() {
+        return name + ": " + snapshot();
+    }
+}

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
@@ -44,9 +44,9 @@ public final class CacheStats implements StatsCounter, Supplier<StatsCounter> {
      * Example usage for a {@link com.github.benmanes.caffeine.cache.Cache} or
      * {@link com.github.benmanes.caffeine.cache.LoadingCache}:
      * <pre>
-     *     LoadingCache&lt;Integer, String> cache = Caffeine.newBuilder()
+     *     LoadingCache&lt;Integer, String&gt; cache = Caffeine.newBuilder()
      *             .recordStats(CacheStats.of(taggedMetricRegistry, "your-cache-name"))
-     *             .build(key -> computeSomethingExpensive(key));
+     *             .build(key -&gt; computeSomethingExpensive(key));
      * </pre>
      * @param taggedMetricRegistry tagged metric registry to add cache metrics
      * @param name cache name

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
@@ -23,6 +23,7 @@ import com.github.benmanes.caffeine.cache.stats.StatsCounter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.palantir.logsafe.Safe;
+import com.palantir.tritium.metrics.caffeine.CacheMetrics.Load_Result;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Arrays;
 import java.util.concurrent.atomic.LongAdder;
@@ -60,11 +61,13 @@ public final class CacheStats implements StatsCounter, Supplier<StatsCounter> {
 
     private CacheStats(CacheMetrics metrics, @Safe String name) {
         this.name = name;
-        this.hitMeter = metrics.hitCount(name);
-        this.missMeter = metrics.missCount(name);
-        this.loadSuccessMeter = metrics.loadSuccessCount(name);
-        this.loadFailureMeter = metrics.loadFailureCount(name);
-        this.evictionsTotalMeter = metrics.evictionCount(name);
+        this.hitMeter = metrics.hit(name);
+        this.missMeter = metrics.miss(name);
+        this.loadSuccessMeter =
+                metrics.load().cache(name).result(Load_Result.SUCCESS).build();
+        this.loadFailureMeter =
+                metrics.load().cache(name).result(Load_Result.FAILURE).build();
+        this.evictionsTotalMeter = metrics.eviction(name);
         this.evictionMeters = Arrays.stream(RemovalCause.values())
                 .collect(Maps.toImmutableEnumMap(cause -> cause, cause -> metrics.evictions()
                         .cache(name)

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
@@ -21,7 +21,6 @@ import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.stats.StatsCounter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import com.palantir.tritium.metrics.cache.CacheMetrics;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Arrays;
 import java.util.concurrent.atomic.LongAdder;
@@ -32,12 +31,11 @@ public final class CacheStats implements StatsCounter, Supplier<StatsCounter> {
     private final String name;
     private final Counter hitCounter;
     private final Counter missCounter;
-
-    private final LongAdder totalLoadNanos = new LongAdder();
     private final Counter loadSuccessCounter;
     private final Counter loadFailureCounter;
     private final Counter evictionsTotalCounter;
     private final ImmutableMap<RemovalCause, Counter> evictionCounters;
+    private final LongAdder totalLoadNanos = new LongAdder();
 
     /**
      * Creates a {@link CacheStats} instance that registers metrics for Caffeine cache statistics.
@@ -56,26 +54,6 @@ public final class CacheStats implements StatsCounter, Supplier<StatsCounter> {
      */
     public static CacheStats of(TaggedMetricRegistry taggedMetricRegistry, String name) {
         return new CacheStats(CacheMetrics.of(taggedMetricRegistry), name);
-    }
-
-    /**
-     * Creates a {@link CacheStats} instance that registers metrics for Caffeine cache statistics.
-     * <p>
-     * Example usage for a {@link com.github.benmanes.caffeine.cache.Cache} or
-     * {@link com.github.benmanes.caffeine.cache.LoadingCache}:
-     * <pre>
-     *     CacheMetrics metrics = CacheMetrics.of(taggedMetricRegistry);
-     *     LoadingCache&lt;Integer, String> cache = Caffeine.newBuilder()
-     *             .recordStats(CacheStats.of(metrics, "your-cache-name"))
-     *             .build(key -> computeSomethingExpensive(key));
-     * </pre>
-     * @param metrics metric instance to use for cache metrics
-     * @param name cache name
-     * @return Caffeine stats instance to register via
-     * {@link com.github.benmanes.caffeine.cache.Caffeine#recordStats(Supplier)}.
-     */
-    public static CacheStats of(CacheMetrics metrics, String name) {
-        return new CacheStats(metrics, name);
     }
 
     private CacheStats(CacheMetrics metrics, String name) {

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
@@ -21,6 +21,7 @@ import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.stats.StatsCounter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.palantir.logsafe.Safe;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Arrays;
 import java.util.concurrent.atomic.LongAdder;
@@ -52,11 +53,11 @@ public final class CacheStats implements StatsCounter, Supplier<StatsCounter> {
      * @return Caffeine stats instance to register via
      * {@link com.github.benmanes.caffeine.cache.Caffeine#recordStats(Supplier)}.
      */
-    public static CacheStats of(TaggedMetricRegistry taggedMetricRegistry, String name) {
+    public static CacheStats of(TaggedMetricRegistry taggedMetricRegistry, @Safe String name) {
         return new CacheStats(CacheMetrics.of(taggedMetricRegistry), name);
     }
 
-    private CacheStats(CacheMetrics metrics, String name) {
+    private CacheStats(CacheMetrics metrics, @Safe String name) {
         this.name = name;
         this.hitCounter = metrics.hitCount(name);
         this.missCounter = metrics.missCount(name);

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
@@ -20,11 +20,11 @@ import com.codahale.metrics.Counter;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.stats.StatsCounter;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.palantir.tritium.metrics.cache.CacheMetrics;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Arrays;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import org.checkerframework.checker.index.qual.NonNegative;
 
@@ -86,7 +86,7 @@ public final class CacheStats implements StatsCounter, Supplier<StatsCounter> {
         this.loadFailureCounter = metrics.loadFailureCount(name);
         this.evictionsTotalCounter = metrics.evictionCount(name);
         this.evictionCounters = Arrays.stream(RemovalCause.values())
-                .collect(ImmutableMap.toImmutableMap(Function.identity(), cause -> metrics.evictions()
+                .collect(Maps.toImmutableEnumMap(cause -> cause, cause -> metrics.evictions()
                         .cache(name)
                         .cause(cause.toString())
                         .build()));

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStats.java
@@ -70,16 +70,17 @@ public final class CaffeineCacheStats {
 
     /**
      * Register specified cache with the given metric registry.
-     *
+     * <p>
      * Callers should ensure that they have {@link Caffeine#recordStats() enabled stats recording}
      * {@code Caffeine.newBuilder().recordStats()} otherwise there are no cache metrics to register.
      *
      * @param registry metric registry
      * @param cache cache to instrument
      * @param name cache name
-     * @deprecated prefer {@link Caffeine#recordStats(Supplier)} and {@link CacheStats#of(TaggedMetricRegistry, String)}
+     * <p>
+     * Soon to be deprecated, prefer {@link Caffeine#recordStats(Supplier)} and {@link CacheStats#of(TaggedMetricRegistry, String)}
      */
-    @Deprecated
+    // Soon to be @Deprecated
     public static void registerCache(TaggedMetricRegistry registry, Cache<?, ?> cache, @Safe String name) {
         checkNotNull(registry, "registry");
         checkNotNull(cache, "cache");

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStats.java
@@ -33,6 +33,7 @@ import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public final class CaffeineCacheStats {
 
@@ -43,7 +44,7 @@ public final class CaffeineCacheStats {
 
     /**
      * Register specified cache with the given metric registry.
-     *
+     * <p>
      * Callers should ensure that they have {@link Caffeine#recordStats() enabled stats recording}
      * {@code Caffeine.newBuilder().recordStats()} otherwise there are no cache metrics to register.
      *
@@ -76,7 +77,9 @@ public final class CaffeineCacheStats {
      * @param registry metric registry
      * @param cache cache to instrument
      * @param name cache name
+     * @deprecated prefer {@link Caffeine#recordStats(Supplier)} and {@link CacheStats#of(TaggedMetricRegistry, String)}
      */
+    @Deprecated
     public static void registerCache(TaggedMetricRegistry registry, Cache<?, ?> cache, @Safe String name) {
         checkNotNull(registry, "registry");
         checkNotNull(cache, "cache");

--- a/tritium-caffeine/src/main/metrics/cache-metrics.yml
+++ b/tritium-caffeine/src/main/metrics/cache-metrics.yml
@@ -6,31 +6,31 @@ namespaces:
     docs: Cache statistic metrics
     metrics:
       hit.count:
-        type: counter
+        type: meter
         tags: [cache]
         docs: Count of cache hits
       miss.count:
-        type: counter
+        type: meter
         tags: [cache]
         docs: Count of cache misses
       load.success.count:
-        type: counter
+        type: meter
         tags: [cache]
         docs: Count of successful cache loads
       load.failure.count:
-        type: counter
+        type: meter
         tags: [cache]
         docs: Count of failed cache loads
       evictions:
-        type: counter
+        type: meter
         tags: [cache, cause]
         docs: Count of evicted entries by cause
       eviction.count:
-        type: counter
+        type: meter
         tags: [cache]
         docs: Total count of evicted entries
       stats.disabled:
-        type: counter
+        type: meter
         tags: [cache]
         docs: |
           Registered cache does not have stats recording enabled, stats will always be zero.

--- a/tritium-caffeine/src/main/metrics/cache-metrics.yml
+++ b/tritium-caffeine/src/main/metrics/cache-metrics.yml
@@ -14,7 +14,7 @@ namespaces:
         tags: [cache]
         docs: Count of cache misses
       load:
-        type: meter
+        type: timer
         tags:
           - name: cache
           - name: result

--- a/tritium-caffeine/src/main/metrics/cache-metrics.yml
+++ b/tritium-caffeine/src/main/metrics/cache-metrics.yml
@@ -1,6 +1,6 @@
 options:
-  javaPackage: com.palantir.tritium.metrics.cache
-  javaVisibility: public
+  javaPackage: com.palantir.tritium.metrics.caffeine
+  javaVisibility: packagePrivate
 namespaces:
   cache:
     docs: Cache statistic metrics

--- a/tritium-caffeine/src/main/metrics/cache-metrics.yml
+++ b/tritium-caffeine/src/main/metrics/cache-metrics.yml
@@ -5,27 +5,26 @@ namespaces:
   cache:
     docs: Cache statistic metrics
     metrics:
-      hit.count:
+      hit:
         type: meter
         tags: [cache]
         docs: Count of cache hits
-      miss.count:
+      miss:
         type: meter
         tags: [cache]
         docs: Count of cache misses
-      load.success.count:
+      load:
         type: meter
-        tags: [cache]
+        tags:
+          - name: cache
+          - name: result
+            values: [success, failure]
         docs: Count of successful cache loads
-      load.failure.count:
-        type: meter
-        tags: [cache]
-        docs: Count of failed cache loads
       evictions:
         type: meter
         tags: [cache, cause]
         docs: Count of evicted entries by cause
-      eviction.count:
+      eviction:
         type: meter
         tags: [cache]
         docs: Total count of evicted entries

--- a/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStatsTest.java
+++ b/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStatsTest.java
@@ -214,10 +214,8 @@ final class CaffeineCacheStatsTest {
     @Test
     void registerTaggedMetrics() {
         CacheStats cacheStats = CacheStats.of(taggedMetricRegistry, "test");
-        Cache<Integer, String> cache = cacheStats.register(Caffeine.newBuilder()
-                .recordStats(cacheStats.recorder())
-                .maximumSize(2)
-                .build());
+        Cache<Integer, String> cache = cacheStats.register(
+                Caffeine.newBuilder().recordStats(cacheStats).maximumSize(2).build());
         assertThat(taggedMetricRegistry.getMetrics().keySet())
                 .extracting(MetricName::safeName)
                 .contains(
@@ -264,10 +262,8 @@ final class CaffeineCacheStatsTest {
     @Test
     void registerLoadingTaggedMetrics() {
         CacheStats cacheStats = CacheStats.of(taggedMetricRegistry, "test");
-        LoadingCache<Integer, String> cache = cacheStats.register(Caffeine.newBuilder()
-                .recordStats(cacheStats.recorder())
-                .maximumSize(2)
-                .build(mapping::apply));
+        LoadingCache<Integer, String> cache = cacheStats.register(
+                Caffeine.newBuilder().recordStats(cacheStats).maximumSize(2).build(mapping::apply));
         assertThat(taggedMetricRegistry.getMetrics().keySet())
                 .extracting(MetricName::safeName)
                 .contains(

--- a/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStatsTest.java
+++ b/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStatsTest.java
@@ -224,35 +224,42 @@ final class CaffeineCacheStatsTest {
         assertThat(taggedMetricRegistry.getMetrics().keySet())
                 .extracting(MetricName::safeName)
                 .containsExactlyInAnyOrder(
-                        "cache.hit.count",
-                        "cache.miss.count",
-                        "cache.eviction.count",
+                        "cache.hit",
+                        "cache.miss",
+                        "cache.eviction",
                         "cache.evictions", // RemovalCause.EXPLICIT
                         "cache.evictions", // RemovalCause.REPLACED
                         "cache.evictions", // RemovalCause.COLLECTED
                         "cache.evictions", // RemovalCause.EXPIRED
                         "cache.evictions", // RemovalCause.SIZE
-                        "cache.load.success.count",
-                        "cache.load.failure.count");
+                        "cache.load", // success
+                        "cache.load" // failure
+                        );
 
         CacheMetrics cacheMetrics = CacheMetrics.of(taggedMetricRegistry);
-        assertThat(cacheMetrics.hitCount("test").getCount()).isZero();
         assertThat(cacheMetrics.evictions().cache("test").cause("SIZE").build().getCount())
                 .asInstanceOf(InstanceOfAssertFactories.LONG)
                 .isZero();
-        assertMeter(taggedMetricRegistry, "cache.hit.count").isZero();
-        assertMeter(taggedMetricRegistry, "cache.miss.count").isZero();
+        assertMeter(taggedMetricRegistry, "cache.hit")
+                .isEqualTo(cacheMetrics.hit("test").getCount())
+                .isZero();
+        assertMeter(taggedMetricRegistry, "cache.miss")
+                .isEqualTo(cacheMetrics.miss("test").getCount())
+                .isZero();
 
         assertThat(cache.get(0, mapping)).isEqualTo("0");
         assertThat(cache.get(1, mapping)).isEqualTo("1");
         assertThat(cache.get(2, mapping)).isEqualTo("2");
         assertThat(cache.get(1, mapping)).isEqualTo("1");
 
-        assertMeter(taggedMetricRegistry, "cache.hit.count").isOne();
-        assertMeter(taggedMetricRegistry, "cache.miss.count").isEqualTo(3);
-        assertThat(cacheMetrics.hitCount("test").getCount()).isOne();
-        assertThat(cacheMetrics.missCount("test").getCount()).isEqualTo(3);
-        cache.cleanUp();
+        assertMeter(taggedMetricRegistry, "cache.hit")
+                .isEqualTo(cacheMetrics.hit("test").getCount())
+                .isOne();
+        assertMeter(taggedMetricRegistry, "cache.miss")
+                .isEqualTo(cacheMetrics.miss("test").getCount())
+                .isEqualTo(3);
+
+        cache.cleanUp(); // force eviction processing
         assertThat(cacheMetrics.evictions().cache("test").cause("SIZE").build().getCount())
                 .asInstanceOf(InstanceOfAssertFactories.LONG)
                 .isOne();
@@ -274,31 +281,42 @@ final class CaffeineCacheStatsTest {
         assertThat(taggedMetricRegistry.getMetrics().keySet())
                 .extracting(MetricName::safeName)
                 .containsExactlyInAnyOrder(
-                        "cache.hit.count",
-                        "cache.miss.count",
-                        "cache.eviction.count",
+                        "cache.hit",
+                        "cache.miss",
+                        "cache.eviction",
                         "cache.evictions", // RemovalCause.EXPLICIT
                         "cache.evictions", // RemovalCause.REPLACED
                         "cache.evictions", // RemovalCause.COLLECTED
                         "cache.evictions", // RemovalCause.EXPIRED
                         "cache.evictions", // RemovalCause.SIZE
-                        "cache.load.success.count",
-                        "cache.load.failure.count");
+                        "cache.load", // success
+                        "cache.load" // failure
+                        );
 
-        assertMeter(taggedMetricRegistry, "cache.hit.count").isZero();
-        assertMeter(taggedMetricRegistry, "cache.miss.count").isZero();
+        CacheMetrics cacheMetrics = CacheMetrics.of(taggedMetricRegistry);
+        assertThat(cacheMetrics.evictions().cache("test").cause("SIZE").build().getCount())
+                .asInstanceOf(InstanceOfAssertFactories.LONG)
+                .isZero();
+        assertMeter(taggedMetricRegistry, "cache.hit")
+                .isEqualTo(cacheMetrics.hit("test").getCount())
+                .isZero();
+        assertMeter(taggedMetricRegistry, "cache.miss")
+                .isEqualTo(cacheMetrics.miss("test").getCount())
+                .isZero();
 
         assertThat(cache.get(0)).isEqualTo("0");
         assertThat(cache.get(1)).isEqualTo("1");
         assertThat(cache.get(2)).isEqualTo("2");
         assertThat(cache.get(1)).isEqualTo("1");
 
-        assertMeter(taggedMetricRegistry, "cache.hit.count").isOne();
-        assertMeter(taggedMetricRegistry, "cache.miss.count").isEqualTo(3);
-        CacheMetrics cacheMetrics = CacheMetrics.of(taggedMetricRegistry);
-        assertThat(cacheMetrics.hitCount("test").getCount()).isOne();
-        assertThat(cacheMetrics.missCount("test").getCount()).isEqualTo(3);
-        cache.cleanUp();
+        assertMeter(taggedMetricRegistry, "cache.hit")
+                .isEqualTo(cacheMetrics.hit("test").getCount())
+                .isOne();
+        assertMeter(taggedMetricRegistry, "cache.miss")
+                .isEqualTo(cacheMetrics.miss("test").getCount())
+                .isEqualTo(3);
+
+        cache.cleanUp(); // force eviction processing
         assertThat(cacheMetrics.evictions().cache("test").cause("SIZE").build().getCount())
                 .asInstanceOf(InstanceOfAssertFactories.LONG)
                 .isOne();

--- a/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStatsTest.java
+++ b/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStatsTest.java
@@ -23,7 +23,9 @@ import static org.awaitility.Awaitility.await;
 
 import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Counting;
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.github.benmanes.caffeine.cache.Cache;
@@ -238,16 +240,16 @@ final class CaffeineCacheStatsTest {
         assertThat(cacheMetrics.evictions().cache("test").cause("SIZE").build().getCount())
                 .asInstanceOf(InstanceOfAssertFactories.LONG)
                 .isZero();
-        assertCounter(taggedMetricRegistry, "cache.hit.count").isZero();
-        assertCounter(taggedMetricRegistry, "cache.miss.count").isZero();
+        assertMeter(taggedMetricRegistry, "cache.hit.count").isZero();
+        assertMeter(taggedMetricRegistry, "cache.miss.count").isZero();
 
         assertThat(cache.get(0, mapping)).isEqualTo("0");
         assertThat(cache.get(1, mapping)).isEqualTo("1");
         assertThat(cache.get(2, mapping)).isEqualTo("2");
         assertThat(cache.get(1, mapping)).isEqualTo("1");
 
-        assertCounter(taggedMetricRegistry, "cache.hit.count").isOne();
-        assertCounter(taggedMetricRegistry, "cache.miss.count").isEqualTo(3);
+        assertMeter(taggedMetricRegistry, "cache.hit.count").isOne();
+        assertMeter(taggedMetricRegistry, "cache.miss.count").isEqualTo(3);
         assertThat(cacheMetrics.hitCount("test").getCount()).isOne();
         assertThat(cacheMetrics.missCount("test").getCount()).isEqualTo(3);
         cache.cleanUp();
@@ -283,16 +285,16 @@ final class CaffeineCacheStatsTest {
                         "cache.load.success.count",
                         "cache.load.failure.count");
 
-        assertCounter(taggedMetricRegistry, "cache.hit.count").isZero();
-        assertCounter(taggedMetricRegistry, "cache.miss.count").isZero();
+        assertMeter(taggedMetricRegistry, "cache.hit.count").isZero();
+        assertMeter(taggedMetricRegistry, "cache.miss.count").isZero();
 
         assertThat(cache.get(0)).isEqualTo("0");
         assertThat(cache.get(1)).isEqualTo("1");
         assertThat(cache.get(2)).isEqualTo("2");
         assertThat(cache.get(1)).isEqualTo("1");
 
-        assertCounter(taggedMetricRegistry, "cache.hit.count").isOne();
-        assertCounter(taggedMetricRegistry, "cache.miss.count").isEqualTo(3);
+        assertMeter(taggedMetricRegistry, "cache.hit.count").isOne();
+        assertMeter(taggedMetricRegistry, "cache.miss.count").isEqualTo(3);
         CacheMetrics cacheMetrics = CacheMetrics.of(taggedMetricRegistry);
         assertThat(cacheMetrics.hitCount("test").getCount()).isOne();
         assertThat(cacheMetrics.missCount("test").getCount()).isEqualTo(3);
@@ -313,9 +315,9 @@ final class CaffeineCacheStatsTest {
         return assertMetric(taggedMetricRegistry, Gauge.class, name).extracting(Gauge::getValue);
     }
 
-    static AbstractLongAssert<?> assertCounter(TaggedMetricRegistry taggedMetricRegistry, String name) {
-        return assertMetric(taggedMetricRegistry, Counter.class, name)
-                .extracting(Counter::getCount)
+    static AbstractLongAssert<?> assertMeter(TaggedMetricRegistry taggedMetricRegistry, String name) {
+        return assertMetric(taggedMetricRegistry, Meter.class, name)
+                .extracting(Counting::getCount)
                 .asInstanceOf(InstanceOfAssertFactories.LONG);
     }
 

--- a/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStatsTest.java
+++ b/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStatsTest.java
@@ -31,7 +31,6 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimaps;
-import com.palantir.tritium.metrics.cache.CacheMetrics;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -216,9 +215,8 @@ final class CaffeineCacheStatsTest {
 
     @Test
     void registerTaggedMetrics() {
-        CacheMetrics cacheMetrics = CacheMetrics.of(taggedMetricRegistry);
         Cache<Integer, String> cache = Caffeine.newBuilder()
-                .recordStats(CacheStats.of(cacheMetrics, "test"))
+                .recordStats(CacheStats.of(taggedMetricRegistry, "test"))
                 .maximumSize(2)
                 .build();
         assertThat(taggedMetricRegistry.getMetrics().keySet())
@@ -235,6 +233,7 @@ final class CaffeineCacheStatsTest {
                         "cache.load.success.count",
                         "cache.load.failure.count");
 
+        CacheMetrics cacheMetrics = CacheMetrics.of(taggedMetricRegistry);
         assertThat(cacheMetrics.hitCount("test").getCount()).isZero();
         assertThat(cacheMetrics.evictions().cache("test").cause("SIZE").build().getCount())
                 .asInstanceOf(InstanceOfAssertFactories.LONG)
@@ -265,9 +264,8 @@ final class CaffeineCacheStatsTest {
 
     @Test
     void registerLoadingTaggedMetrics() {
-        CacheMetrics cacheMetrics = CacheMetrics.of(taggedMetricRegistry);
         LoadingCache<Integer, String> cache = Caffeine.newBuilder()
-                .recordStats(CacheStats.of(cacheMetrics, "test"))
+                .recordStats(CacheStats.of(taggedMetricRegistry, "test"))
                 .maximumSize(2)
                 .build(mapping::apply);
         assertThat(taggedMetricRegistry.getMetrics().keySet())
@@ -294,6 +292,7 @@ final class CaffeineCacheStatsTest {
 
         assertCounter(taggedMetricRegistry, "cache.hit.count").isOne();
         assertCounter(taggedMetricRegistry, "cache.miss.count").isEqualTo(3);
+        CacheMetrics cacheMetrics = CacheMetrics.of(taggedMetricRegistry);
         assertThat(cacheMetrics.hitCount("test").getCount()).isOne();
         assertThat(cacheMetrics.missCount("test").getCount()).isEqualTo(3);
         assertThat(cacheMetrics.evictions().cache("test").cause("SIZE").build().getCount())

--- a/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStatsTest.java
+++ b/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStatsTest.java
@@ -250,6 +250,7 @@ final class CaffeineCacheStatsTest {
         assertCounter(taggedMetricRegistry, "cache.miss.count").isEqualTo(3);
         assertThat(cacheMetrics.hitCount("test").getCount()).isOne();
         assertThat(cacheMetrics.missCount("test").getCount()).isEqualTo(3);
+        cache.cleanUp();
         assertThat(cacheMetrics.evictions().cache("test").cause("SIZE").build().getCount())
                 .asInstanceOf(InstanceOfAssertFactories.LONG)
                 .isOne();
@@ -295,6 +296,7 @@ final class CaffeineCacheStatsTest {
         CacheMetrics cacheMetrics = CacheMetrics.of(taggedMetricRegistry);
         assertThat(cacheMetrics.hitCount("test").getCount()).isOne();
         assertThat(cacheMetrics.missCount("test").getCount()).isEqualTo(3);
+        cache.cleanUp();
         assertThat(cacheMetrics.evictions().cache("test").cause("SIZE").build().getCount())
                 .asInstanceOf(InstanceOfAssertFactories.LONG)
                 .isOne();

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/MetricRegistries.java
@@ -270,7 +270,10 @@ public final class MetricRegistries {
      * @param cache cache to instrument
      * @param name cache name
      * @throws IllegalArgumentException if name is blank
+     * @deprecated Do not use Guava caches, they are outperformed by and harder to use than Caffeine caches.
+     * Prefer {@link Caffeine#recordStats(Supplier)} and {@link CacheStats#of(TaggedMetricRegistry, String)}.
      */
+    @Deprecated // BanGuavaCaches
     @SuppressWarnings("BanGuavaCaches") // this implementation is explicitly for Guava caches
     public static void registerCache(TaggedMetricRegistry registry, Cache<?, ?> cache, @Safe String name) {
         checkNotNull(registry, "metric registry");

--- a/tritium-metrics/src/main/metrics/cache-metrics.yml
+++ b/tritium-metrics/src/main/metrics/cache-metrics.yml
@@ -1,0 +1,66 @@
+options:
+  javaPackage: com.palantir.tritium.metrics.cache
+  javaVisibility: public
+namespaces:
+  cache:
+    docs: Cache statistic metrics
+    metrics:
+      estimated.size:
+        type: gauge
+        tags: [cache]
+        docs: Approximate number of entries in this cache
+      weighted.size:
+        type: gauge
+        tags: [cache]
+        docs: Approximate accumulated weight of entries in this cache
+      maximum.size:
+        type: gauge
+        tags: [cache]
+        docs: Maximum number of cache entries cache can hold if limited, otherwise -1
+      request.count:
+        type: gauge
+        tags: [cache]
+        docs: Count of cache requests
+      hit.count:
+        type: counter
+        tags: [cache]
+        docs: Count of cache hits
+      hit.ratio:
+        type: gauge
+        tags: [cache]
+        docs: Percentage of cache hits
+      miss.count:
+        type: counter
+        tags: [cache]
+        docs: Count of cache misses
+      miss.ratio:
+        type: gauge
+        tags: [cache]
+        docs: Percentage of cache misses
+      load.success.count:
+        type: counter
+        tags: [cache]
+        docs: Count of successful cache loads
+      load.failure.count:
+        type: counter
+        tags: [cache]
+        docs: Count of failed cache loads
+      load.average.millis:
+        type: gauge
+        tags: [cache]
+        docs: Average duration of cache load in milliseconds
+      evictions:
+        type: counter
+        tags: [cache, cause]
+        docs: Count of evicted entries by cause
+      eviction.count:
+        type: counter
+        tags: [cache]
+        docs: Total count of evicted entries
+      stats.disabled:
+        type: counter
+        tags: [cache]
+        docs: |
+          Registered cache does not have stats recording enabled, stats will always be zero.
+          To enable cache metrics, stats recording must be enabled when constructing the cache:
+          Caffeine.newBuilder().recordStats()

--- a/tritium-metrics/src/main/metrics/cache-metrics.yml
+++ b/tritium-metrics/src/main/metrics/cache-metrics.yml
@@ -5,38 +5,14 @@ namespaces:
   cache:
     docs: Cache statistic metrics
     metrics:
-      estimated.size:
-        type: gauge
-        tags: [cache]
-        docs: Approximate number of entries in this cache
-      weighted.size:
-        type: gauge
-        tags: [cache]
-        docs: Approximate accumulated weight of entries in this cache
-      maximum.size:
-        type: gauge
-        tags: [cache]
-        docs: Maximum number of cache entries cache can hold if limited, otherwise -1
-      request.count:
-        type: gauge
-        tags: [cache]
-        docs: Count of cache requests
       hit.count:
         type: counter
         tags: [cache]
         docs: Count of cache hits
-      hit.ratio:
-        type: gauge
-        tags: [cache]
-        docs: Percentage of cache hits
       miss.count:
         type: counter
         tags: [cache]
         docs: Count of cache misses
-      miss.ratio:
-        type: gauge
-        tags: [cache]
-        docs: Percentage of cache misses
       load.success.count:
         type: counter
         tags: [cache]
@@ -45,10 +21,6 @@ namespaces:
         type: counter
         tags: [cache]
         docs: Count of failed cache loads
-      load.average.millis:
-        type: gauge
-        tags: [cache]
-        docs: Average duration of cache load in milliseconds
       evictions:
         type: counter
         tags: [cache, cause]

--- a/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
+++ b/tritium-metrics/src/test/java/com/palantir/tritium/metrics/MetricRegistriesTest.java
@@ -289,6 +289,7 @@ final class MetricRegistriesTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation") // testing deprecated cache registration
     void registerCacheTaggedMetrics() throws ExecutionException {
         MetricRegistries.registerCache(taggedMetricRegistry, cache, "test");
         assertThat(taggedMetricRegistry.getMetrics().keySet())


### PR DESCRIPTION
## Before this PR

Begin to address https://github.com/palantir/tritium/issues/1895

Supersedes https://github.com/palantir/tritium/pull/1075

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Initial Caffeine CacheStats recorder

Example usage:
```
TaggedMetricRegistry taggedMetricRegistry = ...
Cache<Integer, String> cache = Caffeine.newBuilder()
        .recordStats(CacheStats.of(taggedMetricRegistry, "unique-cache-name"))
        .build();

LoadingCache<String, Integer> loadingCache = Caffeine.newBuilder()
        .recordStats(CacheStats.of(taggedMetricRegistry, "unique-loading-cache-name"))
        .build(key::length);
```

==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

