### PR TITLE
Fully enable NullAway:JSpecifyMode checking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ allprojects {
             options.errorprone {
                 option('NullAway:AnnotatedPackages', 'com.palantir,com.google.common')
                 option('NullAway:CheckOptionalEmptiness', 'true')
+                option('NullAway:JSpecifyMode', 'true')
 
                 errorproneArgs = [
                     '-XepAllSuggestionsAsWarnings',

--- a/tritium-api/src/main/java/com/palantir/tritium/api/event/InstrumentationFilter.java
+++ b/tritium-api/src/main/java/com/palantir/tritium/api/event/InstrumentationFilter.java
@@ -18,6 +18,7 @@ package com.palantir.tritium.api.event;
 
 import java.lang.reflect.Method;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 @FunctionalInterface
 public interface InstrumentationFilter {
@@ -32,5 +33,5 @@ public interface InstrumentationFilter {
      *     {@code java.lang.Boolean}.
      * @return true if invocation should be instrumented, false if invocation should not be instrumented
      */
-    boolean shouldInstrument(@NonNull Object instance, @NonNull Method method, @NonNull Object[] args);
+    boolean shouldInstrument(@NonNull Object instance, @NonNull Method method, @Nullable Object @NonNull [] args);
 }

--- a/tritium-api/src/main/java/com/palantir/tritium/event/InvocationContext.java
+++ b/tritium-api/src/main/java/com/palantir/tritium/event/InvocationContext.java
@@ -49,5 +49,6 @@ public interface InvocationContext {
      *
      * @return arguments
      */
+    @Nullable
     Object[] getArgs();
 }

--- a/tritium-api/src/main/java/com/palantir/tritium/event/InvocationEventHandler.java
+++ b/tritium-api/src/main/java/com/palantir/tritium/event/InvocationEventHandler.java
@@ -46,7 +46,7 @@ public interface InvocationEventHandler<C extends InvocationContext> {
      *     {@code java.lang.Boolean}.
      * @return the current invocation context. Null values are not recommended but are supported
      */
-    C preInvocation(@NonNull Object instance, @NonNull Method method, @NonNull Object[] args);
+    C preInvocation(Object instance, Method method, @Nullable Object @NonNull [] args);
 
     /**
      * Invoked with the result of the invocation when it is successful.

--- a/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
@@ -95,7 +95,7 @@ public abstract class AbstractInvocationEventHandler<C extends InvocationContext
      * Returns system property based boolean supplier for the specified class.
      *
      * @param clazz instrumentation handler class
-     * @return false if "instrument.fully.qualified.class.Name" is set to "false", otherwise true
+     * @return `false` if "instrument.fully.qualified.class.Name" is set to "false", otherwise true
      */
     protected static com.palantir.tritium.api.functions.BooleanSupplier getSystemPropertySupplier(
             Class<? extends InvocationEventHandler<InvocationContext>> clazz) {
@@ -104,7 +104,7 @@ public abstract class AbstractInvocationEventHandler<C extends InvocationContext
     }
 
     @SuppressWarnings("WeakerAccess") // public API
-    public static Object[] nullToEmpty(Object @Nullable [] args) {
+    public static @Nullable Object[] nullToEmpty(@Nullable Object @Nullable [] args) {
         return (args == null) ? NO_ARGS : args;
     }
 }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/AbstractInvocationEventHandler.java
@@ -104,7 +104,7 @@ public abstract class AbstractInvocationEventHandler<C extends InvocationContext
     }
 
     @SuppressWarnings("WeakerAccess") // public API
-    public static Object[] nullToEmpty(@Nullable Object[] args) {
+    public static Object[] nullToEmpty(Object @Nullable [] args) {
         return (args == null) ? NO_ARGS : args;
     }
 }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
@@ -53,7 +53,7 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
 
     @Override
     public InvocationContext preInvocation(@NonNull Object instance, @NonNull Method method, @NonNull Object[] args) {
-        InvocationContext[] contexts = new InvocationContext[handlers.length];
+        @Nullable InvocationContext[] contexts = new InvocationContext[handlers.length];
 
         for (int i = 0; i < handlers.length; i++) {
             contexts[i] = Handlers.preWithEnabledCheck(
@@ -71,7 +71,7 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
         }
     }
 
-    private void success(@NonNull InvocationContext[] contexts, @Nullable Object result) {
+    private void success(@Nullable InvocationContext @NonNull [] contexts, @Nullable Object result) {
         for (int i = contexts.length - 1; i > -1; i--) {
             Handlers.onSuccess(handlers[i], contexts[i], result);
         }
@@ -85,7 +85,7 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
         }
     }
 
-    private void failure(InvocationContext[] contexts, @NonNull Throwable cause) {
+    private void failure(@Nullable InvocationContext @NonNull [] contexts, @NonNull Throwable cause) {
         for (int i = contexts.length - 1; i > -1; i--) {
             Handlers.onFailure(handlers[i], contexts[i], cause);
         }
@@ -98,15 +98,19 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
 
     static class CompositeInvocationContext extends DefaultInvocationContext {
 
-        private final InvocationContext[] contexts;
+        private final @Nullable InvocationContext @NonNull [] contexts;
 
         CompositeInvocationContext(
-                Object instance, Method method, @Nullable Object[] args, InvocationContext[] contexts) {
+                Object instance,
+                Method method,
+                Object @Nullable [] args,
+                @Nullable InvocationContext @NonNull [] contexts) {
             super(System.nanoTime(), instance, method, args);
             this.contexts = checkNotNull(contexts);
         }
 
-        InvocationContext[] getContexts() {
+        @Nullable
+        InvocationContext @NonNull [] getContexts() {
             return contexts;
         }
     }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/CompositeInvocationEventHandler.java
@@ -21,7 +21,6 @@ import static com.palantir.logsafe.Preconditions.checkNotNull;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 public final class CompositeInvocationEventHandler extends AbstractInvocationEventHandler<InvocationContext> {
@@ -52,7 +51,7 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
     }
 
     @Override
-    public InvocationContext preInvocation(@NonNull Object instance, @NonNull Method method, @NonNull Object[] args) {
+    public InvocationContext preInvocation(Object instance, Method method, @Nullable Object [] args) {
         @Nullable InvocationContext[] contexts = new InvocationContext[handlers.length];
 
         for (int i = 0; i < handlers.length; i++) {
@@ -71,21 +70,21 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
         }
     }
 
-    private void success(@Nullable InvocationContext @NonNull [] contexts, @Nullable Object result) {
+    private void success(@Nullable InvocationContext[] contexts, @Nullable Object result) {
         for (int i = contexts.length - 1; i > -1; i--) {
             Handlers.onSuccess(handlers[i], contexts[i], result);
         }
     }
 
     @Override
-    public void onFailure(@Nullable InvocationContext context, @NonNull Throwable cause) {
+    public void onFailure(@Nullable InvocationContext context, Throwable cause) {
         debugIfNullContext(context);
         if (context != null) {
             failure(((CompositeInvocationContext) context).getContexts(), cause);
         }
     }
 
-    private void failure(@Nullable InvocationContext @NonNull [] contexts, @NonNull Throwable cause) {
+    private void failure(@Nullable InvocationContext[] contexts, Throwable cause) {
         for (int i = contexts.length - 1; i > -1; i--) {
             Handlers.onFailure(handlers[i], contexts[i], cause);
         }
@@ -98,19 +97,16 @@ public final class CompositeInvocationEventHandler extends AbstractInvocationEve
 
     static class CompositeInvocationContext extends DefaultInvocationContext {
 
-        private final @Nullable InvocationContext @NonNull [] contexts;
+        private final @Nullable InvocationContext[] contexts;
 
         CompositeInvocationContext(
-                Object instance,
-                Method method,
-                Object @Nullable [] args,
-                @Nullable InvocationContext @NonNull [] contexts) {
+                Object instance, Method method, Object @Nullable [] args, @Nullable InvocationContext[] contexts) {
             super(System.nanoTime(), instance, method, args);
             this.contexts = checkNotNull(contexts);
         }
 
         @Nullable
-        InvocationContext @NonNull [] getContexts() {
+        InvocationContext[] getContexts() {
             return contexts;
         }
     }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/DefaultInvocationContext.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/DefaultInvocationContext.java
@@ -28,20 +28,24 @@ public class DefaultInvocationContext implements InvocationContext {
     private final long startTimeNanos;
     private final Object instance;
     private final Method method;
-    private final Object[] args;
+    private final @Nullable Object[] args;
 
-    protected DefaultInvocationContext(long startTimeNanos, Object instance, Method method, Object @Nullable [] args) {
+    protected DefaultInvocationContext(
+            long startTimeNanos, Object instance, Method method, @Nullable Object @Nullable [] args) {
         this.startTimeNanos = startTimeNanos;
         this.instance = instance;
         this.method = method;
         this.args = toNonNullClone(args);
     }
 
-    private static Object[] toNonNullClone(Object @Nullable [] args) {
-        return args == null ? NO_ARGS : args.clone();
+    private static @Nullable Object[] toNonNullClone(@Nullable Object @Nullable [] args) {
+        if (args == null) {
+            return NO_ARGS;
+        }
+        return args.clone();
     }
 
-    public static InvocationContext of(Object instance, Method method, Object @Nullable [] args) {
+    public static InvocationContext of(Object instance, Method method, @Nullable Object @Nullable [] args) {
         return new DefaultInvocationContext(
                 System.nanoTime(), checkNotNull(instance, "instance"), checkNotNull(method, "method"), args);
     }
@@ -61,7 +65,10 @@ public class DefaultInvocationContext implements InvocationContext {
         return method;
     }
 
+    @Nullable
     @Override
+    @SuppressWarnings("NullAway") // false positive
+    // Method returns @Nullable Object [], but overridden method returns Object []
     public final Object[] getArgs() {
         return args;
     }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/DefaultInvocationContext.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/DefaultInvocationContext.java
@@ -30,18 +30,18 @@ public class DefaultInvocationContext implements InvocationContext {
     private final Method method;
     private final Object[] args;
 
-    protected DefaultInvocationContext(long startTimeNanos, Object instance, Method method, @Nullable Object[] args) {
+    protected DefaultInvocationContext(long startTimeNanos, Object instance, Method method, Object @Nullable [] args) {
         this.startTimeNanos = startTimeNanos;
         this.instance = instance;
         this.method = method;
         this.args = toNonNullClone(args);
     }
 
-    private static Object[] toNonNullClone(@Nullable Object[] args) {
+    private static Object[] toNonNullClone(Object @Nullable [] args) {
         return args == null ? NO_ARGS : args.clone();
     }
 
-    public static InvocationContext of(Object instance, Method method, @Nullable Object[] args) {
+    public static InvocationContext of(Object instance, Method method, Object @Nullable [] args) {
         return new DefaultInvocationContext(
                 System.nanoTime(), checkNotNull(instance, "instance"), checkNotNull(method, "method"), args);
     }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/Handlers.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/Handlers.java
@@ -70,7 +70,7 @@ public final class Handlers {
             InstrumentationFilter filter,
             Object instance,
             Method method,
-            Object[] args) {
+            @Nullable Object[] args) {
         try {
             return handler.isEnabled() && filter.shouldInstrument(instance, method, args)
                     ? handler.preInvocation(instance, method, args)
@@ -143,7 +143,7 @@ public final class Handlers {
     private static void logOnFailureFailure(
             InvocationEventHandler<?> handler,
             @Nullable InvocationContext context,
-            Throwable thrown,
+            @Nullable Throwable thrown,
             Throwable throwable) {
         if (log.isWarnEnabled()) {
             log.warn(
@@ -179,6 +179,7 @@ public final class Handlers {
             throw fail();
         }
 
+        @Nullable
         @Override
         public Object[] getArgs() {
             throw fail();

--- a/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationFilters.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/InstrumentationFilters.java
@@ -18,14 +18,14 @@ package com.palantir.tritium.event;
 
 import com.palantir.tritium.api.event.InstrumentationFilter;
 import java.lang.reflect.Method;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public enum InstrumentationFilters implements InstrumentationFilter {
 
     /** Instrument all invocations. */
     INSTRUMENT_ALL {
         @Override
-        public boolean shouldInstrument(@NonNull Object _instance, @NonNull Method _method, @NonNull Object[] _args) {
+        public boolean shouldInstrument(Object _instance, Method _method, @Nullable Object[] _args) {
             return true;
         }
     },
@@ -33,7 +33,7 @@ public enum InstrumentationFilters implements InstrumentationFilter {
     /** Instrument no invocations. */
     INSTRUMENT_NONE {
         @Override
-        public boolean shouldInstrument(@NonNull Object _instance, @NonNull Method _method, @NonNull Object[] _args) {
+        public boolean shouldInstrument(Object _instance, Method _method, @Nullable Object[] _args) {
             return false;
         }
     };

--- a/tritium-core/src/main/java/com/palantir/tritium/event/NoOpInvocationEventHandler.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/NoOpInvocationEventHandler.java
@@ -17,7 +17,6 @@
 package com.palantir.tritium.event;
 
 import java.lang.reflect.Method;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /** No-op implementation of {@link InvocationEventHandler}. */
@@ -30,7 +29,7 @@ public enum NoOpInvocationEventHandler implements InvocationEventHandler<Invocat
     }
 
     @Override
-    public InvocationContext preInvocation(@NonNull Object instance, @NonNull Method method, @NonNull Object[] args) {
+    public InvocationContext preInvocation(Object instance, Method method, @Nullable Object @Nullable [] args) {
         return DefaultInvocationContext.of(instance, method, args);
     }
 
@@ -40,7 +39,7 @@ public enum NoOpInvocationEventHandler implements InvocationEventHandler<Invocat
     }
 
     @Override
-    public void onFailure(@Nullable InvocationContext _context, @NonNull Throwable _cause) {
+    public void onFailure(@Nullable InvocationContext _context, Throwable _cause) {
         // no-op
     }
 }

--- a/tritium-core/src/main/java/com/palantir/tritium/event/package-info.java
+++ b/tritium-core/src/main/java/com/palantir/tritium/event/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.palantir.tritium.event;
+
+import org.jspecify.annotations.NullMarked;

--- a/tritium-core/src/test/java/com/palantir/tritium/event/CompositeInvocationEventHandlerTest.java
+++ b/tritium-core/src/test/java/com/palantir/tritium/event/CompositeInvocationEventHandlerTest.java
@@ -95,7 +95,7 @@ final class CompositeInvocationEventHandlerTest {
                 NoOpInvocationEventHandler.INSTANCE, new ThrowingInvocationEventHandler(/* isEnabled= */ true) {
                     @Override
                     public InvocationContext preInvocation(
-                            @NonNull Object instance, @NonNull Method method, @NonNull Object[] args) {
+                            Object instance, Method method, @Nullable Object @Nullable [] args) {
                         return DefaultInvocationContext.of(instance, method, args);
                     }
                 }));
@@ -112,7 +112,7 @@ final class CompositeInvocationEventHandlerTest {
                 NoOpInvocationEventHandler.INSTANCE, new ThrowingInvocationEventHandler(/* isEnabled= */ true) {
                     @Override
                     public InvocationContext preInvocation(
-                            @NonNull Object instance, @NonNull Method method, @NonNull Object[] args) {
+                            Object instance, Method method, @Nullable Object @Nullable [] args) {
                         return DefaultInvocationContext.of(instance, method, args);
                     }
                 }));
@@ -209,10 +209,10 @@ final class CompositeInvocationEventHandlerTest {
         return new ThrowingInvocationEventHandler(isEnabled);
     }
 
-    private static final class SimpleInvocationEventHandler extends AbstractInvocationEventHandler<InvocationContext> {
+    private static final class SimpleInvocationEventHandler
+            extends AbstractInvocationEventHandler<@NonNull InvocationContext> {
         @Override
-        public InvocationContext preInvocation(
-                @NonNull Object instance, @NonNull Method method, @NonNull Object[] args) {
+        public InvocationContext preInvocation(Object instance, Method method, @Nullable Object @Nullable [] args) {
             return DefaultInvocationContext.of(instance, method, args);
         }
 

--- a/tritium-ids/build.gradle
+++ b/tritium-ids/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation 'com.google.guava:guava'
     implementation 'com.palantir.safe-logging:logger'
     implementation 'com.palantir.safe-logging:preconditions'
+    implementation 'org.jspecify:jspecify'
 
     jmhImplementation 'com.fasterxml.uuid:java-uuid-generator'
 

--- a/tritium-ids/src/main/java/com/palantir/tritium/ids/package-info.java
+++ b/tritium-ids/src/main/java/com/palantir/tritium/ids/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.palantir.tritium.ids;
+
+import org.jspecify.annotations.NullMarked;

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/BlackholeInvocationEventHandler.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/BlackholeInvocationEventHandler.java
@@ -42,7 +42,7 @@ final class BlackholeInvocationEventHandler implements InvocationEventHandler<In
     }
 
     @Override
-    public InvocationContext preInvocation(@NonNull Object instance, @NonNull Method method, @NonNull Object[] args) {
+    public InvocationContext preInvocation(Object instance, Method method, @Nullable Object @Nullable [] args) {
         consume(instance, method, args);
         return SINGLETON_CONTEXT;
     }

--- a/tritium-lib/src/main/java/com/palantir/tritium/io/package-info.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/io/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.palantir.tritium.io;
+
+import org.jspecify.annotations.NullMarked;

--- a/tritium-lib/src/main/java/com/palantir/tritium/package-info.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.palantir.tritium;
+
+import org.jspecify.annotations.NullMarked;

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/InvocationEventProxy.java
@@ -72,7 +72,7 @@ abstract class InvocationEventProxy implements InvocationHandler {
     /** Optimized to avoid excessive stack frames for readable stack traces. */
     @Override
     @Nullable
-    public final Object invoke(Object proxy, Method method, @Nullable Object[] nullableArgs) throws Throwable {
+    public final Object invoke(Object proxy, Method method, Object @Nullable [] nullableArgs) throws Throwable {
         Object[] arguments = nullableArgs == null ? EMPTY_ARRAY : nullableArgs;
         if (isSpecialMethod(method, arguments)) {
             return handleSpecialMethod(proxy, method, arguments);

--- a/tritium-lib/src/main/java/com/palantir/tritium/proxy/package-info.java
+++ b/tritium-lib/src/main/java/com/palantir/tritium/proxy/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.palantir.tritium.proxy;
+
+import org.jspecify.annotations.NullMarked;

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InvocationEventProxyTest.java
@@ -54,7 +54,7 @@ public class InvocationEventProxyTest {
     private InstrumentationFilter mockFilter;
 
     @Mock
-    private InvocationEventHandler<InvocationContext> mockHandler;
+    private InvocationEventHandler<@NonNull InvocationContext> mockHandler;
 
     @Test
     @SuppressWarnings("checkstyle:illegalthrows")
@@ -73,7 +73,7 @@ public class InvocationEventProxyTest {
     @Test
     @SuppressWarnings("checkstyle:illegalthrows")
     public void testInstrumentPreInvocation() throws Throwable {
-        InvocationEventHandler<InvocationContext> testHandler = new SimpleHandler();
+        InvocationEventHandler<@NonNull InvocationContext> testHandler = new SimpleHandler();
         InvocationEventProxy proxy = createTestProxy(testHandler);
 
         assertThat(proxy.invoke(this, getStringLengthMethod(), EMPTY_ARGS)).isEqualTo("test".length());
@@ -98,7 +98,7 @@ public class InvocationEventProxyTest {
         InvocationEventHandler<InvocationContext> testHandler = new SimpleHandler() {
             @Override
             public InvocationContext preInvocation(
-                    @NonNull Object _instance, @NonNull Method _method, @NonNull Object[] _args) {
+                    Object _instance, Method _method, @Nullable Object @Nullable [] _args) {
                 throw new IllegalStateException("expected");
             }
         };
@@ -299,7 +299,7 @@ public class InvocationEventProxyTest {
         return TestInterface.class.getMethod("throwsCheckedException");
     }
 
-    private static class SimpleHandler implements InvocationEventHandler<InvocationContext> {
+    private static class SimpleHandler implements InvocationEventHandler<@NonNull InvocationContext> {
         @Override
         public boolean isEnabled() {
             return true;
@@ -307,7 +307,7 @@ public class InvocationEventProxyTest {
 
         @Override
         public InvocationContext preInvocation(
-                @NonNull Object instance, @NonNull Method method, @NonNull Object[] args) {
+                @NonNull Object instance, @NonNull Method method, @Nullable Object @Nullable [] args) {
             return DefaultInvocationContext.of(instance, method, args);
         }
 

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/MetricsInvocationEventHandler.java
@@ -27,7 +27,6 @@ import com.palantir.tritium.event.InvocationContext;
 import com.palantir.tritium.event.InvocationEventHandler;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /** {@link InvocationEventHandler} that records method timing and failures using Dropwizard metrics. */
@@ -47,7 +46,7 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
         this.serviceName = checkNotNull(serviceName, "serviceName");
     }
 
-    @SuppressWarnings("InconsistentOverloads")
+    @SuppressWarnings({"InconsistentOverloads", "unused"})
     public MetricsInvocationEventHandler(
             MetricRegistry metricRegistry,
             Class<?> _serviceClass,
@@ -58,7 +57,7 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
         this.serviceName = checkNotNull(serviceName, "serviceName");
     }
 
-    @SuppressWarnings("WeakerAccess") // public API
+    @SuppressWarnings({"WeakerAccess", "unused"}) // public API
     public MetricsInvocationEventHandler(
             MetricRegistry metricRegistry, Class<?> serviceClass, @Safe @Nullable String globalGroupPrefix) {
         this(metricRegistry, serviceClass, checkNotNull(serviceClass.getName()), globalGroupPrefix);
@@ -71,7 +70,7 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
     }
 
     @Override
-    public InvocationContext preInvocation(@NonNull Object instance, @NonNull Method method, @NonNull Object[] args) {
+    public InvocationContext preInvocation(Object instance, Method method, @Nullable Object @Nullable [] args) {
         return DefaultInvocationContext.of(instance, method, args);
     }
 
@@ -84,7 +83,7 @@ public final class MetricsInvocationEventHandler extends AbstractInvocationEvent
     }
 
     @Override
-    public void onFailure(@Nullable InvocationContext context, @NonNull Throwable _cause) {
+    public void onFailure(@Nullable InvocationContext context, Throwable _cause) {
         markGlobalFailure();
         debugIfNullContext(context);
         if (context != null) {

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandler.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/TaggedMetricsServiceInvocationEventHandler.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -76,8 +75,7 @@ public class TaggedMetricsServiceInvocationEventHandler extends AbstractInvocati
     }
 
     @Override
-    public final InvocationContext preInvocation(
-            @NonNull Object instance, @NonNull Method method, @NonNull Object[] args) {
+    public final InvocationContext preInvocation(Object instance, Method method, @Nullable Object @Nullable [] args) {
         return DefaultInvocationContext.of(instance, method, args);
     }
 
@@ -92,7 +90,7 @@ public class TaggedMetricsServiceInvocationEventHandler extends AbstractInvocati
     }
 
     @Override
-    public final void onFailure(@Nullable InvocationContext context, @NonNull Throwable _cause) {
+    public final void onFailure(@Nullable InvocationContext context, Throwable _cause) {
         debugIfNullContext(context);
         if (context != null) {
             long nanos = System.nanoTime() - context.getStartTimeNanos();

--- a/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/annotations/AnnotationHelper.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/event/metrics/annotations/AnnotationHelper.java
@@ -21,6 +21,7 @@ import static com.palantir.logsafe.Preconditions.checkNotNull;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -61,14 +62,19 @@ public final class AnnotationHelper {
     @Deprecated
     public static final class MethodSignature {
         private final String methodName;
-        private final Class<?>[] parameterTypes;
+        private final Class<?> @NonNull [] parameterTypes;
 
         private static final Class<?>[] NO_ARGS = new Class<?>[0];
 
-        private MethodSignature(String methodName, @Nullable Class<?>... parameterTypes) {
+        private MethodSignature(String methodName, Class<?> @Nullable [] parameterTypes) {
             this.methodName = checkNotNull(methodName);
-            this.parameterTypes =
-                    (parameterTypes == null || parameterTypes.length == 0) ? NO_ARGS : parameterTypes.clone();
+            this.parameterTypes = nullToEmpty(parameterTypes);
+        }
+
+        @SuppressWarnings("NullAway")
+        private static Class<?> @NonNull [] nullToEmpty(Class<?> @Nullable [] types) {
+            @Nullable Class<?>[] parameterTypes = (types == null || types.length == 0) ? null : types.clone();
+            return parameterTypes == null ? NO_ARGS : parameterTypes;
         }
 
         public String getMethodName() {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
@@ -18,6 +18,7 @@ package com.palantir.tritium.metrics.registry;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Ordering;
+import com.palantir.logsafe.Preconditions;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -108,7 +109,7 @@ final class TagMap implements SortedMap<String, String> {
             int valuesIndex = 2 * i;
             String key = keys[i];
             values[valuesIndex] = key;
-            values[valuesIndex + 1] = data.get(key);
+            values[valuesIndex + 1] = Preconditions.checkNotNull(data.get(key), "value");
         }
         return values;
     }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
@@ -17,8 +17,8 @@
 package com.palantir.tritium.metrics.registry;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.collect.Ordering;
-import com.palantir.logsafe.Preconditions;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -109,7 +109,7 @@ final class TagMap implements SortedMap<String, String> {
             int valuesIndex = 2 * i;
             String key = keys[i];
             values[valuesIndex] = key;
-            values[valuesIndex + 1] = Preconditions.checkNotNull(data.get(key), "value");
+            values[valuesIndex + 1] = Strings.nullToEmpty(data.get(key));
         }
         return values;
     }

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TagMapTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TagMapTest.java
@@ -24,6 +24,8 @@ import com.google.common.collect.Ordering;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class TagMapTest {
@@ -89,5 +91,20 @@ class TagMapTest {
         assertThat(TagMap.isNaturalOrder(immutableSortedMapComparator))
                 .as("Expected ImmutableSortedMap comparator %s to be natural", immutableSortedMapComparator)
                 .isTrue();
+    }
+
+    @Test
+    void testNullValueBecomesEmpty() {
+        Map<String, String> map = new HashMap<>();
+        map.put("a", null);
+        map.put("b", "");
+        map.put("c", "null");
+        assertThat(TagMap.of(map)).satisfies(tagMap -> {
+            assertThat(tagMap).hasSameSizeAs(map);
+            assertThat(tagMap.keySet())
+                    .containsExactlyInAnyOrderElementsOf(map.keySet())
+                    .allSatisfy(value -> assertThat(value).isNotNull());
+            assertThat(tagMap.values()).allSatisfy(value -> assertThat(value).isNotNull());
+        });
     }
 }

--- a/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
+++ b/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
@@ -29,7 +29,6 @@ import com.palantir.tritium.event.InvocationEventHandler;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.function.BiConsumer;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
@@ -79,8 +78,7 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
     }
 
     @Override
-    public final InvocationContext preInvocation(
-            @NonNull Object instance, @NonNull Method method, @NonNull Object[] args) {
+    public final InvocationContext preInvocation(Object instance, Method method, @Nullable Object @Nullable [] args) {
         return DefaultInvocationContext.of(instance, method, args);
     }
 
@@ -90,7 +88,7 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
     }
 
     @Override
-    public final void onFailure(@Nullable InvocationContext context, @NonNull Throwable _cause) {
+    public final void onFailure(@Nullable InvocationContext context, Throwable _cause) {
         logInvocation(context);
     }
 
@@ -102,9 +100,9 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
         }
     }
 
-    private void logInvocation(Method method, Object @Nullable [] nullableArgs, long durationNanos) {
+    private void logInvocation(Method method, @Nullable Object @Nullable [] nullableArgs, long durationNanos) {
         if (isEnabled() && durationPredicate.test(durationNanos)) {
-            Object[] args = nullToEmpty(nullableArgs);
+            @Nullable Object[] args = nullToEmpty(nullableArgs);
             logger.accept(getMessagePattern(args), getLogParams(method, args, durationNanos, level));
         }
     }
@@ -170,14 +168,14 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
         return message.toString();
     }
 
-    static String getMessagePattern(Object[] args) {
+    static String getMessagePattern(@Nullable Object[] args) {
         if (args.length < MESSAGE_PATTERNS.size()) {
             return MESSAGE_PATTERNS.get(args.length);
         }
         return generateMessagePattern(args.length);
     }
 
-    static Object[] getLogParams(Method method, Object[] args, long durationNanos, LoggingLevel level) {
+    static Object[] getLogParams(Method method, @Nullable Object[] args, long durationNanos, LoggingLevel level) {
         @SuppressWarnings("rawtypes") // arrays don't support generics
         Arg[] logParams = new Arg[3 + args.length];
         logParams[0] = SafeArg.of("class", method.getDeclaringClass().getSimpleName());

--- a/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
+++ b/tritium-slf4j/src/main/java/com/palantir/tritium/event/log/LoggingInvocationEventHandler.java
@@ -102,7 +102,7 @@ public class LoggingInvocationEventHandler extends AbstractInvocationEventHandle
         }
     }
 
-    private void logInvocation(Method method, @Nullable Object[] nullableArgs, long durationNanos) {
+    private void logInvocation(Method method, Object @Nullable [] nullableArgs, long durationNanos) {
         if (isEnabled() && durationPredicate.test(durationNanos)) {
             Object[] args = nullToEmpty(nullableArgs);
             logger.accept(getMessagePattern(args), getLogParams(method, args, durationNanos, level));

--- a/tritium-test/src/main/java/com/palantir/tritium/metrics/package-info.java
+++ b/tritium-test/src/main/java/com/palantir/tritium/metrics/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.palantir.tritium.metrics;
+
+import org.jspecify.annotations.NullMarked;

--- a/tritium-test/src/main/java/com/palantir/tritium/test/event/ThrowingInvocationEventHandler.java
+++ b/tritium-test/src/main/java/com/palantir/tritium/test/event/ThrowingInvocationEventHandler.java
@@ -20,7 +20,6 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.tritium.event.InvocationContext;
 import com.palantir.tritium.event.InvocationEventHandler;
 import java.lang.reflect.Method;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 @SuppressWarnings("DesignForExtension")
@@ -33,8 +32,7 @@ public class ThrowingInvocationEventHandler implements InvocationEventHandler<In
     }
 
     @Override
-    public InvocationContext preInvocation(
-            @NonNull Object _instance, @NonNull Method _method, @NonNull Object[] _args) {
+    public InvocationContext preInvocation(Object _instance, Method _method, @Nullable Object @Nullable [] _args) {
         throw new SafeIllegalStateException("preInvocation always throws");
     }
 
@@ -44,7 +42,7 @@ public class ThrowingInvocationEventHandler implements InvocationEventHandler<In
     }
 
     @Override
-    public void onFailure(@Nullable InvocationContext _context, @NonNull Throwable _cause) {
+    public void onFailure(@Nullable InvocationContext _context, Throwable _cause) {
         throw new SafeIllegalStateException("onFailure always throws");
     }
 

--- a/tritium-test/src/main/java/com/palantir/tritium/test/event/package-info.java
+++ b/tritium-test/src/main/java/com/palantir/tritium/test/event/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.palantir.tritium.test.event;
+
+import org.jspecify.annotations.NullMarked;

--- a/tritium-test/src/main/java/com/palantir/tritium/test/package-info.java
+++ b/tritium-test/src/main/java/com/palantir/tritium/test/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.palantir.tritium.test;
+
+import org.jspecify.annotations.NullMarked;

--- a/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java
+++ b/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java
@@ -27,7 +27,6 @@ import com.palantir.tritium.event.InstrumentationProperties;
 import com.palantir.tritium.event.InvocationContext;
 import com.palantir.tritium.event.InvocationEventHandler;
 import java.lang.reflect.Method;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 public final class TracingInvocationEventHandler extends AbstractInvocationEventHandler<InvocationContext> {
@@ -58,7 +57,7 @@ public final class TracingInvocationEventHandler extends AbstractInvocationEvent
     }
 
     @Override
-    public InvocationContext preInvocation(@NonNull Object instance, @NonNull Method method, @NonNull Object[] args) {
+    public InvocationContext preInvocation(Object instance, Method method, @Nullable Object @Nullable [] args) {
         InvocationContext context = DefaultInvocationContext.of(instance, method, args);
         String operationName = getOperationName(method);
         Tracer.fastStartSpan(operationName);
@@ -75,7 +74,7 @@ public final class TracingInvocationEventHandler extends AbstractInvocationEvent
     }
 
     @Override
-    public void onFailure(@Nullable InvocationContext context, @NonNull Throwable _cause) {
+    public void onFailure(@Nullable InvocationContext context, Throwable _cause) {
         complete(context);
     }
 


### PR DESCRIPTION
## Before this PR

We were not using the full [JSpecify mode of NullAway](https://github.com/uber/NullAway/wiki/JSpecify-Support) and several packages were not fully `@NullMarked`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
All tritium packages are fully `@NullMarked` with jspecify `@Nullable` or `@NonNull` annotations as needed by APIs. Enable JSpecify mode for stricter NullAway nullness checking.

See https://github.com/uber/NullAway/wiki/JSpecify-Support and https://github.com/uber/NullAway/wiki/How-NullAway-Works#jspecify
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

