### PR TITLE
Explicitly suppressing internal deprecated method call

### DIFF
--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/SharedTaggedMetricRegistries.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/SharedTaggedMetricRegistries.java
@@ -28,8 +28,8 @@ public final class SharedTaggedMetricRegistries {
      *
      * @deprecated avoid using the global singleton
      */
-    @SuppressWarnings("for-rollout:deprecation")
     @Deprecated
+    @SuppressWarnings("deprecation") // explicitly plumbing through the deprecated singleton tagged registry
     public static TaggedMetricRegistry getSingleton() {
         return DefaultTaggedMetricRegistry.getDefault();
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

https://github.com/palantir/tritium/pull/2258 suppressed `for-rollout:deprecation` but we want to accept this internal deprecated usage as we're explicitly plumbing through the deprecated singleton tagged registry.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
See https://github.com/palantir/gradle-baseline/pull/3244
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

