### PR TITLE
Propagate @SuppressWarnings on @Instrument types

### DIFF
--- a/changelog/@unreleased/pr-1976.v2.yml
+++ b/changelog/@unreleased/pr-1976.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Propagate @SuppressWarnings on @Instrument types
+  links:
+  - https://github.com/palantir/tritium/pull/1976

--- a/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessorStrategy.java
+++ b/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessorStrategy.java
@@ -27,6 +27,7 @@ import com.palantir.tritium.event.Handlers;
 import com.palantir.tritium.event.InvocationContext;
 import com.palantir.tritium.event.InvocationEventHandler;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
@@ -188,11 +189,17 @@ enum TritiumAnnotationProcessorStrategy implements DelegateProcessorStrategy {
 
     @Override
     public void customize(CustomizeArguments arguments, TypeSpec.Builder generatedType) {
-        if (isDeprecated(arguments.type().type())) {
+        TypeElement type = arguments.type().type();
+        if (isDeprecated(type)) {
             generatedType.addAnnotation(Deprecated.class);
         }
 
-        TypeName annotatedTypeName = TypeName.get(arguments.type().type().asType());
+        SuppressWarnings suppressWarnings = type.getAnnotation(SuppressWarnings.class);
+        if (suppressWarnings != null) {
+            generatedType.addAnnotation(AnnotationSpec.get(suppressWarnings));
+        }
+
+        TypeName annotatedTypeName = TypeName.get(type.asType());
         List<AnnotatedTypeMethod> instrumentedMethods = instrumentedMethods(arguments.type());
 
         if (!instrumentedMethods.isEmpty()) {

--- a/tritium-processor/src/test/java/com/palantir/tritium/examples/DeprecatedType.java
+++ b/tritium-processor/src/test/java/com/palantir/tritium/examples/DeprecatedType.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.examples;
+
+import com.palantir.tritium.annotations.Instrument;
+
+@Instrument
+@SuppressWarnings("deprecation")
+public interface DeprecatedType {
+
+    Foo foo();
+
+    @Deprecated
+    interface Foo {
+        String bar();
+    }
+}

--- a/tritium-processor/src/test/java/com/palantir/tritium/processor/TritiumProcessorTest.java
+++ b/tritium-processor/src/test/java/com/palantir/tritium/processor/TritiumProcessorTest.java
@@ -34,6 +34,7 @@ import com.palantir.tritium.examples.DelegateToCallableMethod;
 import com.palantir.tritium.examples.DelegateToRunnable;
 import com.palantir.tritium.examples.DelegateToRunnableMethod;
 import com.palantir.tritium.examples.DeprecatedMethod;
+import com.palantir.tritium.examples.DeprecatedType;
 import com.palantir.tritium.examples.Empty;
 import com.palantir.tritium.examples.HasDefaultMethod;
 import com.palantir.tritium.examples.HasToString;
@@ -112,6 +113,11 @@ public final class TritiumProcessorTest {
     @SuppressWarnings({"deprecation", "UnnecessarilyFullyQualified"}) // testing deprecation linting
     public void testDeprecatedInterface() {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, com.palantir.tritium.examples.DeprecatedInterface.class);
+    }
+
+    @Test
+    public void testDeprecatedType() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, DeprecatedType.class);
     }
 
     @Test

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedDeprecatedType.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedDeprecatedType.java.generated
@@ -1,0 +1,71 @@
+package com.palantir.tritium.examples;
+
+import com.palantir.tritium.annotations.internal.InstrumentationBuilder;
+import com.palantir.tritium.api.event.InstrumentationFilter;
+import com.palantir.tritium.event.Handlers;
+import com.palantir.tritium.event.InvocationContext;
+import com.palantir.tritium.event.InvocationEventHandler;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.tritium.processor.TritiumAnnotationProcessor")
+@SuppressWarnings("deprecation")
+public final class InstrumentedDeprecatedType implements DeprecatedType {
+    private static final Method FOO_ed3d1cab;
+
+    static {
+        try {
+            FOO_ed3d1cab = DeprecatedType.class.getMethod("foo");
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private final DeprecatedType delegate;
+
+    private final InvocationEventHandler<InvocationContext> handler;
+
+    private final InstrumentationFilter filter;
+
+    private InstrumentedDeprecatedType(
+            DeprecatedType delegate, InvocationEventHandler<InvocationContext> handler, InstrumentationFilter filter) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.handler = Objects.requireNonNull(handler, "handler");
+        this.filter = Objects.requireNonNull(filter, "filter");
+    }
+
+    @Override
+    public DeprecatedType.Foo foo() {
+        InvocationContext _invocationContext = this.handler.isEnabled()
+                ? Handlers.pre(this.handler, this.filter, this, FOO_ed3d1cab, new Object[] {})
+                : Handlers.disabled();
+        try {
+            DeprecatedType.Foo _result = this.delegate.foo();
+            Handlers.onSuccess(this.handler, _invocationContext, _result);
+            return _result;
+        } catch (Throwable _throwable) {
+            Handlers.onFailure(this.handler, _invocationContext, _throwable);
+            throw _throwable;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "InstrumentedDeprecatedType{" + this.delegate + "}";
+    }
+
+    public static InstrumentationBuilder<DeprecatedType, DeprecatedType> builder(DeprecatedType delegate) {
+        return new InstrumentationBuilder<DeprecatedType, DeprecatedType>(
+                DeprecatedType.class, delegate, InstrumentedDeprecatedType::new);
+    }
+
+    public static DeprecatedType trace(DeprecatedType delegate) {
+        return InstrumentationBuilder.trace(DeprecatedType.class, delegate, InstrumentedDeprecatedType::new);
+    }
+
+    public static DeprecatedType instrument(DeprecatedType delegate, TaggedMetricRegistry registry) {
+        return builder(delegate).withTaggedMetrics(registry).withTracing().build();
+    }
+}


### PR DESCRIPTION
## Before this PR

If the interface that one `@Instrument` references a deprecated type the generated code will not compile if deprecation warnings are enabled, even if one adds `@SuppressWarnings("deprecation")` to the `@Instrument`ed type:

```
@Instrument
@SuppressWarnings("deprecation")
public interface DeprecatedType {
    Foo foo();
    @Deprecated
    interface Foo {
        String bar();
    }
}
```


```
TritiumProcessorTest > testDeprecatedType() FAILED
    Compilation produced the following diagnostics:
    /SOURCE_OUTPUT/com/palantir/tritium/examples/InstrumentedDeprecatedType.java:39: warning: [deprecation] com.palantir.tritium.examples.DeprecatedType.Foo in com.palantir.tritium.examples.DeprecatedType has been deprecated
        public DeprecatedType.Foo foo() {
                             ^
    /SOURCE_OUTPUT/com/palantir/tritium/examples/InstrumentedDeprecatedType.java:39: warning: [deprecation] com.palantir.tritium.examples.DeprecatedType.Foo in com.palantir.tritium.examples.DeprecatedType has been deprecated
        public DeprecatedType.Foo foo() {
                             ^
    /SOURCE_OUTPUT/com/palantir/tritium/examples/InstrumentedDeprecatedType.java:39: warning: [deprecation] com.palantir.tritium.examples.DeprecatedType.Foo in com.palantir.tritium.examples.DeprecatedType has been deprecated
        public DeprecatedType.Foo foo() {
                             ^
    /SOURCE_OUTPUT/com/palantir/tritium/examples/InstrumentedDeprecatedType.java:44: warning: [deprecation] com.palantir.tritium.examples.DeprecatedType.Foo in com.palantir.tritium.examples.DeprecatedType has been deprecated
                DeprecatedType.Foo _result = this.delegate.foo();
                              ^
    error: warnings found and -Werror specified
    Generated Source Files
    ======================

    /SOURCE_OUTPUT/com/palantir/tritium/examples/InstrumentedDeprecatedType.java:
    package com.palantir.tritium.examples;

    import com.palantir.tritium.annotations.internal.InstrumentationBuilder;
    import com.palantir.tritium.api.event.InstrumentationFilter;
    import com.palantir.tritium.event.Handlers;
    import com.palantir.tritium.event.InvocationContext;
    import com.palantir.tritium.event.InvocationEventHandler;
    import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
    import java.lang.reflect.Method;
    import java.util.Objects;
    import javax.annotation.processing.Generated;

    @Generated("com.palantir.tritium.processor.TritiumAnnotationProcessor")
    public final class InstrumentedDeprecatedType implements DeprecatedType {
        private static final Method FOO_ed3d1cab;

        static {
            try {
                FOO_ed3d1cab = DeprecatedType.class.getMethod("foo");
            } catch (NoSuchMethodException e) {
                throw new RuntimeException(e);
            }
        }

        private final DeprecatedType delegate;

        private final InvocationEventHandler<InvocationContext> handler;

        private final InstrumentationFilter filter;

        private InstrumentedDeprecatedType(
                DeprecatedType delegate, InvocationEventHandler<InvocationContext> handler, InstrumentationFilter filter) {
            this.delegate = Objects.requireNonNull(delegate, "delegate");
            this.handler = Objects.requireNonNull(handler, "handler");
            this.filter = Objects.requireNonNull(filter, "filter");
        }

        @Override
        public DeprecatedType.Foo foo() {
            InvocationContext _invocationContext = this.handler.isEnabled()
                    ? Handlers.pre(this.handler, this.filter, this, FOO_ed3d1cab, new Object[] {})
                    : Handlers.disabled();
            try {
                DeprecatedType.Foo _result = this.delegate.foo();
                Handlers.onSuccess(this.handler, _invocationContext, _result);
                return _result;
            } catch (Throwable _throwable) {
                Handlers.onFailure(this.handler, _invocationContext, _throwable);
                throw _throwable;
            }
        }

        @Override
        public String toString() {
            return "InstrumentedDeprecatedType{" + this.delegate + "}";
        }

        public static InstrumentationBuilder<DeprecatedType, DeprecatedType> builder(DeprecatedType delegate) {
            return new InstrumentationBuilder<DeprecatedType, DeprecatedType>(
                    DeprecatedType.class, delegate, InstrumentedDeprecatedType::new);
        }

        public static DeprecatedType trace(DeprecatedType delegate) {
            return InstrumentationBuilder.trace(DeprecatedType.class, delegate, InstrumentedDeprecatedType::new);
        }

        public static DeprecatedType instrument(DeprecatedType delegate, TaggedMetricRegistry registry) {
            return builder(delegate).withTaggedMetrics(registry).withTracing().build();
        }
    }
        at app//com.palantir.tritium.processor.TritiumProcessorTest.assertTestFileCompileAndMatches(TritiumProcessorTest.java:157)
        at app//com.palantir.tritium.processor.TritiumProcessorTest.testDeprecatedType(TritiumProcessorTest.java:120)

20 tests completed, 1 failed
```


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Propagate @SuppressWarnings on @Instrument types
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

