### PR TITLE
The `cache.stats.disabled` metric is listed in metric-schema

### DIFF
--- a/changelog/@unreleased/pr-2005.v2.yml
+++ b/changelog/@unreleased/pr-2005.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The `cache.stats.disabled` metric is listed in metric-schema
+  links:
+  - https://github.com/palantir/tritium/pull/2005

--- a/tritium-caffeine/src/main/metrics/cache.yml
+++ b/tritium-caffeine/src/main/metrics/cache.yml
@@ -39,3 +39,7 @@ namespaces:
         type: gauge
         tags: [cache]
         docs: Maximum number of cache entries cache can hold if limited
+      stats.disabled:
+        type: meter
+        tags: [cache]
+        docs: Meter marked when `CaffeineCacheStats.registerCache` is called on a cache that does not record stats using `caffeineBuilder.recordStats()`.


### PR DESCRIPTION
This commit changes the type from counter to meter -- the recorded result should be the same, however meters can be elided when their value is zero because they cannot decrease, slightly reducing load on our indexing system.
In practice we only created the counters as needed, so this shouldn't change things in practice, but it will retain that safety even if refactored to create the metric object eagerly.

==COMMIT_MSG==
The `cache.stats.disabled` metric is listed in metric-schema
==COMMIT_MSG==

