### PR TITLE
Remove custom Error Prone configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,24 +72,6 @@ allprojects {
                 option('NullAway:AnnotatedPackages', 'com.palantir,com.google.common')
                 option('NullAway:CheckOptionalEmptiness', 'true')
 
-                // warnings not explicitly provided by error-prone
-                error 'NullAway',
-                        'Slf4jLogsafeArgs',
-                        'PreferCollectionTransform',
-                        'PreferListsPartition',
-                        'PreferSafeLoggingPreconditions',
-                        'PreferSafeLoggableExceptions',
-                        'PreferSafeLogger'
-
-
-                disable 'AndroidJdkLibsChecker', // ignore Android
-                        'Java7ApiChecker', // tritium requires JDK 11+
-                        'Java8ApiChecker', // tritium requires JDK 11+
-                        'MemberName', // false positives on ignored lambda args
-                        'StaticOrDefaultInterfaceMethod', // Android specific
-                        'Var', // high noise, low signal
-                        'Varifier' // don't `var`ify everything yet as this conflicts with baseline VarUsage
-
                 errorproneArgs = [
                     '-XepAllSuggestionsAsWarnings',
                 ]


### PR DESCRIPTION
Baseline upgrades are blocked because Error Prone removed the `Java7ApiChecker` check.

```
Execution failed for task ':tritium-time:compileJava'.
> Java7ApiChecker is not a valid checker name
```

There's no need to disable these checks. It's better to selectively disable them in specific locations using `@SuppressWarnings` so that:
- Things don't break when checks are removed.
- We still get these checks in places we may want them