### PR TITLE
Optimize WeightedSnapshotWithExemplars

### DIFF
--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoirWithExemplars.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoirWithExemplars.java
@@ -229,7 +229,8 @@ public final class LockFreeExponentiallyDecayingReservoirWithExemplars implement
     @Override
     public Snapshot getSnapshot() {
         State stateSnapshot = rescaleIfNeeded(clock.getTick());
-        return new WeightedSnapshotWithExemplars(stateSnapshot.exemplarMetadataProvider, stateSnapshot.values.values());
+        return WeightedSnapshotWithExemplars.snapshot(
+                stateSnapshot.exemplarMetadataProvider, stateSnapshot.values.values());
     }
 
     public static Builder builder() {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/WeightedSnapshotWithExemplars.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/WeightedSnapshotWithExemplars.java
@@ -18,6 +18,7 @@ package com.palantir.tritium.metrics.registry;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.WeightedSnapshot;
 import com.codahale.metrics.WeightedSnapshot.WeightedSample;
+import com.palantir.logsafe.Preconditions;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -63,6 +64,13 @@ final class WeightedSnapshotWithExemplars extends Snapshot implements ExemplarsC
     private final ExemplarMetadataProvider<?> exemplarProvider;
     private final List<LongExemplar<Object>> exemplars;
 
+    private WeightedSnapshotWithExemplars(
+            ExemplarMetadataProvider<?> provider, List<LongExemplar<Object>> exemplars, WeightedSnapshot snapshot) {
+        this.exemplars = Collections.unmodifiableList(exemplars);
+        this.weightedSnapshot = Preconditions.checkNotNull(snapshot, "snapshot");
+        this.exemplarProvider = Preconditions.checkNotNull(provider, "provider");
+    }
+
     /**
      * Create a new {@link Snapshot} with the given values.
      *
@@ -70,18 +78,21 @@ final class WeightedSnapshotWithExemplars extends Snapshot implements ExemplarsC
      * exemplars to clients able to input the same provider instance, to guarantee type-safety.
      * @param values an unordered set of values in the reservoir
      */
-    WeightedSnapshotWithExemplars(ExemplarMetadataProvider<?> provider, Collection<WeightedSampleWithExemplar> values) {
+    static Snapshot snapshot(ExemplarMetadataProvider<?> provider, Collection<WeightedSampleWithExemplar> values) {
         List<WeightedSample> weightedSamples = new ArrayList<>(values.size());
-        List<LongExemplar<Object>> exemplarsBuilder = new ArrayList<>();
+        List<LongExemplar<Object>> exemplars = new ArrayList<>();
         values.forEach(v -> {
             weightedSamples.add(new WeightedSample(v.value, v.weight));
             if (v.exemplarMetadata != null) {
-                exemplarsBuilder.add(DefaultLongExemplar.of(v.exemplarMetadata, v.value));
+                exemplars.add(DefaultLongExemplar.of(v.exemplarMetadata, v.value));
             }
         });
-        this.exemplars = Collections.unmodifiableList(exemplarsBuilder);
-        this.weightedSnapshot = new WeightedSnapshot(Collections.unmodifiableList(weightedSamples));
-        this.exemplarProvider = provider;
+
+        WeightedSnapshot weightedSnapshot = new WeightedSnapshot(weightedSamples);
+        if (exemplars.isEmpty()) {
+            return weightedSnapshot;
+        }
+        return new WeightedSnapshotWithExemplars(provider, exemplars, weightedSnapshot);
     }
 
     /**

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/WeightedSnapshotWithExemplars.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/WeightedSnapshotWithExemplars.java
@@ -18,9 +18,10 @@ package com.palantir.tritium.metrics.registry;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.WeightedSnapshot;
 import com.codahale.metrics.WeightedSnapshot.WeightedSample;
-import com.google.common.collect.ImmutableList;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 
@@ -70,22 +71,21 @@ final class WeightedSnapshotWithExemplars extends Snapshot implements ExemplarsC
      * @param values an unordered set of values in the reservoir
      */
     WeightedSnapshotWithExemplars(ExemplarMetadataProvider<?> provider, Collection<WeightedSampleWithExemplar> values) {
-        ImmutableList.Builder<WeightedSample> weightedSamplesBuilder =
-                ImmutableList.builderWithExpectedSize(values.size());
-        ImmutableList.Builder<LongExemplar<Object>> exemplarsBuilder = null;
+        List<WeightedSample> weightedSamplesBuilder = new ArrayList<>(values.size());
+        List<LongExemplar<Object>> exemplarsBuilder = null;
 
         for (WeightedSampleWithExemplar v : values) {
             weightedSamplesBuilder.add(new WeightedSample(v.value, v.weight));
             if (v.exemplarMetadata != null) {
                 if (exemplarsBuilder == null) {
-                    exemplarsBuilder = ImmutableList.builder();
+                    exemplarsBuilder = new ArrayList<>();
                 }
                 exemplarsBuilder.add(DefaultLongExemplar.of(v.exemplarMetadata, v.value));
             }
         }
-        this.exemplars = (exemplarsBuilder == null) ? ImmutableList.of() : exemplarsBuilder.build();
+        this.exemplars = (exemplarsBuilder == null) ? List.of() : Collections.unmodifiableList(exemplarsBuilder);
 
-        this.weightedSnapshot = new WeightedSnapshot(weightedSamplesBuilder.build());
+        this.weightedSnapshot = new WeightedSnapshot(Collections.unmodifiableList(weightedSamplesBuilder));
         this.exemplarProvider = provider;
     }
 

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/WeightedSnapshotWithExemplars.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/WeightedSnapshotWithExemplars.java
@@ -71,21 +71,16 @@ final class WeightedSnapshotWithExemplars extends Snapshot implements ExemplarsC
      * @param values an unordered set of values in the reservoir
      */
     WeightedSnapshotWithExemplars(ExemplarMetadataProvider<?> provider, Collection<WeightedSampleWithExemplar> values) {
-        List<WeightedSample> weightedSamplesBuilder = new ArrayList<>(values.size());
-        List<LongExemplar<Object>> exemplarsBuilder = null;
-
-        for (WeightedSampleWithExemplar v : values) {
-            weightedSamplesBuilder.add(new WeightedSample(v.value, v.weight));
+        List<WeightedSample> weightedSamples = new ArrayList<>(values.size());
+        List<LongExemplar<Object>> exemplarsBuilder = new ArrayList<>();
+        values.forEach(v -> {
+            weightedSamples.add(new WeightedSample(v.value, v.weight));
             if (v.exemplarMetadata != null) {
-                if (exemplarsBuilder == null) {
-                    exemplarsBuilder = new ArrayList<>();
-                }
                 exemplarsBuilder.add(DefaultLongExemplar.of(v.exemplarMetadata, v.value));
             }
-        }
-        this.exemplars = (exemplarsBuilder == null) ? List.of() : Collections.unmodifiableList(exemplarsBuilder);
-
-        this.weightedSnapshot = new WeightedSnapshot(Collections.unmodifiableList(weightedSamplesBuilder));
+        });
+        this.exemplars = Collections.unmodifiableList(exemplarsBuilder);
+        this.weightedSnapshot = new WeightedSnapshot(Collections.unmodifiableList(weightedSamples));
         this.exemplarProvider = provider;
     }
 

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoirWithExemplarsTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoirWithExemplarsTest.java
@@ -23,6 +23,7 @@ import com.codahale.metrics.Reservoir;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.Timer.Context;
+import com.codahale.metrics.WeightedSnapshot;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -423,11 +424,10 @@ class LockFreeExponentiallyDecayingReservoirWithExemplarsTest {
             reservoir.update(i);
         }
 
-        assertThat(reservoir.getSnapshot()).isInstanceOf(ExemplarsCapture.class);
-        ExemplarsCapture exemplarsCapture = (ExemplarsCapture) reservoir.getSnapshot();
-
         // No exemplars should be returned since the provider didn't return non-null metadata
-        assertThat(exemplarsCapture.getSamples(provider)).isEmpty();
+        assertThat(reservoir.getSnapshot())
+                .isInstanceOf(WeightedSnapshot.class)
+                .isNotInstanceOf(ExemplarsCapture.class);
     }
 
     private static void testShortPeriodShouldNotRescale(long startTimeNanos) {


### PR DESCRIPTION
## Before this PR

`WeightedSnapshotWithExemplars` uses `ImmutableList.Builder` that adds unnecessary extra array copies.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
WeightedSnapshotWithExemplars uses ArrayList
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

