### PR TITLE
Combine hit and miss cache metrics into single tagged metric

### DIFF
--- a/changelog/@unreleased/pr-1921.v2.yml
+++ b/changelog/@unreleased/pr-1921.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The `cache.hit` and `cache.miss` metrics have been combined into a
+    single `cache.request` metric tagged by `result`.
+  links:
+  - https://github.com/palantir/tritium/pull/1921

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.palantir.logsafe.Safe;
 import com.palantir.tritium.metrics.caffeine.CacheMetrics.Load_Result;
+import com.palantir.tritium.metrics.caffeine.CacheMetrics.Request_Result;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -109,8 +110,9 @@ public final class CacheStats implements StatsCounter, Supplier<StatsCounter> {
     private CacheStats(CacheMetrics metrics, @Safe String name) {
         this.metrics = metrics;
         this.name = name;
-        this.hitMeter = metrics.hit(name);
-        this.missMeter = metrics.miss(name);
+        this.hitMeter = metrics.request().cache(name).result(Request_Result.HIT).build();
+        this.missMeter =
+                metrics.request().cache(name).result(Request_Result.MISS).build();
         this.loadSuccessTimer =
                 metrics.load().cache(name).result(Load_Result.SUCCESS).build();
         this.loadFailureTimer =

--- a/tritium-caffeine/src/main/metrics/cache.yml
+++ b/tritium-caffeine/src/main/metrics/cache.yml
@@ -5,14 +5,13 @@ namespaces:
   cache:
     docs: Cache statistic metrics
     metrics:
-      hit:
+      request:
         type: meter
-        tags: [cache]
-        docs: Count of cache hits
-      miss:
-        type: meter
-        tags: [cache]
-        docs: Count of cache misses
+        tags:
+          - name: cache
+          - name: result
+            values: [hit, miss]
+        docs: Count of cache requests
       load:
         type: timer
         tags:
@@ -28,13 +27,6 @@ namespaces:
         type: meter
         tags: [cache, cause]
         docs: Count of evicted weights
-      stats.disabled:
-        type: meter
-        tags: [cache]
-        docs: |
-          Registered cache does not have stats recording enabled, stats will always be zero.
-          To enable cache metrics, stats recording must be enabled when constructing the cache:
-          Caffeine.newBuilder().recordStats()
       estimated.size:
         type: gauge
         tags: [cache]


### PR DESCRIPTION
We already broke the `cache.hit` and `cache.miss` metrics when we changed them to meters in https://github.com/palantir/tritium/pull/1897. We can take this opportunity to improve these metrics by combining them into a single `cache.request` metric tagged by `result`.

This makes it easier for consumers to make queries for things like the total number of requests or the hit rate, without having to know/assume that "requests = hits + misses".