### PR TITLE
Optimize SlidingTimeWindowMovingAverages sumBuckets()

### DIFF
--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/MovingAverageBenchmarks.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/MovingAverageBenchmarks.java
@@ -1,0 +1,104 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.microbenchmarks;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.MovingAverages;
+import com.codahale.metrics.SlidingTimeWindowMovingAverages;
+import com.palantir.tritium.metrics.registry.OptimizedSlidingTimeWindowMovingAverages;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 20, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 20, time = 250, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+@State(Scope.Benchmark)
+@SuppressWarnings({"designforextension", "NullAway"})
+public class MovingAverageBenchmarks {
+
+    @Param({"SlidingTimeWindowMovingAverages", "OptimizedSlidingTimeWindowMovingAverages"})
+    private MovingAveragesType type;
+
+    @Param({"10", "1000"})
+    private int recordings;
+
+    public enum MovingAveragesType {
+        SlidingTimeWindowMovingAverages() {
+            @Override
+            MovingAverages create(Clock clock) {
+                return new SlidingTimeWindowMovingAverages(clock);
+            }
+        },
+        OptimizedSlidingTimeWindowMovingAverages() {
+            @Override
+            MovingAverages create(Clock clock) {
+                return new OptimizedSlidingTimeWindowMovingAverages(clock);
+            }
+        };
+
+        abstract MovingAverages create(Clock clock);
+    }
+
+    private MovingAverages movingAverages;
+
+    @Setup
+    public void before() {
+        ManualClock clock = new ManualClock();
+        movingAverages = type.create(clock);
+        for (int second = 0; second < 60; second++) {
+            for (int i = 0; i < recordings; i++) {
+                movingAverages.update(i);
+            }
+            clock.addSeconds(second);
+        }
+    }
+
+    @Benchmark
+    public double getM1Rate() {
+        return movingAverages.getM1Rate();
+    }
+
+    static final class ManualClock extends Clock {
+        private long ticksInNanos;
+
+        public synchronized void addSeconds(int seconds) {
+            ticksInNanos += TimeUnit.NANOSECONDS.convert(seconds, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public synchronized long getTick() {
+            return ticksInNanos;
+        }
+
+        @Override
+        public synchronized long getTime() {
+            return TimeUnit.NANOSECONDS.toMillis(ticksInNanos);
+        }
+    }
+}

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/OptimizedSlidingTimeWindowMovingAverages.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/OptimizedSlidingTimeWindowMovingAverages.java
@@ -1,0 +1,231 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.registry;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.ExponentialMovingAverages;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MovingAverages;
+import com.codahale.metrics.SlidingTimeWindowArrayReservoir;
+import com.google.common.annotations.VisibleForTesting;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.IntStream;
+
+/**
+ * Optimized fork of {@link com.codahale.metrics.SlidingTimeWindowMovingAverages}, see
+ * <a href="https://github.com/dropwizard/metrics/pull/4936">upstream PR 4936</a>.
+ * <p>
+ * A triple of simple moving average rates (one, five and fifteen minutes rates) as needed by {@link Meter}.
+ * <p>
+ * The averages are unweighted, i.e. they include strictly only the events in the
+ * sliding time window, every event having the same weight. Unlike the
+ * the more widely used {@link ExponentialMovingAverages} implementation,
+ * with this class the moving average rate drops immediately to zero if the last
+ * marked event is older than the time window.
+ * <p>
+ * A {@link Meter} with {@link com.codahale.metrics.SlidingTimeWindowMovingAverages} works similarly to
+ * a {@link Histogram} with an {@link SlidingTimeWindowArrayReservoir}, but as a Meter
+ * needs to keep track only of the count of events (not the events itself), the memory
+ * overhead is much smaller. SlidingTimeWindowMovingAverages uses buckets with just one
+ * counter to accumulate the number of events (one bucket per seconds, giving 900 buckets
+ * for the 15 minutes time window).
+ */
+public final class OptimizedSlidingTimeWindowMovingAverages implements MovingAverages {
+
+    private static final long TIME_WINDOW_DURATION_MINUTES = 15;
+    private static final long TICK_INTERVAL = TimeUnit.SECONDS.toNanos(1);
+    private static final Duration TIME_WINDOW_DURATION = Duration.ofMinutes(TIME_WINDOW_DURATION_MINUTES);
+
+    // package private for the benefit of the unit test
+    static final int NUMBER_OF_BUCKETS = (int) (TIME_WINDOW_DURATION.toNanos() / TICK_INTERVAL);
+
+    private final AtomicLong lastTick;
+    private final Clock clock;
+
+    /**
+     * One counter per time bucket/slot (i.e. per second, see TICK_INTERVAL) for the entire
+     * time window (i.e. 15 minutes, see TIME_WINDOW_DURATION_MINUTES).
+     */
+    private final List<LongAdder> buckets;
+
+    /**
+     * Index into buckets, pointing at the bucket containing the oldest counts.
+     */
+    private int oldestBucketIndex;
+
+    /**
+     * Index into buckets, pointing at the bucket with the count for the current time (tick).
+     */
+    private int currentBucketIndex;
+
+    /**
+     * Instant at creation time of the time window. Used to calculate the currentBucketIndex
+     * for the instant of a given tick (instant modulo time window duration).
+     */
+    private final Instant bucketBaseTime;
+
+    /**
+     * Instant of the bucket with index oldestBucketIndex.
+     */
+    private Instant oldestBucketTime;
+
+    /**
+     * Creates a new {@link com.codahale.metrics.SlidingTimeWindowMovingAverages}.
+     */
+    OptimizedSlidingTimeWindowMovingAverages() {
+        this(Clock.defaultClock());
+    }
+
+    /**
+     * Creates a new {@link com.codahale.metrics.SlidingTimeWindowMovingAverages}.
+     *
+     * @param clock the clock to use for the meter ticks
+     */
+    OptimizedSlidingTimeWindowMovingAverages(Clock clock) {
+        this.clock = clock;
+        final long startTime = clock.getTick();
+        this.lastTick = new AtomicLong(startTime);
+
+        this.buckets = IntStream.range(0, NUMBER_OF_BUCKETS)
+                .mapToObj(_i -> new LongAdder())
+                .toList();
+        this.bucketBaseTime = Instant.ofEpochSecond(0L, startTime);
+        this.oldestBucketTime = bucketBaseTime;
+        this.oldestBucketIndex = 0;
+        this.currentBucketIndex = 0;
+    }
+
+    @Override
+    public void update(long value) {
+        buckets.get(currentBucketIndex).add(value);
+    }
+
+    @Override
+    public void tickIfNecessary() {
+        final long oldTick = lastTick.get();
+        final long newTick = clock.getTick();
+        final long age = newTick - oldTick;
+        if (age >= TICK_INTERVAL) {
+            // - the newTick doesn't fall into the same slot as the oldTick anymore
+            // - newLastTick is the lower border time of the new currentBucketIndex slot
+            final long newLastTick = newTick - age % TICK_INTERVAL;
+            if (lastTick.compareAndSet(oldTick, newLastTick)) {
+                Instant currentInstant = Instant.ofEpochSecond(0L, newLastTick);
+                currentBucketIndex = normalizeIndex(calculateIndexOfTick(currentInstant));
+                cleanOldBuckets(currentInstant);
+            }
+        }
+    }
+
+    @VisibleForTesting
+    Instant oldestBucketTime() {
+        return oldestBucketTime;
+    }
+
+    @Override
+    public double getM15Rate() {
+        return getMinuteRate(15);
+    }
+
+    @Override
+    public double getM5Rate() {
+        return getMinuteRate(5);
+    }
+
+    @Override
+    public double getM1Rate() {
+        return getMinuteRate(1);
+    }
+
+    private double getMinuteRate(int minutes) {
+        Instant now = Instant.ofEpochSecond(0L, lastTick.get());
+        return sumBuckets(now, (int) (TimeUnit.MINUTES.toNanos(minutes) / TICK_INTERVAL));
+    }
+
+    @VisibleForTesting
+    int calculateIndexOfTick(Instant tickTime) {
+        return (int) (Duration.between(bucketBaseTime, tickTime).toNanos() / TICK_INTERVAL);
+    }
+
+    @VisibleForTesting
+    static int normalizeIndex(int index) {
+        int mod = index % NUMBER_OF_BUCKETS;
+        return mod >= 0 ? mod : mod + NUMBER_OF_BUCKETS;
+    }
+
+    private void cleanOldBuckets(Instant currentTick) {
+        int newOldestIndex;
+        Instant oldestStillNeededTime = currentTick.minus(TIME_WINDOW_DURATION).plusNanos(TICK_INTERVAL);
+        Instant youngestNotInWindow = oldestBucketTime.plus(TIME_WINDOW_DURATION);
+        if (oldestStillNeededTime.isAfter(youngestNotInWindow)) {
+            // there was no update() call for more than two whole TIME_WINDOW_DURATION
+            newOldestIndex = oldestBucketIndex;
+            oldestBucketTime = currentTick;
+        } else if (oldestStillNeededTime.isAfter(oldestBucketTime)) {
+            newOldestIndex = normalizeIndex(calculateIndexOfTick(oldestStillNeededTime));
+            oldestBucketTime = oldestStillNeededTime;
+        } else {
+            return;
+        }
+
+        cleanBucketRange(oldestBucketIndex, newOldestIndex);
+        oldestBucketIndex = newOldestIndex;
+    }
+
+    private void cleanBucketRange(int fromIndex, int toIndex) {
+        if (fromIndex < toIndex) {
+            for (int i = fromIndex; i < toIndex; i++) {
+                buckets.get(i).reset();
+            }
+        } else {
+            for (int i = fromIndex; i < NUMBER_OF_BUCKETS; i++) {
+                buckets.get(i).reset();
+            }
+            for (int i = 0; i < toIndex; i++) {
+                buckets.get(i).reset();
+            }
+        }
+    }
+
+    private long sumBuckets(Instant toTime, int numberOfBuckets) {
+
+        // increment toIndex to include the current bucket into the sum
+        int toIndex = normalizeIndex(calculateIndexOfTick(toTime) + 1);
+        int fromIndex = normalizeIndex(toIndex - numberOfBuckets);
+
+        long sum = 0;
+        if (fromIndex < toIndex) {
+            for (int i = fromIndex; i < toIndex; i++) {
+                sum += buckets.get(i).longValue();
+            }
+        } else {
+            for (int i = fromIndex; i < NUMBER_OF_BUCKETS; i++) {
+                sum += buckets.get(i).longValue();
+            }
+            for (int i = 0; i < toIndex; i++) {
+                sum += buckets.get(i).longValue();
+            }
+        }
+        return sum;
+    }
+}

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/OptimizedSlidingTimeWindowMovingAverages.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/OptimizedSlidingTimeWindowMovingAverages.java
@@ -25,11 +25,9 @@ import com.codahale.metrics.SlidingTimeWindowArrayReservoir;
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.stream.IntStream;
 
 /**
  * Optimized fork of {@link com.codahale.metrics.SlidingTimeWindowMovingAverages}, see
@@ -66,7 +64,7 @@ public final class OptimizedSlidingTimeWindowMovingAverages implements MovingAve
      * One counter per time bucket/slot (i.e. per second, see TICK_INTERVAL) for the entire
      * time window (i.e. 15 minutes, see TIME_WINDOW_DURATION_MINUTES).
      */
-    private final List<LongAdder> buckets;
+    private final LongAdder[] buckets;
 
     /**
      * Index into buckets, pointing at the bucket containing the oldest counts.
@@ -92,7 +90,7 @@ public final class OptimizedSlidingTimeWindowMovingAverages implements MovingAve
     /**
      * Creates a new {@link OptimizedSlidingTimeWindowMovingAverages}.
      */
-    OptimizedSlidingTimeWindowMovingAverages() {
+    public OptimizedSlidingTimeWindowMovingAverages() {
         this(Clock.defaultClock());
     }
 
@@ -101,14 +99,15 @@ public final class OptimizedSlidingTimeWindowMovingAverages implements MovingAve
      *
      * @param clock the clock to use for the meter ticks
      */
-    OptimizedSlidingTimeWindowMovingAverages(Clock clock) {
+    public OptimizedSlidingTimeWindowMovingAverages(Clock clock) {
         this.clock = clock;
         final long startTime = clock.getTick();
         this.lastTick = new AtomicLong(startTime);
 
-        this.buckets = IntStream.range(0, NUMBER_OF_BUCKETS)
-                .mapToObj(_i -> new LongAdder())
-                .toList();
+        this.buckets = new LongAdder[NUMBER_OF_BUCKETS];
+        for (int i = 0; i < NUMBER_OF_BUCKETS; i++) {
+            this.buckets[i] = new LongAdder();
+        }
         this.bucketBaseTime = Instant.ofEpochSecond(0L, startTime);
         this.oldestBucketTime = bucketBaseTime;
         this.oldestBucketIndex = 0;
@@ -117,7 +116,7 @@ public final class OptimizedSlidingTimeWindowMovingAverages implements MovingAve
 
     @Override
     public void update(long value) {
-        buckets.get(currentBucketIndex).add(value);
+        buckets[currentBucketIndex].add(value);
     }
 
     @Override
@@ -195,14 +194,14 @@ public final class OptimizedSlidingTimeWindowMovingAverages implements MovingAve
     private void cleanBucketRange(int fromIndex, int toIndex) {
         if (fromIndex < toIndex) {
             for (int i = fromIndex; i < toIndex; i++) {
-                buckets.get(i).reset();
+                buckets[i].reset();
             }
         } else {
             for (int i = fromIndex; i < NUMBER_OF_BUCKETS; i++) {
-                buckets.get(i).reset();
+                buckets[i].reset();
             }
             for (int i = 0; i < toIndex; i++) {
-                buckets.get(i).reset();
+                buckets[i].reset();
             }
         }
     }
@@ -216,14 +215,14 @@ public final class OptimizedSlidingTimeWindowMovingAverages implements MovingAve
         long sum = 0;
         if (fromIndex < toIndex) {
             for (int i = fromIndex; i < toIndex; i++) {
-                sum += buckets.get(i).longValue();
+                sum += buckets[i].longValue();
             }
         } else {
             for (int i = fromIndex; i < NUMBER_OF_BUCKETS; i++) {
-                sum += buckets.get(i).longValue();
+                sum += buckets[i].longValue();
             }
             for (int i = 0; i < toIndex; i++) {
-                sum += buckets.get(i).longValue();
+                sum += buckets[i].longValue();
             }
         }
         return sum;

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/OptimizedSlidingTimeWindowMovingAverages.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/OptimizedSlidingTimeWindowMovingAverages.java
@@ -90,14 +90,14 @@ public final class OptimizedSlidingTimeWindowMovingAverages implements MovingAve
     private Instant oldestBucketTime;
 
     /**
-     * Creates a new {@link com.codahale.metrics.SlidingTimeWindowMovingAverages}.
+     * Creates a new {@link OptimizedSlidingTimeWindowMovingAverages}.
      */
     OptimizedSlidingTimeWindowMovingAverages() {
         this(Clock.defaultClock());
     }
 
     /**
-     * Creates a new {@link com.codahale.metrics.SlidingTimeWindowMovingAverages}.
+     * Creates a new {@link OptimizedSlidingTimeWindowMovingAverages}.
      *
      * @param clock the clock to use for the meter ticks
      */

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/OptimizedSlidingTimeWindowMovingAverages.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/OptimizedSlidingTimeWindowMovingAverages.java
@@ -27,7 +27,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.atomic.AtomicLongArray;
 
 /**
  * Optimized fork of {@link com.codahale.metrics.SlidingTimeWindowMovingAverages}, see
@@ -64,7 +64,7 @@ public final class OptimizedSlidingTimeWindowMovingAverages implements MovingAve
      * One counter per time bucket/slot (i.e. per second, see TICK_INTERVAL) for the entire
      * time window (i.e. 15 minutes, see TIME_WINDOW_DURATION_MINUTES).
      */
-    private final LongAdder[] buckets;
+    private final AtomicLongArray buckets;
 
     /**
      * Index into buckets, pointing at the bucket containing the oldest counts.
@@ -104,10 +104,7 @@ public final class OptimizedSlidingTimeWindowMovingAverages implements MovingAve
         final long startTime = clock.getTick();
         this.lastTick = new AtomicLong(startTime);
 
-        this.buckets = new LongAdder[NUMBER_OF_BUCKETS];
-        for (int i = 0; i < NUMBER_OF_BUCKETS; i++) {
-            this.buckets[i] = new LongAdder();
-        }
+        this.buckets = new AtomicLongArray(NUMBER_OF_BUCKETS);
         this.bucketBaseTime = Instant.ofEpochSecond(0L, startTime);
         this.oldestBucketTime = bucketBaseTime;
         this.oldestBucketIndex = 0;
@@ -116,7 +113,7 @@ public final class OptimizedSlidingTimeWindowMovingAverages implements MovingAve
 
     @Override
     public void update(long value) {
-        buckets[currentBucketIndex].add(value);
+        buckets.addAndGet(currentBucketIndex, value);
     }
 
     @Override
@@ -194,14 +191,14 @@ public final class OptimizedSlidingTimeWindowMovingAverages implements MovingAve
     private void cleanBucketRange(int fromIndex, int toIndex) {
         if (fromIndex < toIndex) {
             for (int i = fromIndex; i < toIndex; i++) {
-                buckets[i].reset();
+                buckets.set(i, 0L);
             }
         } else {
             for (int i = fromIndex; i < NUMBER_OF_BUCKETS; i++) {
-                buckets[i].reset();
+                buckets.set(i, 0L);
             }
             for (int i = 0; i < toIndex; i++) {
-                buckets[i].reset();
+                buckets.set(i, 0L);
             }
         }
     }
@@ -215,14 +212,14 @@ public final class OptimizedSlidingTimeWindowMovingAverages implements MovingAve
         long sum = 0;
         if (fromIndex < toIndex) {
             for (int i = fromIndex; i < toIndex; i++) {
-                sum += buckets[i].longValue();
+                sum += buckets.get(i);
             }
         } else {
             for (int i = fromIndex; i < NUMBER_OF_BUCKETS; i++) {
-                sum += buckets[i].longValue();
+                sum += buckets.get(i);
             }
             for (int i = 0; i < toIndex; i++) {
-                sum += buckets[i].longValue();
+                sum += buckets.get(i);
             }
         }
         return sum;

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/OptimizedSlidingTimeWindowMovingAveragesTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/OptimizedSlidingTimeWindowMovingAveragesTest.java
@@ -1,0 +1,201 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.registry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Meter;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OptimizedSlidingTimeWindowMovingAveragesTest {
+    private ManualClock clock;
+    private OptimizedSlidingTimeWindowMovingAverages movingAverages;
+    private Meter meter;
+
+    @BeforeEach
+    public void init() {
+        clock = new ManualClock();
+        movingAverages = new OptimizedSlidingTimeWindowMovingAverages(clock);
+        meter = new Meter(movingAverages, clock);
+    }
+
+    @Test
+    public void normalizeIndex() {
+
+        assertThat(OptimizedSlidingTimeWindowMovingAverages.normalizeIndex(0)).isEqualTo(0);
+        assertThat(OptimizedSlidingTimeWindowMovingAverages.normalizeIndex(900)).isEqualTo(0);
+        assertThat(OptimizedSlidingTimeWindowMovingAverages.normalizeIndex(9000))
+                .isEqualTo(0);
+        assertThat(OptimizedSlidingTimeWindowMovingAverages.normalizeIndex(-900))
+                .isEqualTo(0);
+
+        assertThat(OptimizedSlidingTimeWindowMovingAverages.normalizeIndex(1)).isEqualTo(1);
+
+        assertThat(OptimizedSlidingTimeWindowMovingAverages.normalizeIndex(899)).isEqualTo(899);
+        assertThat(OptimizedSlidingTimeWindowMovingAverages.normalizeIndex(-1)).isEqualTo(899);
+        assertThat(OptimizedSlidingTimeWindowMovingAverages.normalizeIndex(-901))
+                .isEqualTo(899);
+    }
+
+    @Test
+    public void calculateIndexOfTick() {
+
+        OptimizedSlidingTimeWindowMovingAverages stwm = new OptimizedSlidingTimeWindowMovingAverages(clock);
+
+        assertThat(stwm.calculateIndexOfTick(Instant.ofEpochSecond(0L))).isEqualTo(0);
+        assertThat(stwm.calculateIndexOfTick(Instant.ofEpochSecond(1L))).isEqualTo(1);
+    }
+
+    @Test
+    public void mark_max_without_cleanup() {
+
+        int markCount = OptimizedSlidingTimeWindowMovingAverages.NUMBER_OF_BUCKETS;
+
+        // compensate the first addSeconds in the loop; first tick should be at zero
+        clock.addSeconds(-1);
+
+        for (int i = 0; i < markCount; i++) {
+            clock.addSeconds(1);
+            meter.mark();
+        }
+
+        // verify that no cleanup happened yet
+        assertThat(movingAverages.oldestBucketTime()).isEqualTo(Instant.ofEpochSecond(0L));
+
+        assertThat(meter.getOneMinuteRate()).isEqualTo(60.0);
+        assertThat(meter.getFiveMinuteRate()).isEqualTo(300.0);
+        assertThat(meter.getFifteenMinuteRate()).isEqualTo(900.0);
+    }
+
+    @Test
+    public void mark_first_cleanup() {
+
+        int markCount = OptimizedSlidingTimeWindowMovingAverages.NUMBER_OF_BUCKETS + 1;
+
+        // compensate the first addSeconds in the loop; first tick should be at zero
+        clock.addSeconds(-1);
+
+        for (int i = 0; i < markCount; i++) {
+            clock.addSeconds(1);
+            meter.mark();
+        }
+
+        // verify that at least one cleanup happened
+        assertThat(movingAverages.oldestBucketTime()).isNotEqualTo(Instant.EPOCH);
+
+        assertThat(meter.getOneMinuteRate()).isEqualTo(60.0);
+        assertThat(meter.getFiveMinuteRate()).isEqualTo(300.0);
+        assertThat(meter.getFifteenMinuteRate()).isEqualTo(900.0);
+    }
+
+    @Test
+    public void mark_10_values() {
+
+        // compensate the first addSeconds in the loop; first tick should be at zero
+        clock.addSeconds(-1);
+
+        for (int i = 0; i < 10; i++) {
+            clock.addSeconds(1);
+            meter.mark();
+        }
+
+        assertThat(meter.getCount()).isEqualTo(10L);
+        assertThat(meter.getOneMinuteRate()).isEqualTo(10.0);
+        assertThat(meter.getFiveMinuteRate()).isEqualTo(10.0);
+        assertThat(meter.getFifteenMinuteRate()).isEqualTo(10.0);
+    }
+
+    @Test
+    public void mark_1000_values() {
+
+        for (int i = 0; i < 1000; i++) {
+            clock.addSeconds(1);
+            meter.mark();
+        }
+
+        // only 60/300/900 of the 1000 events took place in the last 1/5/15 minute(s)
+        assertThat(meter.getOneMinuteRate()).isEqualTo(60.0);
+        assertThat(meter.getFiveMinuteRate()).isEqualTo(300.0);
+        assertThat(meter.getFifteenMinuteRate()).isEqualTo(900.0);
+    }
+
+    @Test
+    public void cleanup_pause_shorter_than_window() {
+
+        meter.mark(10);
+
+        // no mark for three minutes
+        clock.addSeconds(180);
+        assertThat(meter.getOneMinuteRate()).isEqualTo(0.0);
+        assertThat(meter.getFiveMinuteRate()).isEqualTo(10.0);
+        assertThat(meter.getFifteenMinuteRate()).isEqualTo(10.0);
+    }
+
+    @Test
+    public void cleanup_window_wrap_around() {
+
+        // mark at 14:40 minutes of the 15-minute window...
+        clock.addSeconds(880);
+        meter.mark(10);
+
+        // and query at 15:30 minutes (the bucket index must have wrapped around)
+        clock.addSeconds(50);
+        assertThat(meter.getOneMinuteRate()).isEqualTo(10.0);
+        assertThat(meter.getFiveMinuteRate()).isEqualTo(10.0);
+        assertThat(meter.getFifteenMinuteRate()).isEqualTo(10.0);
+
+        // and query at 30:10 minutes (the bucket index must have wrapped around for the second time)
+        clock.addSeconds(880);
+        assertThat(meter.getOneMinuteRate()).isEqualTo(0.0);
+        assertThat(meter.getFiveMinuteRate()).isEqualTo(0.0);
+        assertThat(meter.getFifteenMinuteRate()).isEqualTo(0.0);
+    }
+
+    @Test
+    public void cleanup_pause_longer_than_two_windows() {
+
+        meter.mark(10);
+
+        // after forty minutes all rates should be zero
+        clock.addSeconds(2400);
+        assertThat(meter.getOneMinuteRate()).isEqualTo(0.0);
+        assertThat(meter.getFiveMinuteRate()).isEqualTo(0.0);
+        assertThat(meter.getFifteenMinuteRate()).isEqualTo(0.0);
+    }
+
+    static final class ManualClock extends Clock {
+        private long ticksInNanos;
+
+        public synchronized void addSeconds(int seconds) {
+            ticksInNanos += TimeUnit.NANOSECONDS.convert(seconds, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public synchronized long getTick() {
+            return ticksInNanos;
+        }
+
+        @Override
+        public synchronized long getTime() {
+            return TimeUnit.NANOSECONDS.toMillis(ticksInNanos);
+        }
+    }
+}


### PR DESCRIPTION
## Before this PR
`SlidingTimeWindowMovingAverages` `sumBuckets()` method could be optimized to perform indexed list access and remove allocations as it currently allocates a `LongAdder` as well as one or two streams. If one is using the 1, 5, or 15 minute rates on hot paths, these can be unnecessary expensive allocations as well as less optimized computations.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
We can avoid the allocations completely and accumulate the sum directly to a `long` via optimized direct indexed list access.

See upstream PR https://github.com/dropwizard/metrics/pull/4936
==COMMIT_MSG==

[MovingAverageBenchmarks](https://github.com/palantir/tritium/blob/davids/OptimizedSlidingTimeWindowMovingAverages/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/MovingAverageBenchmarks.java) demonstrates the difference in implementations in both execution time and allocations:


```
Benchmark                                             (recordings)                                    (type)  Mode  Cnt     Score     Error   Units
MovingAverageBenchmarks.getM1Rate                               10           SlidingTimeWindowMovingAverages  avgt   20  1364.969 ±  12.040   ns/op
MovingAverageBenchmarks.getM1Rate:gc.alloc.rate.norm            10           SlidingTimeWindowMovingAverages  avgt   20   688.037 ±   0.001    B/op
MovingAverageBenchmarks.getM1Rate                               10  OptimizedSlidingTimeWindowMovingAverages  avgt   20    59.182 ±   0.343   ns/op
MovingAverageBenchmarks.getM1Rate:gc.alloc.rate.norm            10  OptimizedSlidingTimeWindowMovingAverages  avgt   20     0.002 ±   0.001    B/op
MovingAverageBenchmarks.getM1Rate                             1000           SlidingTimeWindowMovingAverages  avgt   20  1401.864 ± 107.134   ns/op
MovingAverageBenchmarks.getM1Rate:gc.alloc.rate.norm          1000           SlidingTimeWindowMovingAverages  avgt   20   688.038 ±   0.003    B/op
MovingAverageBenchmarks.getM1Rate                             1000  OptimizedSlidingTimeWindowMovingAverages  avgt   20    61.157 ±   1.393   ns/op
MovingAverageBenchmarks.getM1Rate:gc.alloc.rate.norm          1000  OptimizedSlidingTimeWindowMovingAverages  avgt   20     0.002 ±   0.001    B/op
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
We maintain a fork until upstream releases a version with these improvements. We've [done this in the past with `LockFreeExponentiallyDecayingReservoir` and deprecated](https://github.com/palantir/tritium/blob/develop/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java) once upstreamed.
