### PR TITLE
Add cache size metrics to CacheStats

### DIFF
--- a/changelog/@unreleased/pr-1919.v2.yml
+++ b/changelog/@unreleased/pr-1919.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add cache size metrics to `CacheStats`.
+  links:
+  - https://github.com/palantir/tritium/pull/1919

--- a/tritium-caffeine/src/main/metrics/cache-metrics.yml
+++ b/tritium-caffeine/src/main/metrics/cache-metrics.yml
@@ -20,14 +20,14 @@ namespaces:
           - name: result
             values: [success, failure]
         docs: Count of successful cache loads
-      evictions:
-        type: meter
-        tags: [cache, cause]
-        docs: Count of evicted entries by cause
       eviction:
         type: meter
-        tags: [cache]
-        docs: Total count of evicted entries
+        tags: [cache, cause]
+        docs: Count of evicted entries
+      eviction.weight:
+        type: meter
+        tags: [cache, cause]
+        docs: Count of evicted weights
       stats.disabled:
         type: meter
         tags: [cache]
@@ -35,3 +35,15 @@ namespaces:
           Registered cache does not have stats recording enabled, stats will always be zero.
           To enable cache metrics, stats recording must be enabled when constructing the cache:
           Caffeine.newBuilder().recordStats()
+      estimated.size:
+        type: gauge
+        tags: [cache]
+        docs: Approximate number of entries in this cache
+      weighted.size:
+        type: gauge
+        tags: [cache]
+        docs: Approximate accumulated weight of entries in this cache
+      maximum.size:
+        type: gauge
+        tags: [cache]
+        docs: Maximum number of cache entries cache can hold if limited, otherwise -1

--- a/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStatsTest.java
+++ b/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/CaffeineCacheStatsTest.java
@@ -217,28 +217,34 @@ final class CaffeineCacheStatsTest {
 
     @Test
     void registerTaggedMetrics() {
-        Cache<Integer, String> cache = Caffeine.newBuilder()
-                .recordStats(CacheStats.of(taggedMetricRegistry, "test"))
-                .maximumSize(2)
-                .build();
+        CacheStats cacheStats = CacheStats.of(taggedMetricRegistry, "test");
+        Cache<Integer, String> cache =
+                Caffeine.newBuilder().recordStats(cacheStats).maximumSize(2).build();
+        cacheStats.register(cache);
+
         assertThat(taggedMetricRegistry.getMetrics().keySet())
                 .extracting(MetricName::safeName)
                 .containsExactlyInAnyOrder(
                         "cache.hit",
                         "cache.miss",
-                        "cache.eviction",
-                        "cache.evictions", // RemovalCause.EXPLICIT
-                        "cache.evictions", // RemovalCause.REPLACED
-                        "cache.evictions", // RemovalCause.COLLECTED
-                        "cache.evictions", // RemovalCause.EXPIRED
-                        "cache.evictions", // RemovalCause.SIZE
+                        "cache.eviction", // RemovalCause.EXPLICIT
+                        "cache.eviction", // RemovalCause.REPLACED
+                        "cache.eviction", // RemovalCause.COLLECTED
+                        "cache.eviction", // RemovalCause.EXPIRED
+                        "cache.eviction", // RemovalCause.SIZE
+                        "cache.eviction.weight", // RemovalCause.EXPLICIT
+                        "cache.eviction.weight", // RemovalCause.REPLACED
+                        "cache.eviction.weight", // RemovalCause.COLLECTED
+                        "cache.eviction.weight", // RemovalCause.EXPIRED
+                        "cache.eviction.weight", // RemovalCause.SIZE
                         "cache.load", // success
-                        "cache.load" // failure
-                        );
+                        "cache.load", // failure
+                        "cache.estimated.size",
+                        "cache.weighted.size",
+                        "cache.maximum.size");
 
         CacheMetrics cacheMetrics = CacheMetrics.of(taggedMetricRegistry);
-        assertThat(cacheMetrics.evictions().cache("test").cause("SIZE").build().getCount())
-                .asInstanceOf(InstanceOfAssertFactories.LONG)
+        assertThat(cacheMetrics.eviction().cache("test").cause("SIZE").build().getCount())
                 .isZero();
         assertMeter(taggedMetricRegistry, "cache.hit")
                 .isEqualTo(cacheMetrics.hit("test").getCount())
@@ -260,8 +266,7 @@ final class CaffeineCacheStatsTest {
                 .isEqualTo(3);
 
         cache.cleanUp(); // force eviction processing
-        assertThat(cacheMetrics.evictions().cache("test").cause("SIZE").build().getCount())
-                .asInstanceOf(InstanceOfAssertFactories.LONG)
+        assertThat(cacheMetrics.eviction().cache("test").cause("SIZE").build().getCount())
                 .isOne();
 
         assertThat(taggedMetricRegistry.getMetrics())
@@ -274,28 +279,33 @@ final class CaffeineCacheStatsTest {
 
     @Test
     void registerLoadingTaggedMetrics() {
-        LoadingCache<Integer, String> cache = Caffeine.newBuilder()
-                .recordStats(CacheStats.of(taggedMetricRegistry, "test"))
-                .maximumSize(2)
-                .build(mapping::apply);
+        CacheStats cacheStats = CacheStats.of(taggedMetricRegistry, "test");
+        LoadingCache<Integer, String> cache =
+                Caffeine.newBuilder().recordStats(cacheStats).maximumSize(2).build(mapping::apply);
+        cacheStats.register(cache);
         assertThat(taggedMetricRegistry.getMetrics().keySet())
                 .extracting(MetricName::safeName)
                 .containsExactlyInAnyOrder(
                         "cache.hit",
                         "cache.miss",
-                        "cache.eviction",
-                        "cache.evictions", // RemovalCause.EXPLICIT
-                        "cache.evictions", // RemovalCause.REPLACED
-                        "cache.evictions", // RemovalCause.COLLECTED
-                        "cache.evictions", // RemovalCause.EXPIRED
-                        "cache.evictions", // RemovalCause.SIZE
+                        "cache.eviction", // RemovalCause.EXPLICIT
+                        "cache.eviction", // RemovalCause.REPLACED
+                        "cache.eviction", // RemovalCause.COLLECTED
+                        "cache.eviction", // RemovalCause.EXPIRED
+                        "cache.eviction", // RemovalCause.SIZE
+                        "cache.eviction.weight", // RemovalCause.EXPLICIT
+                        "cache.eviction.weight", // RemovalCause.REPLACED
+                        "cache.eviction.weight", // RemovalCause.COLLECTED
+                        "cache.eviction.weight", // RemovalCause.EXPIRED
+                        "cache.eviction.weight", // RemovalCause.SIZE
                         "cache.load", // success
-                        "cache.load" // failure
-                        );
+                        "cache.load", // failure
+                        "cache.estimated.size",
+                        "cache.weighted.size",
+                        "cache.maximum.size");
 
         CacheMetrics cacheMetrics = CacheMetrics.of(taggedMetricRegistry);
-        assertThat(cacheMetrics.evictions().cache("test").cause("SIZE").build().getCount())
-                .asInstanceOf(InstanceOfAssertFactories.LONG)
+        assertThat(cacheMetrics.eviction().cache("test").cause("SIZE").build().getCount())
                 .isZero();
         assertMeter(taggedMetricRegistry, "cache.hit")
                 .isEqualTo(cacheMetrics.hit("test").getCount())
@@ -317,8 +327,7 @@ final class CaffeineCacheStatsTest {
                 .isEqualTo(3);
 
         cache.cleanUp(); // force eviction processing
-        assertThat(cacheMetrics.evictions().cache("test").cause("SIZE").build().getCount())
-                .asInstanceOf(InstanceOfAssertFactories.LONG)
+        assertThat(cacheMetrics.eviction().cache("test").cause("SIZE").build().getCount())
                 .isOne();
 
         assertThat(taggedMetricRegistry.getMetrics())


### PR DESCRIPTION
Follow up from https://github.com/palantir/tritium/pull/1897.

This PR provides a mechanism to register metrics that record the following information:
- Estimated size
- Weighted size
- Maximum size

These measurements are equivalent to those recorded by `CaffeineCacheStats.registerCache`.

I intentionally did not add `request`, `hit.ratio`, and `miss.ratio` metrics. Those values can be derived from the existing meters. This is better than creating gauges because:
- It reduces the number of metrics we create
- It works when there are multiple caches with the same name 