### PR TITLE
Replace WeightedSnapshot with primitive-array PrimitiveWeightedSnapshot

### DIFF
--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/SnapshotBenchmark.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/SnapshotBenchmark.java
@@ -1,0 +1,100 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.microbenchmarks;
+
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
+import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.Snapshot;
+import com.palantir.tritium.metrics.registry.LockFreeExponentiallyDecayingReservoir;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@State(Scope.Benchmark)
+@SuppressWarnings({"designforextension", "NullAway"})
+public class SnapshotBenchmark {
+
+    @Param({"WEIGHTED_SNAPSHOT", "PRIMITIVE_WEIGHTED_SNAPSHOT"})
+    private SnapshotType snapshotType;
+
+    @Param({"100", "1028"})
+    private int reservoirSize;
+
+    public enum SnapshotType {
+        WEIGHTED_SNAPSHOT {
+            @Override
+            Reservoir create(int size) {
+                return new ExponentiallyDecayingReservoir(size, 0.015);
+            }
+        },
+        PRIMITIVE_WEIGHTED_SNAPSHOT {
+            @Override
+            @SuppressWarnings("deprecation")
+            Reservoir create(int size) {
+                return LockFreeExponentiallyDecayingReservoir.builder()
+                        .size(size)
+                        .alpha(0.015)
+                        .build();
+            }
+        };
+
+        abstract Reservoir create(int size);
+    }
+
+    private Reservoir reservoir;
+
+    @Setup
+    public void before() {
+        reservoir = snapshotType.create(reservoirSize);
+        ThreadLocalRandom rng = ThreadLocalRandom.current();
+        for (int i = 0; i < reservoirSize * 2; i++) {
+            reservoir.update(rng.nextLong(0, 10_000_000));
+        }
+    }
+
+    @Benchmark
+    public Snapshot getSnapshot() {
+        return reservoir.getSnapshot();
+    }
+
+    @Benchmark
+    public void getSnapshotAndRead(Blackhole bh) {
+        Snapshot snapshot = reservoir.getSnapshot();
+        bh.consume(snapshot.getMedian());
+        bh.consume(snapshot.get75thPercentile());
+        bh.consume(snapshot.get95thPercentile());
+        bh.consume(snapshot.get99thPercentile());
+        bh.consume(snapshot.getMean());
+        bh.consume(snapshot.getStdDev());
+    }
+}

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoir.java
@@ -19,12 +19,12 @@ package com.palantir.tritium.metrics.registry;
 import com.codahale.metrics.Clock;
 import com.codahale.metrics.Reservoir;
 import com.codahale.metrics.Snapshot;
-import com.codahale.metrics.WeightedSnapshot;
 import com.codahale.metrics.WeightedSnapshot.WeightedSample;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -224,7 +224,20 @@ public final class LockFreeExponentiallyDecayingReservoir implements Reservoir {
     @Override
     public Snapshot getSnapshot() {
         State stateSnapshot = rescaleIfNeeded(clock.getTick());
-        return new WeightedSnapshot(stateSnapshot.values.values());
+        Collection<WeightedSample> samples = stateSnapshot.values.values();
+        int sampleCount = samples.size();
+        if (sampleCount == 0) {
+            return PrimitiveWeightedSnapshot.EMPTY;
+        }
+        long[] sampleValues = new long[sampleCount];
+        double[] sampleWeights = new double[sampleCount];
+        int idx = 0;
+        for (WeightedSample sample : samples) {
+            sampleValues[idx] = sample.value;
+            sampleWeights[idx] = sample.weight;
+            idx++;
+        }
+        return new PrimitiveWeightedSnapshot(sampleValues, sampleWeights);
     }
 
     public static Builder builder() {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/PrimitiveWeightedSnapshot.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/PrimitiveWeightedSnapshot.java
@@ -1,0 +1,234 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.tritium.metrics.registry;
+
+import com.codahale.metrics.Snapshot;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * A {@link Snapshot} implementation that avoids the boxing overhead of
+ * {@link com.codahale.metrics.WeightedSnapshot} by sorting primitive {@code long[]} values
+ * directly rather than using {@code Arrays.sort(Object[], Comparator)}.
+ */
+final class PrimitiveWeightedSnapshot extends Snapshot {
+
+    static final Snapshot EMPTY = new PrimitiveWeightedSnapshot(new long[0], new double[0]);
+
+    private static final int INSERTION_SORT_THRESHOLD = 47;
+
+    private final long[] values;
+    private final double[] weights;
+    private final double[] quantiles;
+    private final double inverseSumWeight;
+
+    PrimitiveWeightedSnapshot(long[] values, double[] weights) {
+        sortParallelArrays(values, weights, 0, values.length - 1);
+
+        this.values = values;
+        this.weights = weights;
+        this.quantiles = new double[values.length];
+
+        double sumWeight = 0;
+        for (double weight : weights) {
+            sumWeight += weight;
+        }
+        this.inverseSumWeight = sumWeight != 0 ? 1.0 / sumWeight : 0;
+
+        double cumulativeQuantile = 0;
+        for (int i = 0; i < values.length; i++) {
+            this.quantiles[i] = cumulativeQuantile;
+            cumulativeQuantile += weights[i] * inverseSumWeight;
+        }
+    }
+
+    @Override
+    public double getValue(double quantile) {
+        if (quantile < 0.0 || quantile > 1.0 || Double.isNaN(quantile)) {
+            throw new SafeIllegalArgumentException("quantile is not in [0..1]", SafeArg.of("quantile", quantile));
+        }
+
+        if (values.length == 0) {
+            return 0.0;
+        }
+
+        int idx = Arrays.binarySearch(quantiles, quantile);
+        if (idx < 0) {
+            idx = -idx - 1 - 1;
+        }
+
+        if (idx < 1) {
+            return values[0];
+        }
+
+        if (idx >= values.length) {
+            return values[values.length - 1];
+        }
+
+        return values[idx];
+    }
+
+    @Override
+    public int size() {
+        return values.length;
+    }
+
+    @Override
+    public long[] getValues() {
+        if (values.length == 0) {
+            return values;
+        }
+        return Arrays.copyOf(values, values.length);
+    }
+
+    @Override
+    public long getMax() {
+        if (values.length == 0) {
+            return 0;
+        }
+        return values[values.length - 1];
+    }
+
+    @Override
+    public long getMin() {
+        if (values.length == 0) {
+            return 0;
+        }
+        return values[0];
+    }
+
+    @Override
+    public double getMean() {
+        if (values.length == 0 || inverseSumWeight == 0) {
+            return 0;
+        }
+
+        double sum = 0;
+        for (int i = 0; i < values.length; i++) {
+            sum += values[i] * weights[i];
+        }
+        return sum * inverseSumWeight;
+    }
+
+    @Override
+    public double getStdDev() {
+        if (values.length <= 1 || inverseSumWeight == 0) {
+            return 0;
+        }
+
+        final double mean = getMean();
+        double variance = 0;
+
+        for (int i = 0; i < values.length; i++) {
+            final double diff = values[i] - mean;
+            variance += weights[i] * diff * diff;
+        }
+
+        return Math.sqrt(variance * inverseSumWeight);
+    }
+
+    @Override
+    public void dump(OutputStream output) {
+        try (PrintWriter out = new PrintWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8))) {
+            for (long value : values) {
+                out.printf("%d%n", value);
+            }
+        }
+    }
+
+    private static void sortParallelArrays(long[] values, double[] weights, int lo, int hi) {
+        int left = lo;
+        int right = hi;
+        while (right - left >= INSERTION_SORT_THRESHOLD) {
+            int pivotIdx = partition(values, weights, left, right);
+            if (pivotIdx - left < right - pivotIdx) {
+                sortParallelArrays(values, weights, left, pivotIdx - 1);
+                left = pivotIdx + 1;
+            } else {
+                sortParallelArrays(values, weights, pivotIdx + 1, right);
+                right = pivotIdx - 1;
+            }
+        }
+        if (left < right) {
+            insertionSort(values, weights, left, right);
+        }
+    }
+
+    private static int partition(long[] values, double[] weights, int left, int right) {
+        medianOfThree(values, weights, left, right);
+        long pivot = values[(left + right) >>> 1];
+        swap(values, weights, (left + right) >>> 1, right - 1);
+
+        int lo = left;
+        int hi = right - 1;
+        while (true) {
+            while (values[++lo] < pivot) {
+                // advance
+            }
+            while (values[--hi] > pivot) {
+                // advance
+            }
+            if (lo >= hi) {
+                break;
+            }
+            swap(values, weights, lo, hi);
+        }
+        swap(values, weights, lo, right - 1);
+        return lo;
+    }
+
+    private static void medianOfThree(long[] values, double[] weights, int left, int right) {
+        int mid = (left + right) >>> 1;
+        if (values[left] > values[mid]) {
+            swap(values, weights, left, mid);
+        }
+        if (values[left] > values[right]) {
+            swap(values, weights, left, right);
+        }
+        if (values[mid] > values[right]) {
+            swap(values, weights, mid, right);
+        }
+    }
+
+    private static void insertionSort(long[] values, double[] weights, int left, int right) {
+        for (int idx = left + 1; idx <= right; idx++) {
+            long val = values[idx];
+            double wt = weights[idx];
+            int pos = idx - 1;
+            while (pos >= left && values[pos] > val) {
+                values[pos + 1] = values[pos];
+                weights[pos + 1] = weights[pos];
+                pos--;
+            }
+            values[pos + 1] = val;
+            weights[pos + 1] = wt;
+        }
+    }
+
+    private static void swap(long[] values, double[] weights, int idx1, int idx2) {
+        long tmpVal = values[idx1];
+        values[idx1] = values[idx2];
+        values[idx2] = tmpVal;
+        double tmpWt = weights[idx1];
+        weights[idx1] = weights[idx2];
+        weights[idx2] = tmpWt;
+    }
+}

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/PrimitiveWeightedSnapshot.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/PrimitiveWeightedSnapshot.java
@@ -149,7 +149,7 @@ final class PrimitiveWeightedSnapshot extends Snapshot {
     public void dump(OutputStream output) {
         try (PrintWriter out = new PrintWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8))) {
             for (long value : values) {
-                out.printf("%d%n", value);
+                out.println(value);
             }
         }
     }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/WeightedSnapshotWithExemplars.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/WeightedSnapshotWithExemplars.java
@@ -16,8 +16,6 @@
 package com.palantir.tritium.metrics.registry;
 
 import com.codahale.metrics.Snapshot;
-import com.codahale.metrics.WeightedSnapshot;
-import com.codahale.metrics.WeightedSnapshot.WeightedSample;
 import com.palantir.logsafe.Preconditions;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -27,47 +25,24 @@ import java.util.List;
 import org.jspecify.annotations.Nullable;
 
 /**
- * A {@link WeightedSnapshot} with support for storing exemplar metadata for each sample.
+ * A {@link Snapshot} with support for storing exemplar metadata for each sample.
  */
 final class WeightedSnapshotWithExemplars extends Snapshot implements ExemplarsCapture {
 
     /**
      * A single sample item with value, weights and optional exemplar metadata.
      */
-    static class WeightedSampleWithExemplar {
+    record WeightedSampleWithExemplar(
+            long value, double weight, @Nullable Object exemplarMetadata) {}
 
-        private final long value;
-        private final double weight;
-        private final @Nullable Object exemplarMetadata;
-
-        WeightedSampleWithExemplar(long value, double weight, @Nullable Object exemplarMetadata) {
-            this.value = value;
-            this.weight = weight;
-            this.exemplarMetadata = exemplarMetadata;
-        }
-
-        long value() {
-            return value;
-        }
-
-        double weight() {
-            return weight;
-        }
-
-        @Nullable
-        Object exemplarMetadata() {
-            return exemplarMetadata;
-        }
-    }
-
-    private final WeightedSnapshot weightedSnapshot;
+    private final Snapshot delegate;
     private final ExemplarMetadataProvider<?> exemplarProvider;
     private final List<LongExemplar<Object>> exemplars;
 
     private WeightedSnapshotWithExemplars(
-            ExemplarMetadataProvider<?> provider, List<LongExemplar<Object>> exemplars, WeightedSnapshot snapshot) {
+            ExemplarMetadataProvider<?> provider, List<LongExemplar<Object>> exemplars, Snapshot snapshot) {
         this.exemplars = Collections.unmodifiableList(exemplars);
-        this.weightedSnapshot = Preconditions.checkNotNull(snapshot, "snapshot");
+        this.delegate = Preconditions.checkNotNull(snapshot, "snapshot");
         this.exemplarProvider = Preconditions.checkNotNull(provider, "provider");
     }
 
@@ -79,20 +54,31 @@ final class WeightedSnapshotWithExemplars extends Snapshot implements ExemplarsC
      * @param values an unordered set of values in the reservoir
      */
     static Snapshot snapshot(ExemplarMetadataProvider<?> provider, Collection<WeightedSampleWithExemplar> values) {
-        List<WeightedSample> weightedSamples = new ArrayList<>(values.size());
-        List<LongExemplar<Object>> exemplars = new ArrayList<>();
-        values.forEach(v -> {
-            weightedSamples.add(new WeightedSample(v.value, v.weight));
-            if (v.exemplarMetadata != null) {
-                exemplars.add(DefaultLongExemplar.of(v.exemplarMetadata, v.value));
-            }
-        });
-
-        WeightedSnapshot weightedSnapshot = new WeightedSnapshot(weightedSamples);
-        if (exemplars.isEmpty()) {
-            return weightedSnapshot;
+        if (values.isEmpty()) {
+            return PrimitiveWeightedSnapshot.EMPTY;
         }
-        return new WeightedSnapshotWithExemplars(provider, exemplars, weightedSnapshot);
+        int size = values.size();
+        long[] sampleValues = new long[size];
+        double[] sampleWeights = new double[size];
+        List<LongExemplar<Object>> exemplars = null;
+        int idx = 0;
+        for (WeightedSampleWithExemplar v : values) {
+            sampleValues[idx] = v.value();
+            sampleWeights[idx] = v.weight();
+            if (v.exemplarMetadata() != null) {
+                if (exemplars == null) {
+                    exemplars = new ArrayList<>();
+                }
+                exemplars.add(DefaultLongExemplar.of(v.exemplarMetadata(), v.value()));
+            }
+            idx++;
+        }
+
+        Snapshot snapshot = new PrimitiveWeightedSnapshot(sampleValues, sampleWeights);
+        if (exemplars == null) {
+            return snapshot;
+        }
+        return new WeightedSnapshotWithExemplars(provider, exemplars, snapshot);
     }
 
     /**
@@ -109,45 +95,45 @@ final class WeightedSnapshotWithExemplars extends Snapshot implements ExemplarsC
         return List.of();
     }
 
-    /* All Snapshot methods are delegated to the weightedSnapshot */
+    /* All Snapshot methods are delegated to the delegate */
 
     @Override
     public double getValue(double quantile) {
-        return weightedSnapshot.getValue(quantile);
+        return delegate.getValue(quantile);
     }
 
     @Override
     public long[] getValues() {
-        return weightedSnapshot.getValues();
+        return delegate.getValues();
     }
 
     @Override
     public int size() {
-        return weightedSnapshot.size();
+        return delegate.size();
     }
 
     @Override
     public long getMax() {
-        return weightedSnapshot.getMax();
+        return delegate.getMax();
     }
 
     @Override
     public double getMean() {
-        return weightedSnapshot.getMean();
+        return delegate.getMean();
     }
 
     @Override
     public long getMin() {
-        return weightedSnapshot.getMin();
+        return delegate.getMin();
     }
 
     @Override
     public double getStdDev() {
-        return weightedSnapshot.getStdDev();
+        return delegate.getStdDev();
     }
 
     @Override
     public void dump(OutputStream output) {
-        weightedSnapshot.dump(output);
+        delegate.dump(output);
     }
 }

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoirWithExemplarsTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/LockFreeExponentiallyDecayingReservoirWithExemplarsTest.java
@@ -23,7 +23,6 @@ import com.codahale.metrics.Reservoir;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.Timer.Context;
-import com.codahale.metrics.WeightedSnapshot;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -426,7 +425,7 @@ class LockFreeExponentiallyDecayingReservoirWithExemplarsTest {
 
         // No exemplars should be returned since the provider didn't return non-null metadata
         assertThat(reservoir.getSnapshot())
-                .isInstanceOf(WeightedSnapshot.class)
+                .isInstanceOf(PrimitiveWeightedSnapshot.class)
                 .isNotInstanceOf(ExemplarsCapture.class);
     }
 

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/PrimitiveWeightedSnapshotTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/PrimitiveWeightedSnapshotTest.java
@@ -1,0 +1,165 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.tritium.metrics.registry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.WeightedSnapshot;
+import com.codahale.metrics.WeightedSnapshot.WeightedSample;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.Test;
+
+class PrimitiveWeightedSnapshotTest {
+
+    @Test
+    void emptySnapshot() {
+        Snapshot snapshot = new PrimitiveWeightedSnapshot(new long[0], new double[0]);
+        assertThat(snapshot.size()).isEqualTo(0);
+        assertThat(snapshot.getMax()).isEqualTo(0);
+        assertThat(snapshot.getMin()).isEqualTo(0);
+        assertThat(snapshot.getMean()).isEqualTo(0);
+        assertThat(snapshot.getStdDev()).isEqualTo(0);
+        assertThat(snapshot.getValue(0.5)).isEqualTo(0);
+        assertThat(snapshot.getValues()).isEmpty();
+    }
+
+    @Test
+    void singleElement() {
+        Snapshot snapshot = new PrimitiveWeightedSnapshot(new long[] {42}, new double[] {1.0});
+        assertThat(snapshot.size()).isEqualTo(1);
+        assertThat(snapshot.getMax()).isEqualTo(42);
+        assertThat(snapshot.getMin()).isEqualTo(42);
+        assertThat(snapshot.getMean()).isEqualTo(42);
+        assertThat(snapshot.getStdDev()).isEqualTo(0);
+        assertThat(snapshot.getMedian()).isEqualTo(42);
+    }
+
+    @Test
+    void valuesAreSorted() {
+        Snapshot snapshot = new PrimitiveWeightedSnapshot(new long[] {5, 3, 1, 4, 2}, new double[] {1, 1, 1, 1, 1});
+        assertThat(snapshot.getValues()).containsExactly(1, 2, 3, 4, 5);
+        assertThat(snapshot.getMin()).isEqualTo(1);
+        assertThat(snapshot.getMax()).isEqualTo(5);
+    }
+
+    @Test
+    void weightsAreRespected() {
+        // value 100 has weight 9, value 200 has weight 1
+        // median should be 100 because it accounts for 90% of weight
+        Snapshot snapshot = new PrimitiveWeightedSnapshot(new long[] {200, 100}, new double[] {1.0, 9.0});
+        assertThat(snapshot.getMedian()).isEqualTo(100);
+    }
+
+    @Test
+    void quantileEdgeCases() {
+        Snapshot snapshot = new PrimitiveWeightedSnapshot(new long[] {1, 2, 3, 4, 5}, new double[] {1, 1, 1, 1, 1});
+        assertThat(snapshot.getValue(0.0)).isEqualTo(1);
+        assertThat(snapshot.getValue(1.0)).isEqualTo(5);
+        assertThatThrownBy(() -> snapshot.getValue(-0.1)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> snapshot.getValue(1.1)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> snapshot.getValue(Double.NaN)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void matchesWeightedSnapshotBehavior() {
+        // Generate random data and verify identical results vs upstream WeightedSnapshot
+        ThreadLocalRandom rng = ThreadLocalRandom.current();
+        for (int trial = 0; trial < 20; trial++) {
+            int size = rng.nextInt(1, 200);
+            long[] values = new long[size];
+            double[] weights = new double[size];
+            List<WeightedSample> samples = new ArrayList<>(size);
+            for (int i = 0; i < size; i++) {
+                values[i] = rng.nextLong(-10_000, 10_000);
+                weights[i] = rng.nextDouble(0.01, 100.0);
+                samples.add(new WeightedSample(values[i], weights[i]));
+            }
+
+            Snapshot primitive = new PrimitiveWeightedSnapshot(values.clone(), weights.clone());
+            Snapshot upstream = new WeightedSnapshot(samples);
+
+            assertThat(primitive.size()).as("size trial %d", trial).isEqualTo(upstream.size());
+            assertThat(primitive.getMin()).as("min trial %d", trial).isEqualTo(upstream.getMin());
+            assertThat(primitive.getMax()).as("max trial %d", trial).isEqualTo(upstream.getMax());
+            assertThat(primitive.getMean()).as("mean trial %d", trial).isCloseTo(upstream.getMean(), within(1e-10));
+            assertThat(primitive.getStdDev())
+                    .as("stddev trial %d", trial)
+                    .isCloseTo(upstream.getStdDev(), within(1e-6));
+            assertThat(primitive.getValues()).as("values trial %d", trial).containsExactly(upstream.getValues());
+            assertThat(primitive.getMedian())
+                    .as("median trial %d", trial)
+                    .isCloseTo(upstream.getMedian(), within(1e-10));
+            assertThat(primitive.get75thPercentile())
+                    .as("p75 trial %d", trial)
+                    .isCloseTo(upstream.get75thPercentile(), within(1e-10));
+            assertThat(primitive.get95thPercentile())
+                    .as("p95 trial %d", trial)
+                    .isCloseTo(upstream.get95thPercentile(), within(1e-10));
+            assertThat(primitive.get99thPercentile())
+                    .as("p99 trial %d", trial)
+                    .isCloseTo(upstream.get99thPercentile(), within(1e-10));
+        }
+    }
+
+    @Test
+    void largeArraySort() {
+        int count = 2000;
+        long[] values = new long[count];
+        double[] weights = new double[count];
+        for (int i = 0; i < count; i++) {
+            values[i] = (long) count - i;
+            weights[i] = 1.0;
+        }
+        Snapshot snapshot = new PrimitiveWeightedSnapshot(values, weights);
+        assertThat(snapshot.getMin()).isEqualTo(1);
+        assertThat(snapshot.getMax()).isEqualTo(count);
+        long[] sorted = snapshot.getValues();
+        for (int i = 1; i < sorted.length; i++) {
+            assertThat(sorted[i]).isGreaterThanOrEqualTo(sorted[i - 1]);
+        }
+    }
+
+    @Test
+    void duplicateValues() {
+        Snapshot snapshot = new PrimitiveWeightedSnapshot(new long[] {5, 5, 5, 5, 5}, new double[] {1, 2, 3, 4, 5});
+        assertThat(snapshot.getMin()).isEqualTo(5);
+        assertThat(snapshot.getMax()).isEqualTo(5);
+        assertThat(snapshot.getMean()).isEqualTo(5.0);
+        assertThat(snapshot.getMedian()).isEqualTo(5);
+    }
+
+    @Test
+    void zeroWeights() {
+        Snapshot snapshot = new PrimitiveWeightedSnapshot(new long[] {1, 2, 3}, new double[] {0, 0, 0});
+        assertThat(snapshot.getMean()).isEqualTo(0.0);
+    }
+
+    @Test
+    void dump() {
+        Snapshot snapshot = new PrimitiveWeightedSnapshot(new long[] {3, 1, 2}, new double[] {1, 1, 1});
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        snapshot.dump(out);
+        String result = out.toString(StandardCharsets.UTF_8);
+        assertThat(result).contains("1").contains("2").contains("3");
+    }
+}

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/PrimitiveWeightedSnapshotTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/PrimitiveWeightedSnapshotTest.java
@@ -160,6 +160,6 @@ class PrimitiveWeightedSnapshotTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         snapshot.dump(out);
         String result = out.toString(StandardCharsets.UTF_8);
-        assertThat(result).contains("1").contains("2").contains("3");
+        assertThat(result.lines()).containsExactly("1", "2", "3");
     }
 }


### PR DESCRIPTION
## Before this PR

The codahale `WeightedSnapshot` incurred allocation and CPU overhead due to boxing arrays.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Eliminates boxing overhead from codahale WeightedSnapshot which used Arrays.sort(Object[], Comparator.comparingLong) triggering TimSort on boxed WeightedSample objects. The new PrimitiveWeightedSnapshot sorts parallel long[]/double[] arrays directly with a custom quicksort (median-of-three pivot, insertion sort for small partitions, O(log n) stack depth via tail-recursion elimination).

Additional optimizations:
- Eliminate per-snapshot normWeights array (~8KB at 1028 elements), replaced with scalar inverseSumWeight and deferred multiplication
- Eliminate intermediate WeightedSample allocations in reservoir getSnapshot() paths
- Lazy exemplar list allocation in WeightedSnapshotWithExemplars
- Empty snapshot singleton short-circuit

JMH benchmark results (us/op, lower is better):

  getSnapshot (n=100):  WeightedSnapshot 4.67 -> Primitive 3.00 (1.6x)
  getSnapshot (n=1028): WeightedSnapshot 93.2 -> Primitive 53.9 (1.7x)
  getSnapshotAndRead (n=1028): WeightedSnapshot 121.1 -> Primitive 55.7 (2.2x)

  Allocation per snapshot (n=1028): 47,193 B -> 24,752 B (48% reduction)
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

