### PR TITLE
Update JVM metrics to make thread metrics optional

### DIFF
--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -18,6 +18,7 @@ package com.palantir.tritium.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.RatioGauge;
+import com.codahale.metrics.RatioGauge.Ratio;
 import com.codahale.metrics.jvm.ThreadDeadlockDetector;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
@@ -30,6 +31,7 @@ import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.metrics.jvm.InternalJvmMetrics.AttributeUptime_EnablePreview;
 import com.palantir.tritium.metrics.jvm.InternalJvmMetrics.DnsCacheTtlSeconds_Cache;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.lang.Thread.State;
 import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ClassLoadingMXBean;
 import java.lang.management.ManagementFactory;
@@ -50,7 +52,7 @@ import org.jspecify.annotations.Nullable;
 /** {@link JvmMetrics} provides a standard set of metrics for debugging java services. */
 public final class JvmMetrics {
     private static final SafeLogger log = SafeLoggerFactory.get(JvmMetrics.class);
-    private static final RatioGauge.Ratio RATIO_NAN = RatioGauge.Ratio.of(Double.NaN, Double.NaN);
+    private static final Ratio RATIO_NAN = Ratio.of(Double.NaN, Double.NaN);
 
     /**
      * Registers a default set of metrics.
@@ -109,15 +111,14 @@ public final class JvmMetrics {
         ThreadDeadlockDetector deadlockDetector = new ThreadDeadlockDetector(threads);
         metrics.threadsDeadlockCount(
                 () -> deadlockDetector.getDeadlockedThreads().size());
-        Supplier<Map<Thread.State, Integer>> threadsByStateSupplier =
+        Supplier<Map<State, Integer>> threadsByStateSupplier =
                 Suppliers.memoizeWithExpiration(() -> threadsByState(threads), 10, TimeUnit.SECONDS);
-        metrics.threadsNewCount(() -> threadsByStateSupplier.get().getOrDefault(Thread.State.NEW, 0));
-        metrics.threadsRunnableCount(() -> threadsByStateSupplier.get().getOrDefault(Thread.State.RUNNABLE, 0));
-        metrics.threadsBlockedCount(() -> threadsByStateSupplier.get().getOrDefault(Thread.State.BLOCKED, 0));
-        metrics.threadsWaitingCount(() -> threadsByStateSupplier.get().getOrDefault(Thread.State.WAITING, 0));
-        metrics.threadsTimedWaitingCount(
-                () -> threadsByStateSupplier.get().getOrDefault(Thread.State.TIMED_WAITING, 0));
-        metrics.threadsTerminatedCount(() -> threadsByStateSupplier.get().getOrDefault(Thread.State.TERMINATED, 0));
+        metrics.threadsNewCount(() -> threadsByStateSupplier.get().getOrDefault(State.NEW, 0));
+        metrics.threadsRunnableCount(() -> threadsByStateSupplier.get().getOrDefault(State.RUNNABLE, 0));
+        metrics.threadsBlockedCount(() -> threadsByStateSupplier.get().getOrDefault(State.BLOCKED, 0));
+        metrics.threadsWaitingCount(() -> threadsByStateSupplier.get().getOrDefault(State.WAITING, 0));
+        metrics.threadsTimedWaitingCount(() -> threadsByStateSupplier.get().getOrDefault(State.TIMED_WAITING, 0));
+        metrics.threadsTerminatedCount(() -> threadsByStateSupplier.get().getOrDefault(State.TERMINATED, 0));
     }
 
     @VisibleForTesting
@@ -133,19 +134,19 @@ public final class JvmMetrics {
     }
 
     @SuppressWarnings("UnnecessaryLambda") // Avoid allocations in the threads-by-state loop
-    private static final BiFunction<Thread.State, Integer, Integer> incrementThreadState = (_state, input) -> {
+    private static final BiFunction<State, Integer, Integer> incrementThreadState = (_state, input) -> {
         int existingValue = input == null ? 0 : input;
         return existingValue + 1;
     };
 
-    private static Map<Thread.State, Integer> threadsByState(ThreadMXBean threads) {
+    private static Map<State, Integer> threadsByState(ThreadMXBean threads) {
         // max-depth zero to avoid creating stack traces, we're only interested in high level metadata
         ThreadInfo[] loadedThreadInfo = threads.getThreadInfo(threads.getAllThreadIds(), 0);
-        Map<Thread.State, Integer> threadsByState = new EnumMap<>(Thread.State.class);
+        Map<State, Integer> threadsByState = new EnumMap<>(State.class);
         for (ThreadInfo threadInfo : loadedThreadInfo) {
             // Threads may have been destroyed between ThreadMXBean.getAllThreadIds and ThreadMXBean.getThreadInfo
             if (threadInfo != null) {
-                Thread.State threadState = threadInfo.getThreadState();
+                State threadState = threadInfo.getThreadState();
                 if (threadState != null) {
                     threadsByState.compute(threadState, incrementThreadState);
                 }
@@ -192,11 +193,11 @@ public final class JvmMetrics {
         metrics.heapCommitted(nonNegative(() -> memoryBean.getHeapMemoryUsage().getCommitted()));
         metrics.heapUsage(new RatioGauge() {
             @Override
-            protected RatioGauge.Ratio getRatio() {
+            protected Ratio getRatio() {
                 MemoryUsage heapMemoryUsage = memoryBean.getHeapMemoryUsage();
                 double used = heapMemoryUsage.getUsed();
                 double max = heapMemoryUsage.getMax();
-                return (used < 0 || max < 0) ? RATIO_NAN : RatioGauge.Ratio.of(used, max);
+                return (used < 0 || max < 0) ? RATIO_NAN : Ratio.of(used, max);
             }
         });
         // jvm.memory.non-heap
@@ -207,11 +208,11 @@ public final class JvmMetrics {
                 nonNegative(() -> memoryBean.getNonHeapMemoryUsage().getCommitted()));
         metrics.nonHeapUsage(new RatioGauge() {
             @Override
-            protected RatioGauge.Ratio getRatio() {
+            protected Ratio getRatio() {
                 MemoryUsage nonHeapMemoryUsage = memoryBean.getNonHeapMemoryUsage();
                 double used = nonHeapMemoryUsage.getUsed();
                 double max = nonHeapMemoryUsage.getMax();
-                return (used < 0 || max < 0) ? RATIO_NAN : RatioGauge.Ratio.of(used, max);
+                return (used < 0 || max < 0) ? RATIO_NAN : Ratio.of(used, max);
             }
         });
     }
@@ -258,5 +259,53 @@ public final class JvmMetrics {
 
     private JvmMetrics() {
         throw new UnsupportedOperationException();
+    }
+
+    /** {@link ToggleableJvmMetrics} is like {@link JvmMetrics}, but provides the ability to opt out of some metrics. */
+    public static final class ToggleableJvmMetrics {
+        private final boolean enableThreadsMetrics;
+
+        private ToggleableJvmMetrics(boolean enableThreadsMetrics) {
+            this.enableThreadsMetrics = enableThreadsMetrics;
+        }
+
+        public static final class Builder {
+            private boolean enableThreadsMetrics = true;
+
+            public Builder withThreadsMetrics(boolean threadsMetrics) {
+                this.enableThreadsMetrics = threadsMetrics;
+                return this;
+            }
+
+            public ToggleableJvmMetrics build() {
+                return new ToggleableJvmMetrics(enableThreadsMetrics);
+            }
+        }
+
+        /**
+         * Registers the set of enabled metrics.
+         *
+         * @param registry metric registry
+         */
+        @SuppressWarnings("checkstyle:CyclomaticComplexity")
+        public void register(TaggedMetricRegistry registry) {
+            Preconditions.checkNotNull(registry, "TaggedMetricRegistry is required");
+            InternalJvmMetrics metrics = InternalJvmMetrics.of(registry);
+            MetricRegistries.registerGarbageCollection(registry);
+            MetricRegistries.registerMemoryPools(registry);
+            Jdk9CompatibleFileDescriptorRatioGauge.register(metrics);
+            OperatingSystemMetrics.register(registry);
+            SafepointMetrics.register(registry);
+            registerAttributes(metrics);
+            registerJvmBufferPools(registry);
+            registerClassLoading(metrics);
+            registerJvmMemory(registry);
+            if (enableThreadsMetrics) {
+                registerThreads(metrics);
+            }
+            metrics.processors(Runtime.getRuntime()::availableProcessors);
+            registerCpuShares(registry, JvmDiagnostics.cpuShares());
+            registerDnsCacheMetrics(metrics);
+        }
     }
 }

--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/JvmMetrics.java
@@ -63,6 +63,28 @@ public final class JvmMetrics {
      * @param registry metric registry
      */
     public static void register(TaggedMetricRegistry registry) {
+        registerJvmMetrics(registry, true);
+    }
+
+    /**
+     * Registers a default set of metrics.
+     *
+     * <p>This includes {@link MetricRegistries#registerGarbageCollection(TaggedMetricRegistry)} and
+     * {@link MetricRegistries#registerMemoryPools(TaggedMetricRegistry)},
+     * but does not include gauges for threads by state.
+     *
+     * @param registry metric registry
+     */
+    public static void registerWithoutThreadMetrics(TaggedMetricRegistry registry) {
+        registerJvmMetrics(registry, false);
+    }
+
+    /**
+     * Registers the set of enabled metrics.
+     *
+     * @param registry metric registry
+     */
+    private static void registerJvmMetrics(TaggedMetricRegistry registry, boolean enableThreadsMetrics) {
         Preconditions.checkNotNull(registry, "TaggedMetricRegistry is required");
         MetricRegistries.registerGarbageCollection(registry);
         MetricRegistries.registerMemoryPools(registry);
@@ -74,7 +96,9 @@ public final class JvmMetrics {
         registerJvmBufferPools(registry);
         registerClassLoading(metrics);
         registerJvmMemory(registry);
-        registerThreads(metrics);
+        if (enableThreadsMetrics) {
+            registerThreads(metrics);
+        }
         metrics.processors(Runtime.getRuntime()::availableProcessors);
         registerCpuShares(registry, JvmDiagnostics.cpuShares());
         registerDnsCacheMetrics(metrics);
@@ -259,53 +283,5 @@ public final class JvmMetrics {
 
     private JvmMetrics() {
         throw new UnsupportedOperationException();
-    }
-
-    /** {@link ToggleableJvmMetrics} is like {@link JvmMetrics}, but provides the ability to opt out of some metrics. */
-    public static final class ToggleableJvmMetrics {
-        private final boolean enableThreadsMetrics;
-
-        private ToggleableJvmMetrics(boolean enableThreadsMetrics) {
-            this.enableThreadsMetrics = enableThreadsMetrics;
-        }
-
-        public static final class Builder {
-            private boolean enableThreadsMetrics = true;
-
-            public Builder withThreadsMetrics(boolean threadsMetrics) {
-                this.enableThreadsMetrics = threadsMetrics;
-                return this;
-            }
-
-            public ToggleableJvmMetrics build() {
-                return new ToggleableJvmMetrics(enableThreadsMetrics);
-            }
-        }
-
-        /**
-         * Registers the set of enabled metrics.
-         *
-         * @param registry metric registry
-         */
-        @SuppressWarnings("checkstyle:CyclomaticComplexity")
-        public void register(TaggedMetricRegistry registry) {
-            Preconditions.checkNotNull(registry, "TaggedMetricRegistry is required");
-            InternalJvmMetrics metrics = InternalJvmMetrics.of(registry);
-            MetricRegistries.registerGarbageCollection(registry);
-            MetricRegistries.registerMemoryPools(registry);
-            Jdk9CompatibleFileDescriptorRatioGauge.register(metrics);
-            OperatingSystemMetrics.register(registry);
-            SafepointMetrics.register(registry);
-            registerAttributes(metrics);
-            registerJvmBufferPools(registry);
-            registerClassLoading(metrics);
-            registerJvmMemory(registry);
-            if (enableThreadsMetrics) {
-                registerThreads(metrics);
-            }
-            metrics.processors(Runtime.getRuntime()::availableProcessors);
-            registerCpuShares(registry, JvmDiagnostics.cpuShares());
-            registerDnsCacheMetrics(metrics);
-        }
     }
 }

--- a/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
+++ b/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
@@ -22,7 +22,9 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.RatioGauge;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MoreCollectors;
+import com.google.common.collect.Sets;
 import com.palantir.tritium.metrics.jvm.InternalJvmMetrics.DnsCacheTtlSeconds_Cache;
+import com.palantir.tritium.metrics.jvm.JvmMetrics.ToggleableJvmMetrics;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -39,47 +41,13 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import javax.management.ObjectName;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 final class JvmMetricsTest {
 
-    private static final ImmutableSet<String> EXPECTED_NAMES = ImmutableSet.of(
-            "jvm.attribute.uptime",
-            "jvm.buffers.direct.capacity",
-            "jvm.buffers.direct.count",
-            "jvm.buffers.direct.used",
-            "jvm.buffers.mapped.capacity",
-            "jvm.buffers.mapped.count",
-            "jvm.buffers.mapped.used",
-            "jvm.classloader.loaded",
-            "jvm.classloader.unloaded",
-            "jvm.filedescriptor",
-            "jvm.gc.time",
-            "jvm.gc.count",
-            "jvm.gc.finalizer.queue.size",
-            "jvm.memory.heap.usage",
-            "jvm.memory.pools.committed",
-            "jvm.memory.total.max",
-            "jvm.memory.pools.used",
-            "jvm.memory.pools.init",
-            "jvm.memory.pools.usage",
-            "jvm.memory.pools.max",
-            "jvm.memory.heap.committed",
-            "jvm.memory.total.committed",
-            "jvm.memory.total.used",
-            "jvm.memory.total.init",
-            "jvm.memory.pools.used-after-gc",
-            "jvm.memory.heap.used",
-            "jvm.memory.heap.init",
-            "jvm.memory.non-heap.init",
-            "jvm.memory.non-heap.usage",
-            "jvm.memory.non-heap.used",
-            "jvm.memory.non-heap.committed",
-            "jvm.memory.non-heap.max",
-            "jvm.memory.heap.max",
-            "jvm.processors",
-            "jvm.safepoint.time",
+    private static final ImmutableSet<@NotNull String> EXPECTED_THREAD_METRIC_NAMES = ImmutableSet.of(
             "jvm.threads.timed-waiting.count",
             "jvm.threads.waiting.count",
             "jvm.threads.count",
@@ -88,10 +56,50 @@ final class JvmMetricsTest {
             "jvm.threads.daemon.count",
             "jvm.threads.runnable.count",
             "jvm.threads.terminated.count",
-            "jvm.threads.blocked.count",
-            "os.load.1",
-            "os.load.norm.1",
-            "process.cpu.utilization");
+            "jvm.threads.blocked.count");
+
+    private static final ImmutableSet<@NotNull String> EXPECTED_NAMES = ImmutableSet.<String>builder()
+            .addAll(EXPECTED_THREAD_METRIC_NAMES)
+            .addAll(List.of(
+                    "jvm.attribute.uptime",
+                    "jvm.buffers.direct.capacity",
+                    "jvm.buffers.direct.count",
+                    "jvm.buffers.direct.used",
+                    "jvm.buffers.mapped.capacity",
+                    "jvm.buffers.mapped.count",
+                    "jvm.buffers.mapped.used",
+                    "jvm.classloader.loaded",
+                    "jvm.classloader.unloaded",
+                    "jvm.filedescriptor",
+                    "jvm.gc.time",
+                    "jvm.gc.count",
+                    "jvm.gc.finalizer.queue.size",
+                    "jvm.memory.heap.usage",
+                    "jvm.memory.pools.committed",
+                    "jvm.memory.total.max",
+                    "jvm.memory.pools.used",
+                    "jvm.memory.pools.init",
+                    "jvm.memory.pools.usage",
+                    "jvm.memory.pools.max",
+                    "jvm.memory.heap.committed",
+                    "jvm.memory.total.committed",
+                    "jvm.memory.total.used",
+                    "jvm.memory.total.init",
+                    "jvm.memory.pools.used-after-gc",
+                    "jvm.memory.heap.used",
+                    "jvm.memory.heap.init",
+                    "jvm.memory.non-heap.init",
+                    "jvm.memory.non-heap.usage",
+                    "jvm.memory.non-heap.used",
+                    "jvm.memory.non-heap.committed",
+                    "jvm.memory.non-heap.max",
+                    "jvm.memory.heap.max",
+                    "jvm.processors",
+                    "jvm.safepoint.time",
+                    "os.load.1",
+                    "os.load.norm.1",
+                    "process.cpu.utilization"))
+            .build();
 
     @Test
     void testExpectedMetrics() {
@@ -101,6 +109,16 @@ final class JvmMetricsTest {
                         .map(MetricName::safeName)
                         .collect(ImmutableSet.toImmutableSet()))
                 .containsAll(EXPECTED_NAMES);
+    }
+
+    @Test
+    void testToggleableExpectedMetrics() {
+        TaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+        new ToggleableJvmMetrics.Builder().withThreadsMetrics(false).build().register(registry);
+        assertThat(registry.getMetrics().keySet().stream()
+                        .map(MetricName::safeName)
+                        .collect(ImmutableSet.toImmutableSet()))
+                .containsAll(Sets.difference(EXPECTED_NAMES, EXPECTED_THREAD_METRIC_NAMES));
     }
 
     @Test

--- a/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
+++ b/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MoreCollectors;
 import com.google.common.collect.Sets;
 import com.palantir.tritium.metrics.jvm.InternalJvmMetrics.DnsCacheTtlSeconds_Cache;
-import com.palantir.tritium.metrics.jvm.JvmMetrics.ToggleableJvmMetrics;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -114,7 +113,7 @@ final class JvmMetricsTest {
     @Test
     void testToggleableExpectedMetrics() {
         TaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
-        new ToggleableJvmMetrics.Builder().withThreadsMetrics(false).build().register(registry);
+        JvmMetrics.registerWithoutThreadMetrics(registry);
         assertThat(registry.getMetrics().keySet().stream()
                         .map(MetricName::safeName)
                         .collect(ImmutableSet.toImmutableSet()))


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Previously, a user could either register all tritium JVM metrics or none. This could cause problems for applications where collecting some of the thread metrics is a known expensive operation. This PR enables users to opt out of some metrics when registering JVM metrics.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update JVM metric registration API to allow opting out of thread metrics
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
This not provides _some_ configurability to something that used to be consistent for all users of the library. In this case, I believe the complexity is worth it, but we can add additional docs to make it clear that most users will not need to opt out.
