### PR TITLE
Add opinionated cache API

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,7 @@ apply plugin: 'com.palantir.jdks.settings'
 rootProject.name = 'tritium'
 
 include 'tritium-api'
+include 'tritium-cache'
 include 'tritium-caffeine'
 include 'tritium-core'
 include 'tritium-ids'

--- a/tritium-cache/build.gradle
+++ b/tritium-cache/build.gradle
@@ -1,0 +1,18 @@
+apply plugin: 'com.palantir.external-publish-jar'
+apply plugin: 'org.revapi.revapi-gradle-plugin'
+
+dependencies {
+    api project(':tritium-registry')
+
+    implementation project(':tritium-caffeine')
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation 'com.google.errorprone:error_prone_annotations'
+    implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:preconditions'
+    implementation 'com.palantir.safe-logging:safe-logging'
+    implementation 'org.jspecify:jspecify'
+
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+}

--- a/tritium-cache/build.gradle
+++ b/tritium-cache/build.gradle
@@ -10,8 +10,10 @@ dependencies {
     implementation 'com.google.guava:guava'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
+    implementation 'com.palantir.tracing:tracing'
     implementation 'org.jspecify:jspecify'
 
+    testImplementation 'com.palantir.tracing:tracing-api'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncBulkLoadingCache.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncBulkLoadingCache.java
@@ -1,0 +1,27 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import java.util.Map;
+
+public interface AsyncBulkLoadingCache<K, V> extends AsyncLoadingCache<K, V> {
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.LoadingCache#getAll(Iterable)}.
+     */
+    Map<K, V> getAll(Iterable<? extends K> keys);
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncBulkLoadingCacheImpl.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncBulkLoadingCacheImpl.java
@@ -25,8 +25,8 @@ class AsyncBulkLoadingCacheImpl<K, V> extends AsyncLoadingCacheImpl<K, V> implem
 
     private final Function<Set<? extends K>, Map<K, V>> bulkMappingFunction;
 
-    AsyncBulkLoadingCacheImpl(AsyncCache<K, V> cache, BulkCacheLoader<K, V> cacheLoader) {
-        super(cache, cacheLoader);
+    AsyncBulkLoadingCacheImpl(String name, AsyncCache<K, V> cache, BulkCacheLoader<K, V> cacheLoader) {
+        super(name, cache, cacheLoader);
         this.bulkMappingFunction = CacheLoaders.newBulkMappingFunction(cacheLoader);
     }
 

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncBulkLoadingCacheImpl.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncBulkLoadingCacheImpl.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+class AsyncBulkLoadingCacheImpl<K, V> extends AsyncLoadingCacheImpl<K, V> implements AsyncBulkLoadingCache<K, V> {
+
+    private final Function<Set<? extends K>, Map<K, V>> bulkMappingFunction;
+
+    AsyncBulkLoadingCacheImpl(AsyncCache<K, V> cache, BulkCacheLoader<K, V> cacheLoader) {
+        super(cache, cacheLoader);
+        this.bulkMappingFunction = CacheLoaders.newBulkMappingFunction(cacheLoader);
+    }
+
+    @Override
+    public final Map<K, V> getAll(Iterable<? extends K> keys) {
+        return getAll(keys, bulkMappingFunction);
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncCache.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncCache.java
@@ -1,0 +1,86 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
+
+public interface AsyncCache<K, V> {
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#getIfPresent(Object)}.
+     */
+    @Nullable
+    V getIfPresent(K key);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#get(Object, Function)}.
+     */
+    @Nullable
+    V get(K key, Function<? super K, ? extends V> mappingFunction);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#getAllPresent(Iterable)}.
+     */
+    Map<K, V> getAllPresent(Iterable<? extends K> keys);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#getAll(Iterable, Function)}.
+     */
+    Map<K, V> getAll(
+            Iterable<? extends K> keys,
+            Function<? super Set<? extends K>, ? extends Map<? extends K, ? extends V>> mappingFunction);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#put(Object, Object)}.
+     */
+    void put(K key, V value);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#putAll(Map)}.
+     */
+    void putAll(Map<? extends K, ? extends V> map);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#invalidate(Object)}.
+     */
+    void invalidate(K key);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#invalidateAll(Iterable)}.
+     */
+    void invalidateAll(Iterable<? extends K> keys);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#invalidateAll()}.
+     */
+    void invalidateAll();
+
+    // This interface intentionally does not support asMap() because we do not want to support cache mutations outside
+    // of the methods explicitly provide as part of this interface. We cannot guarantee the map implementation returned
+    // by Caffeine has the desired behavior. For example, it is impractical to provide a sensible, performant
+    // implementation of methods like Map.compute() for an async cache with in-flight computations.
+    //
+    // It is reasonable for callers to want to obtain snapshots of cache entries, so we provide this method to allow
+    // callers to iterate over the realized cache entries. This method intentionally returns an Iterator to avoid
+    // providing Collection methods which may have surprising behavior.
+    Iterator<Entry<K, V>> entries();
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncCacheImpl.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncCacheImpl.java
@@ -21,6 +21,7 @@ import static com.palantir.logsafe.Preconditions.checkState;
 import com.google.common.collect.Iterators;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import com.palantir.tracing.Tracers;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -35,9 +36,11 @@ import org.jspecify.annotations.Nullable;
 
 class AsyncCacheImpl<K, V> implements AsyncCache<K, V> {
 
+    private final String loadOperation;
     private final com.github.benmanes.caffeine.cache.AsyncCache<K, V> cache;
 
-    AsyncCacheImpl(com.github.benmanes.caffeine.cache.AsyncCache<K, V> cache) {
+    AsyncCacheImpl(String name, com.github.benmanes.caffeine.cache.AsyncCache<K, V> cache) {
+        this.loadOperation = name + " cache load";
         this.cache = cache;
     }
 
@@ -51,8 +54,8 @@ class AsyncCacheImpl<K, V> implements AsyncCache<K, V> {
     @Nullable
     public final V get(K key, Function<? super K, ? extends V> mappingFunction) {
         CompletableFuture<V> future;
-        try (ValueFactory<K, V> valueFactory = new ValueFactory<>(mappingFunction)) {
-            future = cache.get(key, valueFactory);
+        try (Loader<K, V> loader = loader(mappingFunction)) {
+            future = cache.get(key, loader);
         }
 
         return await(future);
@@ -68,9 +71,8 @@ class AsyncCacheImpl<K, V> implements AsyncCache<K, V> {
             Iterable<? extends K> keys,
             Function<? super Set<? extends K>, ? extends Map<? extends K, ? extends V>> mappingFunction) {
         CompletableFuture<Map<K, V>> future;
-        try (ValueFactory<Set<? extends K>, Map<? extends K, ? extends V>> valueFactory =
-                new ValueFactory<>(mappingFunction)) {
-            future = cache.getAll(keys, valueFactory);
+        try (Loader<Set<? extends K>, Map<? extends K, ? extends V>> loader = loader(mappingFunction)) {
+            future = cache.getAll(keys, loader);
         }
 
         return await(future);
@@ -126,22 +128,28 @@ class AsyncCacheImpl<K, V> implements AsyncCache<K, V> {
         }
     }
 
+    @MustBeClosed
+    private <I, O> Loader<I, O> loader(Function<? super I, ? extends O> mappingFunction) {
+        return new Loader<>(loadOperation, mappingFunction);
+    }
+
     // This class exists to ensure that we do not start loading values until the entry is inserted into the cache.
     // This ensures that invalidateAll will remove entries that are being loaded.
     //
     // By default, Caffeine creates async cache entries with something like CompletableFuture.supplyAsync. If the load
     // completes and invalidateAll is called before the entry is inserted into the cache, then we may insert a stale
     // entry into the cache.
-    private static final class ValueFactory<I, O>
-            implements BiFunction<I, Executor, CompletableFuture<O>>, AutoCloseable {
+    private static final class Loader<I, O> implements BiFunction<I, Executor, CompletableFuture<O>>, AutoCloseable {
 
+        private final String loadOperation;
         private final Function<? super I, ? extends O> mappingFunction;
 
         @Nullable
         private Runnable runnable;
 
         @MustBeClosed
-        ValueFactory(Function<? super I, ? extends O> mappingFunction) {
+        Loader(String loadOperation, Function<? super I, ? extends O> mappingFunction) {
+            this.loadOperation = loadOperation;
             this.mappingFunction = mappingFunction;
         }
 
@@ -153,13 +161,13 @@ class AsyncCacheImpl<K, V> implements AsyncCache<K, V> {
 
             runnable = () -> {
                 try {
-                    executor.execute(() -> {
+                    executor.execute(Tracers.wrap(loadOperation, () -> {
                         try {
                             future.complete(mappingFunction.apply(key));
                         } catch (Throwable t) {
                             future.completeExceptionally(t);
                         }
-                    });
+                    }));
                 } catch (Throwable t) {
                     future.obtrudeException(t);
                 }

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncCacheImpl.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncCacheImpl.java
@@ -122,7 +122,7 @@ class AsyncCacheImpl<K, V> implements AsyncCache<K, V> {
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
+            throw new SafeRuntimeException("Cache load interrupted", e);
         }
     }
 

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncCacheImpl.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncCacheImpl.java
@@ -1,0 +1,178 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import static com.palantir.logsafe.Preconditions.checkState;
+
+import com.google.common.collect.Iterators;
+import com.google.errorprone.annotations.MustBeClosed;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
+
+class AsyncCacheImpl<K, V> implements AsyncCache<K, V> {
+
+    private final com.github.benmanes.caffeine.cache.AsyncCache<K, V> cache;
+
+    AsyncCacheImpl(com.github.benmanes.caffeine.cache.AsyncCache<K, V> cache) {
+        this.cache = cache;
+    }
+
+    @Override
+    @Nullable
+    public final V getIfPresent(K key) {
+        return cache.synchronous().getIfPresent(key);
+    }
+
+    @Override
+    @Nullable
+    public final V get(K key, Function<? super K, ? extends V> mappingFunction) {
+        CompletableFuture<V> future;
+        try (ValueFactory<K, V> valueFactory = new ValueFactory<>(mappingFunction)) {
+            future = cache.get(key, valueFactory);
+        }
+
+        return await(future);
+    }
+
+    @Override
+    public final Map<K, V> getAllPresent(Iterable<? extends K> keys) {
+        return cache.synchronous().getAllPresent(keys);
+    }
+
+    @Override
+    public final Map<K, V> getAll(
+            Iterable<? extends K> keys,
+            Function<? super Set<? extends K>, ? extends Map<? extends K, ? extends V>> mappingFunction) {
+        CompletableFuture<Map<K, V>> future;
+        try (ValueFactory<Set<? extends K>, Map<? extends K, ? extends V>> valueFactory =
+                new ValueFactory<>(mappingFunction)) {
+            future = cache.getAll(keys, valueFactory);
+        }
+
+        return await(future);
+    }
+
+    @Override
+    public final void put(K key, V value) {
+        cache.synchronous().put(key, value);
+    }
+
+    @Override
+    public final void putAll(Map<? extends K, ? extends V> map) {
+        cache.synchronous().putAll(map);
+    }
+
+    @Override
+    public final void invalidate(K key) {
+        cache.synchronous().invalidate(key);
+    }
+
+    @Override
+    public final void invalidateAll(Iterable<? extends K> keys) {
+        cache.synchronous().invalidateAll(keys);
+    }
+
+    @Override
+    public final void invalidateAll() {
+        cache.synchronous().invalidateAll();
+    }
+
+    @Override
+    public Iterator<Entry<K, V>> entries() {
+        return Iterators.unmodifiableIterator(
+                cache.synchronous().asMap().entrySet().iterator());
+    }
+
+    private static <T> T await(Future<T> future) {
+        try {
+            return future.get();
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof RuntimeException runtimeException) {
+                runtimeException.addSuppressed(new SafeRuntimeException("Cache load failed"));
+                throw runtimeException;
+            } else if (e.getCause() instanceof Error error) {
+                error.addSuppressed(new SafeRuntimeException("Cache load failed"));
+                throw error;
+            } else {
+                throw new SafeRuntimeException("Cache load failed", e.getCause());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    // This class exists to ensure that we do not start loading values until the entry is inserted into the cache.
+    // This ensures that invalidateAll will remove entries that are being loaded.
+    //
+    // By default, Caffeine creates async cache entries with something like CompletableFuture.supplyAsync. If the load
+    // completes and invalidateAll is called before the entry is inserted into the cache, then we may insert a stale
+    // entry into the cache.
+    private static final class ValueFactory<I, O>
+            implements BiFunction<I, Executor, CompletableFuture<O>>, AutoCloseable {
+
+        private final Function<? super I, ? extends O> mappingFunction;
+
+        @Nullable
+        private Runnable runnable;
+
+        @MustBeClosed
+        ValueFactory(Function<? super I, ? extends O> mappingFunction) {
+            this.mappingFunction = mappingFunction;
+        }
+
+        @Override
+        public CompletableFuture<O> apply(I key, Executor executor) {
+            checkState(runnable == null);
+
+            CompletableFuture<O> future = new CompletableFuture<>();
+
+            runnable = () -> {
+                try {
+                    executor.execute(() -> {
+                        try {
+                            future.complete(mappingFunction.apply(key));
+                        } catch (Throwable t) {
+                            future.completeExceptionally(t);
+                        }
+                    });
+                } catch (Throwable t) {
+                    future.obtrudeException(t);
+                }
+            };
+
+            return future;
+        }
+
+        @Override
+        public void close() {
+            if (runnable != null) {
+                runnable.run();
+            }
+        }
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncLoadingCache.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncLoadingCache.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import org.jspecify.annotations.Nullable;
+
+public interface AsyncLoadingCache<K, V> extends AsyncCache<K, V> {
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.LoadingCache#get(Object)}.
+     */
+    @Nullable
+    V get(K key);
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncLoadingCacheImpl.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncLoadingCacheImpl.java
@@ -23,8 +23,9 @@ class AsyncLoadingCacheImpl<K, V> extends AsyncCacheImpl<K, V> implements AsyncL
 
     private final Function<K, V> mappingFunction;
 
-    AsyncLoadingCacheImpl(com.github.benmanes.caffeine.cache.AsyncCache<K, V> cache, CacheLoader<K, V> cacheLoader) {
-        super(cache);
+    AsyncLoadingCacheImpl(
+            String name, com.github.benmanes.caffeine.cache.AsyncCache<K, V> cache, CacheLoader<K, V> cacheLoader) {
+        super(name, cache);
         this.mappingFunction = CacheLoaders.newMappingFunction(cacheLoader);
     }
 

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncLoadingCacheImpl.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/AsyncLoadingCacheImpl.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
+
+class AsyncLoadingCacheImpl<K, V> extends AsyncCacheImpl<K, V> implements AsyncLoadingCache<K, V> {
+
+    private final Function<K, V> mappingFunction;
+
+    AsyncLoadingCacheImpl(com.github.benmanes.caffeine.cache.AsyncCache<K, V> cache, CacheLoader<K, V> cacheLoader) {
+        super(cache);
+        this.mappingFunction = CacheLoaders.newMappingFunction(cacheLoader);
+    }
+
+    @Override
+    @Nullable
+    public final V get(K key) {
+        return get(key, mappingFunction);
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/BulkCacheLoader.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/BulkCacheLoader.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.Nullable;
+
+public interface BulkCacheLoader<K, V> extends CacheLoader<K, V> {
+
+    @Override
+    @Nullable
+    default V load(K key) {
+        return loadAll(Set.of(key)).get(key);
+    }
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.CacheLoader#loadAll(Set)}.
+     */
+    Map<K, V> loadAll(Set<K> keys);
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/Cache.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/Cache.java
@@ -1,0 +1,82 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+
+public enum Cache {
+    ;
+
+    @CheckReturnValue
+    public static <K, V> NameBuilder<K, V> builder() {
+        return new CacheBuilder<>();
+    }
+
+    @CheckReturnValue
+    public interface NameBuilder<K, V> {
+
+        SizeBuilder<K, V> name(@CompileTimeConstant String name);
+    }
+
+    @CheckReturnValue
+    public interface SizeBuilder<K, V> {
+
+        ExpiryBuilder<K, V> maximumSize(long maximumSize);
+
+        ExpiryBuilder<K, V> maximumSize(long maximumSize, Weigher<? super K, ? super V> weigher);
+    }
+
+    @CheckReturnValue
+    public interface ExpiryBuilder<K, V> {
+
+        MetricsBuilder<K, V> expiry(Expiry<? super K, ? super V> expiry);
+
+        MetricsBuilder<K, V> noExpiry();
+    }
+
+    @CheckReturnValue
+    public interface MetricsBuilder<K, V> {
+
+        ExecutorBuilder<K, V> metrics(TaggedMetricRegistry taggedMetrics);
+
+        ExecutorBuilder<K, V> noMetrics();
+    }
+
+    @CheckReturnValue
+    public interface ExecutorBuilder<K, V> {
+
+        Builder<K, V> executor(ExecutorFactory executorFactory);
+    }
+
+    @CheckReturnValue
+    public interface Builder<K, V> {
+
+        Builder<K, V> ticker(Ticker ticker);
+
+        SyncCache<K, V> buildSync();
+
+        SyncLoadingCache<K, V> buildSyncWithLoader(CacheLoader<K, V> cacheLoader);
+
+        AsyncCache<K, V> buildAsync();
+
+        AsyncLoadingCache<K, V> buildAsyncWithLoader(CacheLoader<K, V> cacheLoader);
+
+        AsyncBulkLoadingCache<K, V> buildAsyncWithBulkLoader(BulkCacheLoader<K, V> cacheLoader);
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/CacheBuilder.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/CacheBuilder.java
@@ -129,17 +129,17 @@ final class CacheBuilder<K, V>
 
     @Override
     public AsyncCache<K, V> buildAsync() {
-        return new AsyncCacheImpl<>(buildAsyncCache());
+        return new AsyncCacheImpl<>(checkNotNull(name), buildAsyncCache());
     }
 
     @Override
     public AsyncLoadingCache<K, V> buildAsyncWithLoader(CacheLoader<K, V> cacheLoader) {
-        return new AsyncLoadingCacheImpl<>(buildAsyncCache(), cacheLoader);
+        return new AsyncLoadingCacheImpl<>(checkNotNull(name), buildAsyncCache(), cacheLoader);
     }
 
     @Override
     public AsyncBulkLoadingCache<K, V> buildAsyncWithBulkLoader(BulkCacheLoader<K, V> cacheLoader) {
-        return new AsyncBulkLoadingCacheImpl<>(buildAsyncCache(), cacheLoader);
+        return new AsyncBulkLoadingCacheImpl<>(checkNotNull(name), buildAsyncCache(), cacheLoader);
     }
 
     private com.github.benmanes.caffeine.cache.Cache<K, V> buildSyncCache() {
@@ -156,14 +156,14 @@ final class CacheBuilder<K, V>
             Function<C, com.github.benmanes.caffeine.cache.Cache<K, V>> synchronous) {
         CacheStats cacheStats;
         if (taggedMetrics != null) {
-            cacheStats = CacheStats.of(taggedMetrics, checkNotNull(name, "name"));
+            cacheStats = CacheStats.of(taggedMetrics, checkNotNull(name));
         } else {
             cacheStats = null;
         }
 
         Caffeine<K, V> builder = ((Caffeine<K, V>) Caffeine.newBuilder())
                 .maximumSize(maximumSize)
-                .executor(checkNotNull(executorFactory, "executorFactory").create(name + "-cache"));
+                .executor(checkNotNull(executorFactory).create(name + "-cache"));
         if (weigher != null) {
             builder = builder.weigher(new WeigherAdapter<>(weigher));
         }

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/CacheBuilder.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/CacheBuilder.java
@@ -1,0 +1,242 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import static com.palantir.logsafe.Preconditions.checkArgument;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.base.CharMatcher;
+import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.tritium.metrics.caffeine.CacheStats;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
+
+@SuppressWarnings("HiddenField")
+final class CacheBuilder<K, V>
+        implements Cache.NameBuilder<K, V>,
+                Cache.SizeBuilder<K, V>,
+                Cache.ExpiryBuilder<K, V>,
+                Cache.MetricsBuilder<K, V>,
+                Cache.ExecutorBuilder<K, V>,
+                Cache.Builder<K, V> {
+
+    private static final CharMatcher NAME_MATCHER = CharMatcher.inRange('a', 'z')
+            .or(CharMatcher.inRange('0', '9'))
+            .or(CharMatcher.is('-'))
+            .precomputed();
+
+    @Nullable
+    private String name;
+
+    private long maximumSize;
+
+    @Nullable
+    private Weigher<? super K, ? super V> weigher;
+
+    @Nullable
+    private Expiry<? super K, ? super V> expiry;
+
+    @Nullable
+    private ExecutorFactory executorFactory;
+
+    @Nullable
+    private TaggedMetricRegistry taggedMetrics;
+
+    @Nullable
+    private Ticker ticker;
+
+    @Override
+    public Cache.SizeBuilder<K, V> name(@CompileTimeConstant String name) {
+        checkArgument(NAME_MATCHER.matchesAllOf(name));
+        this.name = checkNotNull(name, "name");
+        return this;
+    }
+
+    @Override
+    public Cache.ExpiryBuilder<K, V> maximumSize(long maximumSize) {
+        this.maximumSize = checkNotNull(maximumSize, "maximumSize");
+        return this;
+    }
+
+    @Override
+    public Cache.ExpiryBuilder<K, V> maximumSize(long maximumSize, Weigher<? super K, ? super V> weigher) {
+        this.maximumSize = checkNotNull(maximumSize, "maximumSize");
+        this.weigher = checkNotNull(weigher, "weigher");
+        return this;
+    }
+
+    @Override
+    public Cache.MetricsBuilder<K, V> expiry(Expiry<? super K, ? super V> expiry) {
+        this.expiry = checkNotNull(expiry, "expiry");
+        return this;
+    }
+
+    @Override
+    public Cache.MetricsBuilder<K, V> noExpiry() {
+        this.expiry = null;
+        return this;
+    }
+
+    @Override
+    public Cache.ExecutorBuilder<K, V> metrics(TaggedMetricRegistry taggedMetrics) {
+        this.taggedMetrics = checkNotNull(taggedMetrics, "taggedMetrics");
+        return this;
+    }
+
+    @Override
+    public Cache.ExecutorBuilder<K, V> noMetrics() {
+        this.taggedMetrics = null;
+        return this;
+    }
+
+    @Override
+    public Cache.Builder<K, V> executor(ExecutorFactory executorFactory) {
+        this.executorFactory = checkNotNull(executorFactory, "executorFactory");
+        return this;
+    }
+
+    @Override
+    public Cache.Builder<K, V> ticker(Ticker ticker) {
+        this.ticker = checkNotNull(ticker, "ticker");
+        return this;
+    }
+
+    @Override
+    public SyncCache<K, V> buildSync() {
+        return new SyncCacheImpl<>(buildSyncCache());
+    }
+
+    @Override
+    public SyncLoadingCache<K, V> buildSyncWithLoader(CacheLoader<K, V> cacheLoader) {
+        return new SyncLoadingCacheImpl<>(buildSyncCache(), cacheLoader);
+    }
+
+    @Override
+    public AsyncCache<K, V> buildAsync() {
+        return new AsyncCacheImpl<>(buildAsyncCache());
+    }
+
+    @Override
+    public AsyncLoadingCache<K, V> buildAsyncWithLoader(CacheLoader<K, V> cacheLoader) {
+        return new AsyncLoadingCacheImpl<>(buildAsyncCache(), cacheLoader);
+    }
+
+    @Override
+    public AsyncBulkLoadingCache<K, V> buildAsyncWithBulkLoader(BulkCacheLoader<K, V> cacheLoader) {
+        return new AsyncBulkLoadingCacheImpl<>(buildAsyncCache(), cacheLoader);
+    }
+
+    private com.github.benmanes.caffeine.cache.Cache<K, V> buildSyncCache() {
+        return buildCache(Caffeine::build, Function.identity());
+    }
+
+    private com.github.benmanes.caffeine.cache.AsyncCache<K, V> buildAsyncCache() {
+        return buildCache(Caffeine::buildAsync, com.github.benmanes.caffeine.cache.AsyncCache::synchronous);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <C> C buildCache(
+            Function<Caffeine<K, V>, C> build,
+            Function<C, com.github.benmanes.caffeine.cache.Cache<K, V>> synchronous) {
+        CacheStats cacheStats;
+        if (taggedMetrics != null) {
+            cacheStats = CacheStats.of(taggedMetrics, checkNotNull(name, "name"));
+        } else {
+            cacheStats = null;
+        }
+
+        Caffeine<K, V> builder = ((Caffeine<K, V>) Caffeine.newBuilder())
+                .maximumSize(maximumSize)
+                .executor(checkNotNull(executorFactory, "executorFactory").create(name + "-cache"));
+        if (weigher != null) {
+            builder = builder.weigher(new WeigherAdapter<>(weigher));
+        }
+        if (expiry != null) {
+            builder = builder.expireAfter(new ExpiryAdapter<>(expiry));
+        }
+        if (ticker != null) {
+            builder = builder.ticker(new TickerAdapter(ticker));
+        }
+        if (cacheStats != null) {
+            builder = builder.recordStats(cacheStats);
+        }
+
+        C cache = build.apply(builder);
+
+        com.github.benmanes.caffeine.cache.Cache<K, V> synchronousCache = synchronous.apply(cache);
+
+        if (cacheStats != null) {
+            cacheStats.register(synchronousCache);
+        }
+
+        return cache;
+    }
+
+    private static final class ExpiryAdapter<K, V> implements com.github.benmanes.caffeine.cache.Expiry<K, V> {
+
+        private final Expiry<? super K, ? super V> expiry;
+
+        private ExpiryAdapter(Expiry<? super K, ? super V> expiry) {
+            this.expiry = expiry;
+        }
+
+        @Override
+        public long expireAfterCreate(K key, V value, long currentTime) {
+            return expiry.expireAfterCreate(key, value, currentTime);
+        }
+
+        @Override
+        public long expireAfterUpdate(K key, V value, long currentTime, long currentDuration) {
+            return expiry.expireAfterUpdate(key, value, currentTime, currentDuration);
+        }
+
+        @Override
+        public long expireAfterRead(K key, V value, long currentTime, long currentDuration) {
+            return expiry.expireAfterRead(key, value, currentTime, currentDuration);
+        }
+    }
+
+    private static final class WeigherAdapter<K, V> implements com.github.benmanes.caffeine.cache.Weigher<K, V> {
+
+        private final Weigher<? super K, ? super V> weigher;
+
+        private WeigherAdapter(Weigher<? super K, ? super V> weigher) {
+            this.weigher = weigher;
+        }
+
+        @Override
+        public int weigh(K key, V value) {
+            return weigher.weigh(key, value);
+        }
+    }
+
+    private static final class TickerAdapter implements com.github.benmanes.caffeine.cache.Ticker {
+
+        private final Ticker ticker;
+
+        private TickerAdapter(Ticker ticker) {
+            this.ticker = ticker;
+        }
+
+        @Override
+        public long read() {
+            return ticker.read();
+        }
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/CacheLoader.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/CacheLoader.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import org.jspecify.annotations.Nullable;
+
+public interface CacheLoader<K, V> {
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.CacheLoader#load(Object)}.
+     */
+    @Nullable
+    V load(K key);
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/CacheLoaders.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/CacheLoaders.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+enum CacheLoaders {
+    ;
+
+    static <K, V> Function<K, V> newMappingFunction(CacheLoader<K, V> cacheLoader) {
+        return cacheLoader::load;
+    }
+
+    static <K, V> Function<Set<? extends K>, Map<K, V>> newBulkMappingFunction(BulkCacheLoader<K, V> cacheLoader) {
+        // Safely upcast Set<? extends K> to Set<K>
+        return keys -> cacheLoader.loadAll(Collections.unmodifiableSet(keys));
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/DirectExecutorFactory.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/DirectExecutorFactory.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.concurrent.Executor;
+
+public enum DirectExecutorFactory implements ExecutorFactory {
+    INSTANCE;
+
+    @Override
+    public Executor create(String _name) {
+        return MoreExecutors.directExecutor();
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/ExecutorFactory.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/ExecutorFactory.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import java.util.concurrent.Executor;
+
+public interface ExecutorFactory {
+
+    Executor create(String name);
+
+    static ExecutorFactory direct() {
+        return DirectExecutorFactory.INSTANCE;
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/Expiry.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/Expiry.java
@@ -1,0 +1,51 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.tritium.cache;
+
+import java.time.Duration;
+import java.util.function.BiFunction;
+
+public interface Expiry<K, V> {
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Expiry#expireAfterCreate(Object, Object, long)}.
+     */
+    long expireAfterCreate(K key, V value, long currentTime);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Expiry#expireAfterUpdate(Object, Object, long, long)}.
+     */
+    long expireAfterUpdate(K key, V value, long currentTime, long currentDuration);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Expiry#expireAfterRead(Object, Object, long, long)}.
+     */
+    long expireAfterRead(K key, V value, long currentTime, long currentDuration);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Expiry#accessing(BiFunction)}.
+     */
+    static <K, V> Expiry<K, V> afterAccess(Duration duration) {
+        return new ExpiryAfterAccess<>(duration);
+    }
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Expiry#writing(BiFunction)}.
+     */
+    static <K, V> Expiry<K, V> afterWrite(Duration duration) {
+        return new ExpiryAfterWrite<>(duration);
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/ExpiryAfterAccess.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/ExpiryAfterAccess.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import java.time.Duration;
+
+final class ExpiryAfterAccess<K, V> implements Expiry<K, V> {
+
+    private final long expireAfterNanos;
+
+    ExpiryAfterAccess(Duration duration) {
+        this.expireAfterNanos = duration.toNanos();
+    }
+
+    @Override
+    public long expireAfterCreate(K _key, V _value, long _currentTime) {
+        return expireAfterNanos;
+    }
+
+    @Override
+    public long expireAfterUpdate(K _key, V _value, long _currentTime, long _currentDuration) {
+        return expireAfterNanos;
+    }
+
+    @Override
+    public long expireAfterRead(K _key, V _value, long _currentTime, long _currentDuration) {
+        return expireAfterNanos;
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/ExpiryAfterWrite.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/ExpiryAfterWrite.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import java.time.Duration;
+
+final class ExpiryAfterWrite<K, V> implements Expiry<K, V> {
+
+    private final long expireAfterNanos;
+
+    ExpiryAfterWrite(Duration duration) {
+        this.expireAfterNanos = duration.toNanos();
+    }
+
+    @Override
+    public long expireAfterCreate(K _key, V _value, long _currentTime) {
+        return expireAfterNanos;
+    }
+
+    @Override
+    public long expireAfterUpdate(K _key, V _value, long _currentTime, long _currentDuration) {
+        return expireAfterNanos;
+    }
+
+    @Override
+    public long expireAfterRead(K _key, V _value, long _currentTime, long currentDuration) {
+        return currentDuration;
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/SingletonWeigher.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/SingletonWeigher.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+enum SingletonWeigher implements Weigher<Object, Object>, com.github.benmanes.caffeine.cache.Weigher<Object, Object> {
+    INSTANCE;
+
+    @Override
+    public int weigh(Object _key, Object _value) {
+        return 1;
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/SyncCache.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/SyncCache.java
@@ -1,0 +1,87 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
+
+public interface SyncCache<K, V> {
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#getIfPresent(Object)}.
+     */
+    @Nullable
+    V getIfPresent(K key);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#get(Object, Function)}.
+     */
+    @Nullable
+    V get(K key, Function<? super K, ? extends V> mappingFunction);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#getAllPresent(Iterable)}.
+     */
+    Map<K, V> getAllPresent(Iterable<? extends K> keys);
+
+    // This interface intentionally does not support getAll() because it is does not provide the desired linearizability
+    // properties. The loads in getAll() are performed outside of the backing concurrent map locks and thus will not be
+    // removed by a concurrent invalidate() request. This can lead to surprising behavior where outdated entries are
+    // added to the cache after an invalidation has occurred.
+    //
+    // See https://github.com/ben-manes/caffeine/issues/1739#issuecomment-2200862708.
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#put(Object, Object)}.
+     */
+    void put(K key, V value);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#putAll(Map)}.
+     */
+    void putAll(Map<? extends K, ? extends V> map);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#invalidate(Object)}.
+     */
+    void invalidate(K key);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Cache#invalidateAll(Iterable)}.
+     */
+    void invalidateAll(Iterable<? extends K> keys);
+
+    // This interface intentionally does not support invalidateAll() because it is does not provide the desired
+    // linearizability properties. The cache does not have visibility into in-flight computations (because the backing
+    // concurrent map does not expose them) and thus cannot invalidate these in-flight computations. This can lead to
+    // surprising behavior where outdated entries are added to the cache after an invalidation has occurred.
+    //
+    // See https://github.com/ben-manes/caffeine/issues/1739#issuecomment-2200862708.
+
+    // This interface intentionally does not support asMap() because we do not want to support cache mutations outside
+    // of the methods explicitly provide as part of this interface. We cannot guarantee the map implementation returned
+    // by Caffeine has the desired behavior. For example, it is impractical to provide a sensible, performant
+    // implementation of methods like Map.compute() for an async cache with in-flight computations.
+    //
+    // It is reasonable for callers to want to obtain snapshots of cache entries, so we provide this method to allow
+    // callers to iterate over the realized cache entries. This method intentionally returns an Iterator to avoid
+    // providing Collection methods which may have surprising behavior.
+    Iterator<Entry<K, V>> entries();
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/SyncCacheImpl.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/SyncCacheImpl.java
@@ -1,0 +1,75 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import com.google.common.collect.Iterators;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
+
+class SyncCacheImpl<K, V> implements SyncCache<K, V> {
+
+    private final com.github.benmanes.caffeine.cache.Cache<K, V> cache;
+
+    SyncCacheImpl(com.github.benmanes.caffeine.cache.Cache<K, V> cache) {
+        this.cache = cache;
+    }
+
+    @Override
+    @Nullable
+    public V getIfPresent(K key) {
+        return cache.getIfPresent(key);
+    }
+
+    @Override
+    @Nullable
+    public V get(K key, Function<? super K, ? extends V> mappingFunction) {
+        return cache.get(key, mappingFunction);
+    }
+
+    @Override
+    public Map<K, V> getAllPresent(Iterable<? extends K> keys) {
+        return cache.getAllPresent(keys);
+    }
+
+    @Override
+    public void put(K key, V value) {
+        cache.put(key, value);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> map) {
+        cache.putAll(map);
+    }
+
+    @Override
+    public void invalidate(K key) {
+        cache.invalidate(key);
+    }
+
+    @Override
+    public void invalidateAll(Iterable<? extends K> keys) {
+        cache.invalidateAll(keys);
+    }
+
+    @Override
+    public Iterator<Entry<K, V>> entries() {
+        return Iterators.unmodifiableIterator(cache.asMap().entrySet().iterator());
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/SyncLoadingCache.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/SyncLoadingCache.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import org.jspecify.annotations.Nullable;
+
+public interface SyncLoadingCache<K, V> extends SyncCache<K, V> {
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.LoadingCache#get(Object)}.
+     */
+    @Nullable
+    V get(K key);
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/SyncLoadingCacheImpl.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/SyncLoadingCacheImpl.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
+
+class SyncLoadingCacheImpl<K, V> extends SyncCacheImpl<K, V> implements SyncLoadingCache<K, V> {
+
+    private final Function<K, V> mappingFunction;
+
+    SyncLoadingCacheImpl(com.github.benmanes.caffeine.cache.Cache<K, V> cache, CacheLoader<K, V> cacheLoader) {
+        super(cache);
+        this.mappingFunction = CacheLoaders.newMappingFunction(cacheLoader);
+    }
+
+    @Override
+    @Nullable
+    public final V get(K key) {
+        return get(key, mappingFunction);
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/SystemTicker.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/SystemTicker.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+enum SystemTicker implements Ticker {
+    INSTANCE;
+
+    @Override
+    public long read() {
+        return System.nanoTime();
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/Ticker.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/Ticker.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+public interface Ticker {
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Ticker#read()}.
+     */
+    long read();
+
+    static Ticker system() {
+        return SystemTicker.INSTANCE;
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/Weigher.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/Weigher.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.tritium.cache;
+
+public interface Weigher<K, V> {
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Weigher#weigh(Object, Object)}.
+     */
+    int weigh(K key, V value);
+
+    /**
+     * See {@link com.github.benmanes.caffeine.cache.Weigher#singletonWeigher()}.
+     */
+    @SuppressWarnings("unchecked")
+    static <K, V> Weigher<K, V> singleton() {
+        return (Weigher<K, V>) SingletonWeigher.INSTANCE;
+    }
+}

--- a/tritium-cache/src/main/java/com/palantir/tritium/cache/package-info.java
+++ b/tritium-cache/src/main/java/com/palantir/tritium/cache/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.palantir.tritium.cache;
+
+import org.jspecify.annotations.NullMarked;

--- a/tritium-cache/src/test/java/com/palantir/tritium/cache/CacheTest.java
+++ b/tritium-cache/src/test/java/com/palantir/tritium/cache/CacheTest.java
@@ -19,6 +19,12 @@ package com.palantir.tritium.cache;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.tracing.Observability;
+import com.palantir.tracing.Tracer;
+import com.palantir.tracing.Tracers;
+import com.palantir.tracing.api.OpenSpan;
+import com.palantir.tracing.api.Span;
+import com.palantir.tracing.api.SpanType;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
@@ -42,6 +48,7 @@ final class CacheTest {
 
     @AfterEach
     void after() {
+        Tracer.getAndClearTrace();
         executor.shutdownNow();
     }
 
@@ -347,6 +354,56 @@ final class CacheTest {
         finishLatch.countDown();
 
         assertThat(future).succeedsWithin(1, TimeUnit.SECONDS).isEqualTo("value2");
+    }
+
+    @Test
+    void tracing_sync() throws Exception {
+        SyncCache<String, String> cache = Cache.<String, String>builder()
+                .name("test")
+                .maximumSize(10)
+                .noExpiry()
+                .noMetrics()
+                .executor(_name -> executor)
+                .buildSync();
+
+        String traceId = Tracers.randomId();
+        Tracer.initTraceWithSpan(Observability.SAMPLE, traceId, "root", SpanType.LOCAL);
+
+        OpenSpan parentSpan = Tracer.startSpan("parent");
+
+        cache.get("key", _key -> {
+            Span span = Tracer.completeSpan().orElseThrow();
+            assertThat(span.getTraceId()).isEqualTo(traceId);
+            assertThat(span.getSpanId()).isEqualTo(parentSpan.getSpanId());
+            assertThat(span.getOperation()).isEqualTo("parent");
+
+            return "value";
+        });
+    }
+
+    @Test
+    void tracing_async() throws Exception {
+        AsyncCache<String, String> cache = Cache.<String, String>builder()
+                .name("test")
+                .maximumSize(10)
+                .noExpiry()
+                .noMetrics()
+                .executor(_name -> executor)
+                .buildAsync();
+
+        String traceId = Tracers.randomId();
+        Tracer.initTraceWithSpan(Observability.SAMPLE, traceId, "root", SpanType.LOCAL);
+
+        OpenSpan parentSpan = Tracer.startSpan("parent");
+
+        cache.get("key", _key -> {
+            Span span = Tracer.completeSpan().orElseThrow();
+            assertThat(span.getTraceId()).isEqualTo(traceId);
+            assertThat(span.getParentSpanId()).contains(parentSpan.getSpanId());
+            assertThat(span.getOperation()).isEqualTo("test cache load");
+
+            return "value";
+        });
     }
 
     private interface DefaultExpiry<K, V> extends Expiry<K, V> {

--- a/tritium-cache/src/test/java/com/palantir/tritium/cache/CacheTest.java
+++ b/tritium-cache/src/test/java/com/palantir/tritium/cache/CacheTest.java
@@ -1,0 +1,365 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class CacheTest {
+
+    private ExecutorService executor;
+
+    @BeforeEach
+    void before() {
+        executor = Executors.newCachedThreadPool();
+    }
+
+    @AfterEach
+    void after() {
+        executor.shutdownNow();
+    }
+
+    @Test
+    void maximumSize_sync() throws Exception {
+        SyncCache<String, String> cache = Cache.<String, String>builder()
+                .name("test")
+                .maximumSize(1)
+                .noExpiry()
+                .noMetrics()
+                .executor(_name -> executor)
+                .buildSync();
+
+        cache.put("key1", "value1");
+
+        assertThat(cache.getAllPresent(Set.of("key1"))).hasSize(1);
+
+        cache.put("key2", "value2");
+
+        // maximumSize is enforced by a background task
+        executor.shutdown();
+        assertThat(executor.awaitTermination(1, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(cache.getAllPresent(Set.of("key1", "key2"))).hasSize(1);
+    }
+
+    @Test
+    void maximumSize_async() throws Exception {
+        AsyncCache<String, String> cache = Cache.<String, String>builder()
+                .name("test")
+                .maximumSize(1)
+                .noExpiry()
+                .noMetrics()
+                .executor(_name -> executor)
+                .buildAsync();
+
+        cache.put("key1", "value1");
+
+        assertThat(cache.getAllPresent(Set.of("key1"))).hasSize(1);
+
+        cache.put("key2", "value2");
+
+        // maximumSize is enforced by a background task
+        executor.shutdown();
+        assertThat(executor.awaitTermination(1, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(cache.getAllPresent(Set.of("key1", "key2"))).hasSize(1);
+    }
+
+    @Test
+    void expiry_afterCreate_sync() {
+        Expiry<String, String> expiry = new DefaultExpiry<>() {
+            @Override
+            public long expireAfterCreate(String _key, String _value, long _currentTime) {
+                return 1;
+            }
+        };
+        FakeTicker ticker = new FakeTicker();
+
+        SyncCache<String, String> cache = Cache.<String, String>builder()
+                .name("test")
+                .maximumSize(1)
+                .expiry(expiry)
+                .noMetrics()
+                .executor(_name -> executor)
+                .ticker(ticker)
+                .buildSync();
+
+        cache.put("key", "value");
+
+        assertThat(cache.getIfPresent("key")).isEqualTo("value");
+
+        ticker.plus(Duration.ofNanos(1));
+
+        assertThat(cache.getIfPresent("key")).isNull();
+    }
+
+    @Test
+    void expiry_afterCreate_async() {
+        Expiry<String, String> expiry = new DefaultExpiry<>() {
+            @Override
+            public long expireAfterCreate(String _key, String _value, long _currentTime) {
+                return 1;
+            }
+        };
+        FakeTicker ticker = new FakeTicker();
+
+        AsyncCache<String, String> cache = Cache.<String, String>builder()
+                .name("test")
+                .maximumSize(1)
+                .expiry(expiry)
+                .noMetrics()
+                .executor(_name -> executor)
+                .ticker(ticker)
+                .buildAsync();
+
+        cache.put("key", "value");
+
+        assertThat(cache.getIfPresent("key")).isEqualTo("value");
+
+        ticker.plus(Duration.ofNanos(1));
+
+        assertThat(cache.getIfPresent("key1")).isNull();
+    }
+
+    @Test
+    void expiry_afterUpdate_sync() {
+        Expiry<String, String> expiry = new DefaultExpiry<>() {
+            @Override
+            public long expireAfterUpdate(String _key, String _value, long _currentTime, long _currentDuration) {
+                return 1;
+            }
+        };
+        FakeTicker ticker = new FakeTicker();
+
+        SyncCache<String, String> cache = Cache.<String, String>builder()
+                .name("test")
+                .maximumSize(1)
+                .expiry(expiry)
+                .noMetrics()
+                .executor(_name -> executor)
+                .ticker(ticker)
+                .buildSync();
+
+        cache.put("key", "value1");
+
+        assertThat(cache.getIfPresent("key")).isEqualTo("value1");
+
+        ticker.plus(Duration.ofNanos(1));
+
+        assertThat(cache.getIfPresent("key")).isEqualTo("value1");
+
+        cache.put("key", "value2");
+
+        assertThat(cache.getIfPresent("key")).isEqualTo("value2");
+
+        ticker.plus(Duration.ofNanos(1));
+
+        assertThat(cache.getIfPresent("key")).isNull();
+    }
+
+    @Test
+    void expiry_afterUpdate_async() {
+        Expiry<String, String> expiry = new DefaultExpiry<>() {
+            @Override
+            public long expireAfterUpdate(String _key, String _value, long _currentTime, long _currentDuration) {
+                return 1;
+            }
+        };
+        FakeTicker ticker = new FakeTicker();
+
+        AsyncCache<String, String> cache = Cache.<String, String>builder()
+                .name("test")
+                .maximumSize(1)
+                .expiry(expiry)
+                .noMetrics()
+                .executor(_name -> executor)
+                .ticker(ticker)
+                .buildAsync();
+
+        cache.put("key", "value1");
+
+        assertThat(cache.getIfPresent("key")).isEqualTo("value1");
+
+        ticker.plus(Duration.ofNanos(1));
+
+        assertThat(cache.getIfPresent("key")).isEqualTo("value1");
+
+        cache.put("key", "value2");
+
+        assertThat(cache.getIfPresent("key")).isEqualTo("value2");
+
+        ticker.plus(Duration.ofNanos(1));
+
+        assertThat(cache.getIfPresent("key")).isNull();
+    }
+
+    @Test
+    void expiry_afterRead_sync() {
+        Expiry<String, String> expiry = new DefaultExpiry<>() {
+            @Override
+            public long expireAfterRead(String _key, String _value, long _currentTime, long _currentDuration) {
+                return 1;
+            }
+        };
+        FakeTicker ticker = new FakeTicker();
+
+        SyncCache<String, String> cache = Cache.<String, String>builder()
+                .name("test")
+                .maximumSize(1)
+                .expiry(expiry)
+                .noMetrics()
+                .executor(_name -> executor)
+                .ticker(ticker)
+                .buildSync();
+
+        cache.put("key", "value1");
+
+        ticker.plus(Duration.ofNanos(1));
+
+        assertThat(cache.getIfPresent("key")).isEqualTo("value1");
+
+        ticker.plus(Duration.ofNanos(1));
+
+        assertThat(cache.getIfPresent("key")).isNull();
+    }
+
+    @Test
+    void expiry_afterRead_async() {
+        Expiry<String, String> expiry = new DefaultExpiry<>() {
+            @Override
+            public long expireAfterRead(String _key, String _value, long _currentTime, long _currentDuration) {
+                return 1;
+            }
+        };
+        FakeTicker ticker = new FakeTicker();
+
+        AsyncCache<String, String> cache = Cache.<String, String>builder()
+                .name("test")
+                .maximumSize(1)
+                .expiry(expiry)
+                .noMetrics()
+                .executor(_name -> executor)
+                .ticker(ticker)
+                .buildAsync();
+
+        cache.put("key", "value1");
+
+        ticker.plus(Duration.ofNanos(1));
+
+        assertThat(cache.getIfPresent("key")).isEqualTo("value1");
+
+        ticker.plus(Duration.ofNanos(1));
+
+        assertThat(cache.getIfPresent("key")).isNull();
+    }
+
+    @Test
+    void entries_sync() {
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch finishLatch = new CountDownLatch(1);
+
+        SyncCache<String, String> cache = Cache.<String, String>builder()
+                .name("test")
+                .maximumSize(10)
+                .noExpiry()
+                .noMetrics()
+                .executor(_name -> executor)
+                .buildSync();
+
+        cache.put("key1", "value1");
+
+        Future<String> future = executor.submit(() -> {
+            return cache.get("key2", _key -> {
+                startLatch.countDown();
+                Uninterruptibles.awaitUninterruptibly(finishLatch);
+                return "value2";
+            });
+        });
+
+        assertThat(cache.entries())
+                .isUnmodifiable()
+                .toIterable()
+                .containsExactlyInAnyOrder(Map.entry("key1", "value1"));
+
+        finishLatch.countDown();
+
+        assertThat(future).succeedsWithin(1, TimeUnit.SECONDS).isEqualTo("value2");
+    }
+
+    @Test
+    void entries_async() {
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch finishLatch = new CountDownLatch(1);
+
+        AsyncCache<String, String> cache = Cache.<String, String>builder()
+                .name("test")
+                .maximumSize(10)
+                .noExpiry()
+                .noMetrics()
+                .executor(_name -> executor)
+                .buildAsync();
+
+        cache.put("key1", "value1");
+
+        Future<String> future = executor.submit(() -> {
+            return cache.get("key2", _key -> {
+                startLatch.countDown();
+                Uninterruptibles.awaitUninterruptibly(finishLatch);
+                return "value2";
+            });
+        });
+
+        assertThat(cache.entries())
+                .isUnmodifiable()
+                .toIterable()
+                .containsExactlyInAnyOrder(Map.entry("key1", "value1"));
+
+        finishLatch.countDown();
+
+        assertThat(future).succeedsWithin(1, TimeUnit.SECONDS).isEqualTo("value2");
+    }
+
+    private interface DefaultExpiry<K, V> extends Expiry<K, V> {
+
+        @Override
+        default long expireAfterCreate(K _key, V _value, long _currentTime) {
+            return Long.MAX_VALUE;
+        }
+
+        @Override
+        default long expireAfterUpdate(K _key, V _value, long _currentTime, long currentDuration) {
+            return currentDuration;
+        }
+
+        @Override
+        default long expireAfterRead(K _key, V _value, long _currentTime, long currentDuration) {
+            return currentDuration;
+        }
+    }
+}

--- a/tritium-cache/src/test/java/com/palantir/tritium/cache/CacheTest.java
+++ b/tritium-cache/src/test/java/com/palantir/tritium/cache/CacheTest.java
@@ -280,7 +280,7 @@ final class CacheTest {
     }
 
     @Test
-    void entries_sync() {
+    void entries_sync() throws Exception {
         CountDownLatch startLatch = new CountDownLatch(1);
         CountDownLatch finishLatch = new CountDownLatch(1);
 
@@ -302,6 +302,8 @@ final class CacheTest {
             });
         });
 
+        startLatch.await();
+
         assertThat(cache.entries())
                 .isUnmodifiable()
                 .toIterable()
@@ -313,7 +315,7 @@ final class CacheTest {
     }
 
     @Test
-    void entries_async() {
+    void entries_async() throws Exception {
         CountDownLatch startLatch = new CountDownLatch(1);
         CountDownLatch finishLatch = new CountDownLatch(1);
 
@@ -334,6 +336,8 @@ final class CacheTest {
                 return "value2";
             });
         });
+
+        startLatch.await();
 
         assertThat(cache.entries())
                 .isUnmodifiable()

--- a/tritium-cache/src/test/java/com/palantir/tritium/cache/FakeTicker.java
+++ b/tritium-cache/src/test/java/com/palantir/tritium/cache/FakeTicker.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.cache;
+
+import java.time.Duration;
+
+final class FakeTicker implements Ticker {
+
+    private long time = 0;
+
+    @Override
+    public long read() {
+        return time;
+    }
+
+    void plus(Duration duration) {
+        time += duration.toNanos();
+    }
+}

--- a/versions.props
+++ b/versions.props
@@ -12,7 +12,6 @@ com.palantir.safe-logging:* = 3.9.0
 com.palantir.tracing:* = 6.29.0
 com.palantir.javapoet:javapoet = 0.7.0
 com.squareup.okhttp3:* = 5.3.0
-# Keep major.minor metrics version in sync with Apache Spark
 io.dropwizard.metrics:* = 4.2.37
 io.undertow:* = 2.3.20.Final
 net.bytebuddy:* = 1.17.8


### PR DESCRIPTION
This PR aims to provide a simpler, more tailored, and harder to misuse cache API in an effort to avoid many of the pitfalls we find developers running into when using caches.

This code was adapted from a similar API we designed in an internal service.

## Background

The Caffeine API is powerful but has some gotchas:

1. Synchronous loading caches can block the retrieval while other entires we being loaded.

    This is due to the coarse nature of `ConcurrentHashMap` locking. The `Map.compute*` APIs suffer from a similar problem. But when using an in-memory map, this mapping function is typically pure so the critical section is short. But loading values into a cache typically requires I/O, which holds the lock for a much longer period of time.

2. By default, caches use global, shared resources.

    Most notably, the default executor is the `ForkJoinPool.commonPool()`. `ForkJoinPool.commonPool()` is a work-stealing executor that is intended to be used for cooperative multi-tasking. It only has [as many threads as processors](https://github.com/openjdk/jdk/blob/890adb6410dab4606a4f26a942aed02fb2f55387/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java#L2767) - the expectation is that you are not performing blocking I/O on this executor.

    Caffeine uses this executor to load values in async caches and refresh values in both sync and async caches. Loading/refreshing values often requires I/O and these tasks can quickly starve other tasks submitted to `ForkJoinPool.commonPool()`. Nested cache loads introduce the potential for deadlock, although `CompletableFuture` has some [tricks](https://github.com/openjdk/jdk/blob/jdk-21%2B35/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java#L1886-L1887) to avoid deadlocks when using `ForkJoinPool`.

    `Scheduler.systemScheduler()` is another example of a global shared resource. Using this scheduled with a something like a direct executor can hog the single global scheduling thread, delaying the execution of other scheduled tasks.

3. `invalidateAll` does not provide the same guarantees as `ConcurrentHashMap.clear()`.

    `invalidateAll` is not always performed while holding the map's locks. [This Caffeine issue](https://github.com/ben-manes/caffeine/issues/1739) does a good job describing the limitations and the constraints that resulted in this tradeoff.

    This can be problematic. It is common to have caches that we want to clear in response to events indicating the the backing values have changed. But without these guarantees, it's possible that `invalidateAll` will not see entries that have already started to be loaded. These loaders then may load stale values (values before the change that precipitated the invalidation event) into the cache.

## Change in this PR

This PR introduces the `tritium-cache` library without own Cache API and implementations that wrap Caffeine caches in order to provider the enforcement and behavior we desire. The cache API is a mostly drop-in replacement for the subset of the Caffeine API we support and should be sufficient for the vast majority of users.

The cache interfaces, cache implementations, and builder API are pretty straight-forward. There are 3 interfaces:
- `Cache` is a non-loading cache
- `LoadingCache` is a loading cache that supports loading singular values at a time
- `BulkLoadingCache` is a loading cache that supports loading multiple values at a time

Caches are constructed using the builder API defined in `CacheBuilder`. This is a staged builder to force decisions to be explicit, such as:
- Whether a cache is sync or async
- What executor this cache uses
- If this cache records metrics

More considerations are detailed in comments below.
