### PR TITLE
Remove error-prone AllSuggestionsAsWarnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,10 +70,6 @@ allprojects {
             options.errorprone {
                 option('NullAway:AnnotatedPackages', 'com.palantir,com.google.common')
                 option('NullAway:CheckOptionalEmptiness', 'true')
-
-                errorproneArgs = [
-                    '-XepAllSuggestionsAsWarnings',
-                ]
             }
         }
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
[`RequireExplicitNullMarking` NullAway error-prone check](https://github.com/uber/NullAway/blob/master/nullaway/src/main/java/com/uber/nullaway/RequireExplicitNullMarking.java) enabled by `AllSuggestionsAsWarnings` is blocking gradle-baseline upgrade https://github.com/palantir/tritium/pull/2344/ . There is https://github.com/palantir/tritium/pull/2270 to expand full jspecify + NullAway support; however, that is currently on hold.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

