### PR TITLE
Add JVM metric for safepoint sync time

### DIFF
--- a/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
+++ b/tritium-metrics-jvm/src/main/java/com/palantir/tritium/metrics/jvm/SafepointMetrics.java
@@ -35,6 +35,8 @@ final class SafepointMetrics {
         Optional<SafepointTimeAccessor> safepointTimeAccessor = JvmDiagnostics.totalSafepointTime();
         if (safepointTimeAccessor.isPresent()) {
             InternalJvmMetrics.of(registry).safepointTime(safepointTimeAccessor.get()::safepointTimeMilliseconds);
+            InternalJvmMetrics.of(registry)
+                    .safepointSyncTime(safepointTimeAccessor.get()::safepointSyncTimeMilliseconds);
         } else {
             log.info("Could not get the total safepoint time, these metrics will not be registered.");
         }

--- a/tritium-metrics-jvm/src/main/metrics/metrics.yml
+++ b/tritium-metrics-jvm/src/main/metrics/metrics.yml
@@ -31,6 +31,9 @@ namespaces:
       safepoint.time:
         type: gauge
         docs: The accumulated elapsed time waiting at safepoints in ms (equivalent to `+PrintGCApplicationStoppedTime`). It helps debugging stop-the-world GCing, or biased locking going badly. See https://stackoverflow.com/questions/29666057/analyzing-gc-logs/29673564#29673564 for details.
+      safepoint.sync.time:
+        type: gauge
+        docs: The accumulated elapsed time waiting to reach safepoints in ms ("time to safepoint", equivalent to the sync field in `+PrintSafepointStatistics`).
       filedescriptor:
         type: gauge
         docs: Ratio of open file descriptors to the maximum allowed open file descriptors. When this value reaches 1, attempts to open files (including sockets) will fail.

--- a/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
+++ b/tritium-metrics-jvm/src/test/java/com/palantir/tritium/metrics/jvm/JvmMetricsTest.java
@@ -181,6 +181,12 @@ final class JvmMetricsTest {
                 registry, MetricName.builder().safeName("jvm.safepoint.time").build(), Gauge.class);
         assertThat(safepointTime)
                 .satisfies(gauge -> assertThat(gauge.getValue()).isNotNegative());
+        Gauge<Long> safepointSyncTime = (Gauge<Long>) find(
+                registry,
+                MetricName.builder().safeName("jvm.safepoint.sync.time").build(),
+                Gauge.class);
+        assertThat(safepointSyncTime)
+                .satisfies(gauge -> assertThat(gauge.getValue()).isNotNegative());
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Previously, our safepoint metrics only tracked the amount of time spent in a safepointed state. In conjunction with the change in https://github.com/palantir/jvm-diagnostics/pull/557, we now emit the time taken getting to a safepointed state, which should surface different types issue from the previous metrics.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add JVM metric for safepoint sync time
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

