### PR TITLE
Use metric-schema to report JVM Buffer Pool metrics

### DIFF
--- a/changelog/@unreleased/pr-2018.v2.yml
+++ b/changelog/@unreleased/pr-2018.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use metric-schema to report JVM Buffer Pool metrics
+  links:
+  - https://github.com/palantir/tritium/pull/2018

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -219,11 +219,11 @@ public final class JvmMetrics {
         JvmBuffersMetrics jvmBuffersMetrics = JvmBuffersMetrics.of(registry);
         for (BufferPoolMXBean pool : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)) {
             String poolName = pool.getName();
-            if (poolName.equals("direct")) {
+            if ("direct".equals(poolName)) {
                 jvmBuffersMetrics.directCount(nonNegative(pool::getCount));
                 jvmBuffersMetrics.directUsed(nonNegative(pool::getMemoryUsed));
                 jvmBuffersMetrics.directCapacity(nonNegative(pool::getTotalCapacity));
-            } else if (poolName.equals("mapped")) {
+            } else if ("mapped".equals(poolName)) {
                 jvmBuffersMetrics.mappedCount(nonNegative(pool::getCount));
                 jvmBuffersMetrics.mappedUsed(nonNegative(pool::getMemoryUsed));
                 jvmBuffersMetrics.mappedCapacity(nonNegative(pool::getTotalCapacity));

--- a/tritium-metrics-jvm/src/main/metrics/metrics.yml
+++ b/tritium-metrics-jvm/src/main/metrics/metrics.yml
@@ -148,3 +148,24 @@ namespaces:
       non-heap.usage:
         type: gauge
         docs: Ratio of `jvm.memory.non-heap.used` to `jvm.memory.non-heap.max`.
+  jvm.buffers:
+    docs: Java virtual machine buffer pool metrics.
+    metrics:
+      direct.count:
+        type: gauge
+        docs: Number of buffers in the direct buffer pool.
+      direct.used:
+        type: gauge
+        docs: Total memory used by the direct buffer pool.
+      direct.capacity:
+        type: gauge
+        docs: Total capacity of the direct buffer pool.
+      mapped.count:
+        type: gauge
+        docs: Number of buffers in the mapped buffer pool.
+      mapped.used:
+        type: gauge
+        docs: Total memory used by the mapped buffer pool.
+      mapped.capacity:
+        type: gauge
+        docs: Total capacity of the mapped buffer pool.


### PR DESCRIPTION
## Before this PR
We weren't using [metric-schema](https://github.com/palantir/metric-schema) when registering the JVM Buffer Pool metrics. Using metric-schema gives us some nice tooling, like markdown file generation allowing devs to find all published metrics easily.

## After this PR
==COMMIT_MSG==
Use metric-schema to report JVM Buffer Pool metrics
==COMMIT_MSG==

## Possible downsides?
N/A
