### PR TITLE
Revert unintended error-prone change in #2333

### DIFF
--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TaggedMetricRegistry.java
@@ -108,7 +108,7 @@ public interface TaggedMetricRegistry extends TaggedMetricSet {
         }
         remove(metricName).ifPresent(_removed -> LoggerFactory.getLogger(getClass())
                 .debug("Removed previously registered gauge {}", SafeArg.of("metricName", metricName)));
-        registerWithReplacement(metricName, gauge);
+        gauge(metricName, gauge);
     }
 
     /**


### PR DESCRIPTION
## Before this PR
See https://github.com/palantir/tritium/pull/2333/changes#r2670096520

I don't believe this would have any adverse impact, as it would just recursively call `registerWithReplacement` and go through the early return in the next call, but this was unintended

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Revert unintended error-prone change
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

