### PR TITLE
Add `queued-delay` metric for ScheduledExecutorService

### DIFF
--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsScheduledThreadPoolExecutor.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsScheduledThreadPoolExecutor.java
@@ -17,12 +17,20 @@
 package com.palantir.tritium.metrics;
 
 import com.codahale.metrics.Timer;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Instruments an {@link ScheduledThreadPoolExecutor} that monitors the delay between when a task was scheduled
+ * to be executed and when it actually got executed.
+ * Use in conjunction with {@link MetricRegistries#instrument(TaggedMetricRegistry, ScheduledExecutorService, String)}
+ * to fully instrument an {@link ScheduledExecutorService}.
+ */
 public class TaggedMetricsScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
     private final Timer delay;
 
@@ -33,14 +41,15 @@ public class TaggedMetricsScheduledThreadPoolExecutor extends ScheduledThreadPoo
     }
 
     @Override
-    protected void beforeExecute(Thread t, Runnable r) {
-        if (r instanceof ScheduledFuture<?> sf) {
-            long delay = sf.getDelay(TimeUnit.MILLISECONDS);
-            if (delay < 0) {
-                this.delay.update(-delay, TimeUnit.MILLISECONDS);
+    @SuppressWarnings("checkstyle:DesignForExtension")
+    protected void beforeExecute(Thread thread, Runnable runnable) {
+        if (runnable instanceof ScheduledFuture<?> sf) {
+            long futureDelay = sf.getDelay(TimeUnit.MILLISECONDS);
+            if (futureDelay < 0) {
+                this.delay.update(-futureDelay, TimeUnit.MILLISECONDS);
             }
         }
 
-        super.beforeExecute(t, r);
+        super.beforeExecute(thread, runnable);
     }
 }

--- a/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsScheduledThreadPoolExecutor.java
+++ b/tritium-metrics/src/main/java/com/palantir/tritium/metrics/TaggedMetricsScheduledThreadPoolExecutor.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics;
+
+import com.codahale.metrics.Timer;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import org.jetbrains.annotations.NotNull;
+
+public class TaggedMetricsScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
+    private final Timer delay;
+
+    public TaggedMetricsScheduledThreadPoolExecutor(
+            int corePoolSize, @NotNull ThreadFactory threadFactory, ExecutorMetrics metrics, String name) {
+        super(corePoolSize, threadFactory);
+        this.delay = metrics.queuedDuration(name);
+    }
+
+    @Override
+    protected void beforeExecute(Thread t, Runnable r) {
+        if (r instanceof ScheduledFuture<?> sf) {
+            long delay = sf.getDelay(TimeUnit.MILLISECONDS);
+            if (delay < 0) {
+                this.delay.update(-delay, TimeUnit.MILLISECONDS);
+            }
+        }
+
+        super.beforeExecute(t, r);
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We would not populate the `executor.queued-duration` metric for scheduled executor services.

## After this PR
We populate this metric.

Additional considerations:
- thought of adding a new metric to `ExecutorMetrics`, but biased for ease-of-use - dashboards already reference this metric, and it still makes sense in this context
- considered adding a `reportQueuedDuration` boolean, similar to how we instrument `ExecutorService`. Decided against that because all internal usages require a fixed thread pool for `ScheduledExecutorService`.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

