### PR TITLE
Add native image tag to `attributeUptime` metric

### DIFF
--- a/changelog/@unreleased/pr-2192.v2.yml
+++ b/changelog/@unreleased/pr-2192.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Adds native image tag to the attributeUptime metric, which contains
+    other informational tags.
+  links:
+  - https://github.com/palantir/tritium/pull/2192

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/GraalImageInfo.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/GraalImageInfo.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.jvm;
+
+import com.palantir.tritium.metrics.jvm.InternalJvmMetrics.InternalJvm_NativeImage;
+
+public final class GraalImageInfo {
+
+    /**
+     * Ported over from {@code org.graalvm.nativeimage.ImageInfo},
+     * so that we do not have to pull the entire graal-sdk jar at runtime.
+     */
+    private static final String PROPERTY_IMAGE_CODE_KEY = "org.graalvm.nativeimage.imagecode";
+
+    public static final InternalJvm_NativeImage NATIVE = System.getProperty(PROPERTY_IMAGE_CODE_KEY) != null
+            ? InternalJvm_NativeImage.TRUE
+            : InternalJvm_NativeImage.FALSE;
+
+    private GraalImageInfo() {}
+}

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/GraalImageInfo.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/GraalImageInfo.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.metrics.jvm;
 
-import com.palantir.tritium.metrics.jvm.JvmMemoryMetrics.JvmMemory_NativeImage;
+import com.palantir.tritium.metrics.jvm.InternalJvmMetrics.AttributeUptime_NativeImage;
 
 public final class GraalImageInfo {
 
@@ -26,9 +26,9 @@ public final class GraalImageInfo {
      */
     private static final String PROPERTY_IMAGE_CODE_KEY = "org.graalvm.nativeimage.imagecode";
 
-    public static final JvmMemory_NativeImage NATIVE = System.getProperty(PROPERTY_IMAGE_CODE_KEY) != null
-            ? JvmMemory_NativeImage.TRUE
-            : JvmMemory_NativeImage.FALSE;
+    public static final AttributeUptime_NativeImage NATIVE = System.getProperty(PROPERTY_IMAGE_CODE_KEY) != null
+            ? AttributeUptime_NativeImage.TRUE
+            : AttributeUptime_NativeImage.FALSE;
 
     private GraalImageInfo() {}
 }

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/GraalImageInfo.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/GraalImageInfo.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tritium.metrics.jvm;
 
-import com.palantir.tritium.metrics.jvm.InternalJvmMetrics.InternalJvm_NativeImage;
+import com.palantir.tritium.metrics.jvm.JvmMemoryMetrics.JvmMemory_NativeImage;
 
 public final class GraalImageInfo {
 
@@ -26,9 +26,9 @@ public final class GraalImageInfo {
      */
     private static final String PROPERTY_IMAGE_CODE_KEY = "org.graalvm.nativeimage.imagecode";
 
-    public static final InternalJvm_NativeImage NATIVE = System.getProperty(PROPERTY_IMAGE_CODE_KEY) != null
-            ? InternalJvm_NativeImage.TRUE
-            : InternalJvm_NativeImage.FALSE;
+    public static final JvmMemory_NativeImage NATIVE = System.getProperty(PROPERTY_IMAGE_CODE_KEY) != null
+            ? JvmMemory_NativeImage.TRUE
+            : JvmMemory_NativeImage.FALSE;
 
     private GraalImageInfo() {}
 }

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -64,7 +64,10 @@ public final class JvmMetrics {
         Preconditions.checkNotNull(registry, "TaggedMetricRegistry is required");
         MetricRegistries.registerGarbageCollection(registry);
         MetricRegistries.registerMemoryPools(registry);
-        InternalJvmMetrics metrics = InternalJvmMetrics.of(registry);
+        InternalJvmMetrics metrics = InternalJvmMetrics.builder()
+                .registry(registry)
+                .nativeImage(GraalImageInfo.NATIVE)
+                .build();
         Jdk9CompatibleFileDescriptorRatioGauge.register(metrics);
         OperatingSystemMetrics.register(registry);
         SafepointMetrics.register(registry);

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -91,6 +91,7 @@ public final class JvmMetrics {
                         runtimeMxBean.getInputArguments().contains("--enable-preview")
                                 ? AttributeUptime_EnablePreview.TRUE
                                 : AttributeUptime_EnablePreview.FALSE)
+                .nativeImage(GraalImageInfo.NATIVE)
                 .build(runtimeMxBean::getUptime);
     }
 
@@ -178,10 +179,7 @@ public final class JvmMetrics {
 
     @VisibleForTesting
     static void registerJvmMemory(TaggedMetricRegistry registry, MemoryMXBean memoryBean) {
-        JvmMemoryMetrics metrics = JvmMemoryMetrics.builder()
-                .registry(registry)
-                .nativeImage(GraalImageInfo.NATIVE)
-                .build();
+        JvmMemoryMetrics metrics = JvmMemoryMetrics.of(registry);
         // jvm.memory.total
         metrics.totalInit(nonNegative(() -> totalHeapPlusNonHeap(memoryBean, MemoryUsage::getInit)));
         metrics.totalUsed(nonNegative(() -> totalHeapPlusNonHeap(memoryBean, MemoryUsage::getUsed)));

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -64,10 +64,7 @@ public final class JvmMetrics {
         Preconditions.checkNotNull(registry, "TaggedMetricRegistry is required");
         MetricRegistries.registerGarbageCollection(registry);
         MetricRegistries.registerMemoryPools(registry);
-        InternalJvmMetrics metrics = InternalJvmMetrics.builder()
-                .registry(registry)
-                .nativeImage(GraalImageInfo.NATIVE)
-                .build();
+        InternalJvmMetrics metrics = InternalJvmMetrics.of(registry);
         Jdk9CompatibleFileDescriptorRatioGauge.register(metrics);
         OperatingSystemMetrics.register(registry);
         SafepointMetrics.register(registry);
@@ -181,7 +178,10 @@ public final class JvmMetrics {
 
     @VisibleForTesting
     static void registerJvmMemory(TaggedMetricRegistry registry, MemoryMXBean memoryBean) {
-        JvmMemoryMetrics metrics = JvmMemoryMetrics.of(registry);
+        JvmMemoryMetrics metrics = JvmMemoryMetrics.builder()
+                .registry(registry)
+                .nativeImage(GraalImageInfo.NATIVE)
+                .build();
         // jvm.memory.total
         metrics.totalInit(nonNegative(() -> totalHeapPlusNonHeap(memoryBean, MemoryUsage::getInit)));
         metrics.totalUsed(nonNegative(() -> totalHeapPlusNonHeap(memoryBean, MemoryUsage::getUsed)));

--- a/tritium-metrics-jvm/src/main/metrics/metrics.yml
+++ b/tritium-metrics-jvm/src/main/metrics/metrics.yml
@@ -27,12 +27,6 @@ namespaces:
     docs: JVM Metrics
     # The default 'JvmMetrics' name collides with the public JvmMetrics utility.
     shortName: InternalJvm
-    tags:
-      - name: nativeImage
-        docs: If the service is running as a native image
-        values:
-          - value: true
-          - value: false
     metrics:
       safepoint.time:
         type: gauge
@@ -111,6 +105,12 @@ namespaces:
               A value of `-1` means values are cached forever and `0` describes no caching.
   jvm.memory:
     docs: Java virtual machine memory usage metrics.
+    tags:
+      - name: nativeImage
+        docs: If the service is running as a native image
+        values:
+          - value: true
+          - value: false
     metrics:
       total.init:
         type: gauge

--- a/tritium-metrics-jvm/src/main/metrics/metrics.yml
+++ b/tritium-metrics-jvm/src/main/metrics/metrics.yml
@@ -54,6 +54,9 @@ namespaces:
         - name: enablePreview
           docs: "Whether the JVM is running with --enable-preview (see https://openjdk.org/jeps/12 )"
           values: ['true', 'false']
+        - name: nativeImage
+          docs: "If the service is running as a native image"
+          values: ['true', 'false']
       classloader.loaded:
         type: gauge
         docs: Total number of classes that have been loaded since the jvm started.
@@ -105,12 +108,6 @@ namespaces:
               A value of `-1` means values are cached forever and `0` describes no caching.
   jvm.memory:
     docs: Java virtual machine memory usage metrics.
-    tags:
-      - name: nativeImage
-        docs: If the service is running as a native image
-        values:
-          - value: true
-          - value: false
     metrics:
       total.init:
         type: gauge

--- a/tritium-metrics-jvm/src/main/metrics/metrics.yml
+++ b/tritium-metrics-jvm/src/main/metrics/metrics.yml
@@ -27,6 +27,12 @@ namespaces:
     docs: JVM Metrics
     # The default 'JvmMetrics' name collides with the public JvmMetrics utility.
     shortName: InternalJvm
+    tags:
+      - name: nativeImage
+        docs: If the service is running as a native image
+        values:
+          - value: true
+          - value: false
     metrics:
       safepoint.time:
         type: gauge


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Wanted to be able to differentiate native image metrics from hotspot metrics in Grafana.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds native image tag to the `attributeUptime` metric, which contains other informational tags.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

