### PR TITLE
Remove queued duration minimum threshold

### DIFF
--- a/changelog/@unreleased/pr-2184.v2.yml
+++ b/changelog/@unreleased/pr-2184.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: The executor queued duration metric no longer excludes small measurements.
+    This ensures that the metrics accurately measure the time between submission and
+    execution.
+  links:
+  - https://github.com/palantir/tritium/pull/2184

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsExecutorService.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsExecutorService.java
@@ -29,14 +29,6 @@ import org.jspecify.annotations.Nullable;
 
 final class TaggedMetricsExecutorService extends AbstractExecutorService {
 
-    // 250ms minimum threshold is required to update the queued duration timer.
-    // The queued duration is an estimate based on time between a task being submitted
-    // and beginning to execute, there is always a delta between these operations, but
-    // it doesn't necessarily mean there's a queue at all. We assume anything longer than
-    // this threshold, which should be longer than pauses in most cases, is the result
-    // of queueing.
-    private static final long QUEUED_DURATION_MINIMUM_THRESHOLD_NANOS = 250_000_000L;
-
     private final ExecutorService delegate;
     private final String name;
 
@@ -148,12 +140,8 @@ final class TaggedMetricsExecutorService extends AbstractExecutorService {
 
         @SuppressWarnings("PreferJavaTimeOverload") // performance sensitive
         void stopQueueTimer() {
-            Timer queuedDurationTimer = queuedDuration;
-            if (queuedDurationTimer != null) {
-                long queuedDurationNanos = System.nanoTime() - created;
-                if (queuedDurationNanos > QUEUED_DURATION_MINIMUM_THRESHOLD_NANOS) {
-                    queuedDurationTimer.update(queuedDurationNanos, TimeUnit.NANOSECONDS);
-                }
+            if (queuedDuration != null) {
+                queuedDuration.update(System.nanoTime() - created, TimeUnit.NANOSECONDS);
             }
         }
     }
@@ -184,12 +172,8 @@ final class TaggedMetricsExecutorService extends AbstractExecutorService {
 
         @SuppressWarnings("PreferJavaTimeOverload") // performance sensitive
         void stopQueueTimer() {
-            Timer queuedDurationTimer = queuedDuration;
-            if (queuedDurationTimer != null) {
-                long queuedDurationNanos = System.nanoTime() - created;
-                if (queuedDurationNanos > QUEUED_DURATION_MINIMUM_THRESHOLD_NANOS) {
-                    queuedDurationTimer.update(queuedDurationNanos, TimeUnit.NANOSECONDS);
-                }
+            if (queuedDuration != null) {
+                queuedDuration.update(System.nanoTime() - created, TimeUnit.NANOSECONDS);
             }
         }
     }


### PR DESCRIPTION
## Before this PR

In our internal authentication service, we have a single threaded executor where, at any given time, there is at most one executing task and one queued task. The code looks something like:

```java
private final ExecutorService updateExecutor = Executors.newSingleThreadExecutor();
private final AtomicReference<SettableFuture<Void>> pendingUpdate = new AtomicReference<>();

Future<Void> updateCache() {
    SettableFuture<Void> future = pendingUpdate.get();
    if (future != null) {
        return future;
    }

    future = SettableFuture.create();

    SettableFuture<Void> witness = pendingUpdate.compareAndExchange(null, future);
    if (witness != null) {
        return witness;
    }

    future.setFuture(updateExecutor.submit(this::doUpdateCache, null));

    return future;
}

void doUpdateCache() {
    pendingUpdate.set(null);

    ...
}
```

Metrics seem to indicate that the queued duration p99 is longer than the duration p99. Here are metrics from our internal test environment.

![Screenshot 2025-05-29 at 12 38 30 PM](https://github.com/user-attachments/assets/6c87f9e3-74bb-4e73-b2f1-9c468416f781)

This should be impossible, given how this executor is used.

But it happens because `TaggedMetricsExecutorService` is simply dropping any samples below the threshold. This causes the value of the queued duration metrics to be artificially inflated - especially for executors that typically have short queue duration.

It's confusing for measurements to simply be dropped in this way and causes the resulting metrics to be misleading.

## After this PR

`TaggedMetricsExecutorService` no longer excludes measurements from the queued duration metric. This metric now accurately captures the time between submission and execution for all submitted tasks.