### PR TITLE
Fix ErrorProne configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ allprojects {
             options.errorprone {
                 option('NullAway:AnnotatedPackages', 'com.palantir,com.google.common')
                 option('NullAway:CheckOptionalEmptiness', 'true')
-                option('AllSuggestionsAsWarnings') // https://github.com/google/error-prone/pull/3301
 
                 // warnings not explicitly provided by error-prone
                 error 'NullAway',
@@ -86,6 +85,10 @@ allprojects {
                         'StaticOrDefaultInterfaceMethod', // Android specific
                         'Var', // high noise, low signal
                         'Varifier' // don't `var`ify everything yet as this conflicts with baseline VarUsage
+
+                errorproneArgs = [
+                    '-XepAllSuggestionsAsWarnings',
+                ]
             }
         }
     })


### PR DESCRIPTION
The current config will result in the command line argument `-XepOpt:AllSuggestionsAsWarnings=true`. But we want `-XepAllSuggestionsAsWarnings`.

https://github.com/tbroyer/gradle-errorprone-plugin/blob/5d9e2a80d37fcdb393ff694f1b02e31f044f17e9/src/main/kotlin/net/ltgt/gradle/errorprone/ErrorProneOptions.kt#L242-L245