### PR TITLE
Make TagMap.Builder resilient and fast for sorted-key hot path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,9 +81,8 @@ allprojects {
             tasks.jmhCompileGeneratedClasses {
                 options.annotationProcessorPath = configurations.jmhAnnotationProcessor
                 options.errorprone {
-                    enabled = true
-                    // JMH generates duplicate field names like byte p000, p001, p002
-                    disable('HidingField')
+                    // JMH generates code that doesn't conform to error-prone
+                    enabled = false
                 }
             }
         }

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/MetricNameBenchmark.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/MetricNameBenchmark.java
@@ -34,9 +34,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(1)
+@Warmup(iterations = 40, time = 50, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 30, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
 @State(Scope.Benchmark)
 @SuppressWarnings({"designforextension", "NullAway"})
 public class MetricNameBenchmark {

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/ImmutableMetricName.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/ImmutableMetricName.java
@@ -117,8 +117,6 @@ final class ImmutableMetricName {
 
         @CanIgnoreReturnValue
         public MetricName.PreSizedBuilder putSafeTags(@Safe String key, @Safe String value) {
-            Preconditions.checkNotNull(key, "safeTagName");
-            Preconditions.checkNotNull(value, "safeTagValue");
             tagMapBuilder.put(key, value);
             return (MetricName.PreSizedBuilder) this;
         }

--- a/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
+++ b/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java
@@ -19,7 +19,6 @@ package com.palantir.tritium.metrics.registry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Ordering;
 import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.SafeArg;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -115,20 +114,27 @@ final class TagMap implements SortedMap<String, String> {
         return values;
     }
 
-    /** Builds a new {@link TagMap}. Keys are expected to be inserted in lexicographical order. */
+    /** Builds a new {@link TagMap}. */
     static final class Builder {
-        private final String[] values;
-        private final int expectedSize;
+        private String[] values;
         private int size;
+        private boolean sorted = true;
 
         Builder(int expectedSize) {
             this.values = new String[expectedSize * 2];
-            this.expectedSize = expectedSize;
             this.size = 0;
         }
 
         Builder put(String key, String value) {
+            Preconditions.checkNotNull(key, "safeTagName");
+            Preconditions.checkNotNull(value, "safeTagValue");
             int arrayLen = size * 2;
+            if (arrayLen + 1 >= values.length) {
+                values = Arrays.copyOf(values, Math.max(values.length * 3 / 2, arrayLen + 2));
+            }
+            if (sorted && arrayLen >= 2 && values[arrayLen - 2].compareTo(key) > 0) {
+                sorted = false;
+            }
             values[arrayLen] = key;
             values[arrayLen + 1] = value;
             size++;
@@ -140,19 +146,31 @@ final class TagMap implements SortedMap<String, String> {
                 return EMPTY;
             }
 
-            Preconditions.checkArgument(
-                    size == expectedSize,
-                    "TagMap#builder inserted keys should be equal to the number of expected keys",
-                    SafeArg.of("size", size),
-                    SafeArg.of("expectedSize", expectedSize));
-
-            for (int i = 2; i < values.length; i += 2) {
-                Preconditions.checkArgument(
-                        values[i - 2].compareTo(values[i]) < 0,
-                        "TagMap#builder keys should be inserted in lexicographically ascending order");
+            if (!sorted) {
+                sortKeyValuePairs(values, size);
             }
 
+            int requiredLength = size * 2;
+            if (requiredLength < values.length) {
+                return new TagMap(Arrays.copyOf(values, requiredLength));
+            }
             return new TagMap(values);
+        }
+
+        private static void sortKeyValuePairs(String[] values, int size) {
+            // Insertion sort: suitable for the small tag maps we expect
+            for (int i = 1; i < size; i++) {
+                String key = values[i * 2];
+                String value = values[i * 2 + 1];
+                int jx = i - 1;
+                while (jx >= 0 && values[jx * 2].compareTo(key) > 0) {
+                    values[(jx + 1) * 2] = values[jx * 2];
+                    values[(jx + 1) * 2 + 1] = values[jx * 2 + 1];
+                    jx--;
+                }
+                values[(jx + 1) * 2] = key;
+                values[(jx + 1) * 2 + 1] = value;
+            }
         }
     }
 
@@ -270,13 +288,16 @@ final class TagMap implements SortedMap<String, String> {
 
     @Override
     public SortedMap<String, String> subMap(String fromKey, String toKey) {
-        int beginIndex = 0;
+        int beginIndex = -1;
         for (int i = 0; i < values.length; i += 2) {
             String key = values[i];
             if (key.compareTo(fromKey) >= 0) {
                 beginIndex = i;
                 break;
             }
+        }
+        if (beginIndex < 0) {
+            return EMPTY;
         }
         for (int i = values.length - 2; i >= beginIndex; i -= 2) {
             String key = values[i];
@@ -464,7 +485,7 @@ final class TagMap implements SortedMap<String, String> {
             for (int i = 0; i < local.length; i += 2) {
                 result[i / 2] = (T) new TagEntry(local[i], local[i + 1]);
             }
-            Arrays.fill(result, resultLength, array.length, null);
+            Arrays.fill(result, resultLength, result.length, null);
             return result;
         }
 

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/MetricNameTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/MetricNameTest.java
@@ -19,162 +19,316 @@ package com.palantir.tritium.metrics.registry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Collections;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class MetricNameTest {
 
-    @Test
-    public void compareSame() {
-        MetricName one = MetricName.builder()
-                .safeName("test")
-                .putSafeTags("key", "value")
-                .putSafeTags("key1", "value1")
-                .putSafeTags("key2", "value2")
-                .build();
-        MetricName two = MetricName.builder()
-                .safeName("test")
-                .putSafeTags("key2", "value2")
-                .putSafeTags("key", "value")
-                .putSafeTags("key1", "value1")
-                .build();
-        MetricName three = RealMetricName.create(two);
-        MetricName four = RealMetricName.create(
-                MetricName.builder()
-                        .safeName("test")
-                        .putSafeTags("key2", "value2")
-                        .putSafeTags("key", "value")
-                        .build(),
-                "key1",
-                "value1");
-        MetricName five = MetricName.builder().from(four).build();
+    @Nested
+    class Equality {
 
-        assertThat(one).isEqualTo(two).isEqualTo(three).isEqualTo(four).isEqualTo(five);
-        assertThat(two).isEqualTo(one).isEqualTo(three).isEqualTo(four).isEqualTo(five);
-        assertThat(three).isEqualTo(one).isEqualTo(two).isEqualTo(four).isEqualTo(five);
-        assertThat(four).isEqualTo(one).isEqualTo(two).isEqualTo(three).isEqualTo(five);
+        @Test
+        public void sameTags() {
+            MetricName one = MetricName.builder()
+                    .safeName("test")
+                    .putSafeTags("key", "value")
+                    .putSafeTags("key1", "value1")
+                    .putSafeTags("key2", "value2")
+                    .build();
+            MetricName two = MetricName.builder()
+                    .safeName("test")
+                    .putSafeTags("key2", "value2")
+                    .putSafeTags("key", "value")
+                    .putSafeTags("key1", "value1")
+                    .build();
+            MetricName three = RealMetricName.create(two);
+            MetricName four = RealMetricName.create(
+                    MetricName.builder()
+                            .safeName("test")
+                            .putSafeTags("key2", "value2")
+                            .putSafeTags("key", "value")
+                            .build(),
+                    "key1",
+                    "value1");
+            MetricName five = MetricName.builder().from(four).build();
 
-        assertThat(one.toString())
-                .isEqualTo(two.toString())
-                .isEqualTo(three.toString())
-                .isEqualTo(four.toString())
-                .isEqualTo(five.toString())
-                .isEqualTo("MetricName{safeName=test, safeTags={key=value, key1=value1, key2=value2}}");
-        assertThat(one)
-                .hasSameHashCodeAs(two)
-                .hasSameHashCodeAs(three)
-                .hasSameHashCodeAs(four)
-                .hasSameHashCodeAs(five);
+            assertThat(one).isEqualTo(two).isEqualTo(three).isEqualTo(four).isEqualTo(five);
+            assertThat(two).isEqualTo(one).isEqualTo(three).isEqualTo(four).isEqualTo(five);
+            assertThat(three).isEqualTo(one).isEqualTo(two).isEqualTo(four).isEqualTo(five);
+            assertThat(four).isEqualTo(one).isEqualTo(two).isEqualTo(three).isEqualTo(five);
+
+            assertThat(one.toString())
+                    .isEqualTo(two.toString())
+                    .isEqualTo(three.toString())
+                    .isEqualTo(four.toString())
+                    .isEqualTo(five.toString())
+                    .isEqualTo("MetricName{safeName=test, safeTags={key=value, key1=value1, key2=value2}}");
+            assertThat(one)
+                    .hasSameHashCodeAs(two)
+                    .hasSameHashCodeAs(three)
+                    .hasSameHashCodeAs(four)
+                    .hasSameHashCodeAs(five);
+        }
+
+        @Test
+        public void sameReference() {
+            MetricName name =
+                    MetricName.builder().safeName("test").putSafeTags("k", "v").build();
+            assertThat(name.equals(name)).isTrue();
+        }
+
+        @Test
+        public void differentName() {
+            assertThat(MetricName.builder().safeName("a").build())
+                    .isEqualTo(MetricName.builder().safeName("a").build());
+            assertThat(MetricName.builder().safeName("a").build())
+                    .isNotEqualTo(MetricName.builder().safeName("b").build());
+        }
+
+        @Test
+        public void differentTagKeys() {
+            MetricName one = MetricName.builder()
+                    .safeName("a")
+                    .putSafeTags("key1", "value1")
+                    .putSafeTags("key2", "value2")
+                    .build();
+            MetricName two = MetricName.builder()
+                    .safeName("a")
+                    .putSafeTags("key1", "value1")
+                    .putSafeTags("key3", "value2")
+                    .build();
+            assertThat(one).isNotEqualTo(two);
+            assertThat(two).isNotEqualTo(one);
+        }
+
+        @Test
+        public void differentTagValues() {
+            MetricName one = MetricName.builder()
+                    .safeName("a")
+                    .putSafeTags("key1", "value1")
+                    .putSafeTags("key2", "value2")
+                    .build();
+            MetricName two = MetricName.builder()
+                    .safeName("a")
+                    .putSafeTags("key1", "value1")
+                    .putSafeTags("key2", "valueZ")
+                    .build();
+            assertThat(one).isNotEqualTo(two);
+            assertThat(two).isNotEqualTo(one);
+        }
+
+        @Test
+        public void notEqualToNonMetricName() {
+            MetricName name = MetricName.builder().safeName("a").build();
+            assertThat(name).isNotEqualTo("not a MetricName");
+        }
+
+        @Test
+        public void nameOnlyFactory() {
+            MetricName name = RealMetricName.create("test");
+            assertThat(name.safeName()).isEqualTo("test");
+            assertThat(name.safeTags()).isEmpty();
+            assertThat(name).isEqualTo(MetricName.builder().safeName("test").build());
+        }
     }
 
-    @Test
-    public void compareName() {
-        assertThat(MetricName.builder().safeName("a").build())
-                .isEqualTo(MetricName.builder().safeName("a").build());
+    @Nested
+    class StandardBuilder {
 
-        assertThat(MetricName.builder().safeName("a").build())
-                .isNotEqualTo(MetricName.builder().safeName("b").build());
+        @Test
+        public void putSafeTagsEntry() {
+            MetricName name = MetricName.builder()
+                    .safeName("test")
+                    .putSafeTags(new SimpleImmutableEntry<>("k1", "v1"))
+                    .putSafeTags(new SimpleImmutableEntry<>("k2", "v2"))
+                    .build();
+            assertThat(name.safeTags()).containsEntry("k1", "v1").containsEntry("k2", "v2");
+        }
+
+        @Test
+        public void safeTagsReplacesAll() {
+            MetricName name = MetricName.builder()
+                    .safeName("test")
+                    .putSafeTags("old", "tag")
+                    .safeTags(ImmutableMap.of("new1", "v1", "new2", "v2"))
+                    .build();
+            assertThat(name.safeTags()).hasSize(2).containsEntry("new1", "v1").doesNotContainKey("old");
+        }
+
+        @Test
+        public void putAllSafeTagsOntoEmpty() {
+            MetricName name = MetricName.builder()
+                    .safeName("test")
+                    .putAllSafeTags(ImmutableMap.of("a", "1", "b", "2"))
+                    .build();
+            assertThat(name.safeTags()).hasSize(2).containsEntry("a", "1").containsEntry("b", "2");
+        }
+
+        @Test
+        public void putAllSafeTagsMergesWithExisting() {
+            MetricName name = MetricName.builder()
+                    .safeName("test")
+                    .putSafeTags("a", "1")
+                    .putAllSafeTags(ImmutableMap.of("b", "2", "c", "3"))
+                    .build();
+            assertThat(name.safeTags()).hasSize(3).containsEntry("a", "1").containsEntry("b", "2");
+        }
+
+        @Test
+        public void putAllSafeTagsEmptyIsNoop() {
+            MetricName name = MetricName.builder()
+                    .safeName("test")
+                    .putSafeTags("a", "1")
+                    .putAllSafeTags(Collections.emptyMap())
+                    .build();
+            assertThat(name.safeTags()).hasSize(1).containsEntry("a", "1");
+        }
+
+        @Test
+        public void from() {
+            MetricName original =
+                    MetricName.builder().safeName("test").putSafeTags("k", "v").build();
+            MetricName copy = MetricName.builder().from(original).build();
+            assertThat(copy).isEqualTo(original);
+            assertThat(copy).hasSameHashCodeAs(original);
+        }
     }
 
-    @Test
-    public void compareTagNames() {
-        MetricName one = MetricName.builder()
-                .safeName("a")
-                .putSafeTags("key1", "value1")
-                .putSafeTags("key2", "value2")
-                .build();
-        MetricName two = MetricName.builder()
-                .safeName("a")
-                .putSafeTags("key1", "value1")
-                .putSafeTags("key3", "value2")
-                .build();
+    @Nested
+    class PreSizedBuilderTest {
 
-        assertThat(one).isNotEqualTo(two);
-        assertThat(two).isNotEqualTo(one);
+        @Test
+        public void matchesStandardBuilder() {
+            MetricName preSized = MetricName.builderWithExpectedTags(2)
+                    .safeName("test")
+                    .putSafeTags("key1", "value1")
+                    .putSafeTags("key2", "value2")
+                    .build();
+            MetricName standard = MetricName.builder()
+                    .safeName("test")
+                    .putSafeTags("key1", "value1")
+                    .putSafeTags("key2", "value2")
+                    .build();
+
+            assertThat(preSized).isEqualTo(standard);
+            assertThat(preSized).hasSameHashCodeAs(standard);
+            assertThat(preSized.safeName()).isEqualTo("test");
+            assertThat(preSized.safeTags()).containsEntry("key1", "value1").containsEntry("key2", "value2");
+        }
+
+        @Test
+        public void noTags() {
+            MetricName preSized =
+                    MetricName.builderWithExpectedTags(0).safeName("test").build();
+            MetricName standard = MetricName.builder().safeName("test").build();
+            assertThat(preSized).isEqualTo(standard);
+            assertThat(preSized).hasSameHashCodeAs(standard);
+        }
+
+        @Test
+        public void differentInsertionOrder() {
+            MetricName preSized = MetricName.builderWithExpectedTags(3)
+                    .safeName("test")
+                    .putSafeTags("a", "1")
+                    .putSafeTags("b", "2")
+                    .putSafeTags("c", "3")
+                    .build();
+            MetricName standard = MetricName.builder()
+                    .safeName("test")
+                    .putSafeTags("c", "3")
+                    .putSafeTags("a", "1")
+                    .putSafeTags("b", "2")
+                    .build();
+
+            assertThat(preSized).isEqualTo(standard);
+            assertThat(preSized).hasSameHashCodeAs(standard);
+            assertThat(preSized.toString()).isEqualTo(standard.toString());
+        }
+
+        @Test
+        public void sizeMismatchShrinks() {
+            MetricName result = MetricName.builderWithExpectedTags(3)
+                    .safeName("test")
+                    .putSafeTags("key1", "value1")
+                    .putSafeTags("key2", "value2")
+                    .build();
+            MetricName expected = MetricName.builder()
+                    .safeName("test")
+                    .putSafeTags("key1", "value1")
+                    .putSafeTags("key2", "value2")
+                    .build();
+            assertThat(result).isEqualTo(expected);
+        }
+
+        @Test
+        public void notLexicographicalOrderSorts() {
+            MetricName result = MetricName.builderWithExpectedTags(2)
+                    .safeName("test")
+                    .putSafeTags("key2", "value2")
+                    .putSafeTags("key1", "value1")
+                    .build();
+            MetricName expected = MetricName.builder()
+                    .safeName("test")
+                    .putSafeTags("key1", "value1")
+                    .putSafeTags("key2", "value2")
+                    .build();
+            assertThat(result).isEqualTo(expected);
+        }
     }
 
-    @Test
-    public void compareTagValues() {
-        MetricName one = MetricName.builder()
-                .safeName("a")
-                .putSafeTags("key1", "value1")
-                .putSafeTags("key2", "value2")
-                .build();
-        MetricName two = MetricName.builder()
-                .safeName("a")
-                .putSafeTags("key1", "value1")
-                .putSafeTags("key2", "valueZ")
-                .build();
+    @Nested
+    class NullValidation {
 
-        assertThat(one).isNotEqualTo(two);
-        assertThat(two).isNotEqualTo(one);
-    }
+        @Test
+        public void builderNullSafeName() {
+            assertThatThrownBy(() -> MetricName.builder().safeName(null)).isInstanceOf(NullPointerException.class);
+        }
 
-    @Test
-    public void preSizedBuilder() {
-        MetricName preSized = MetricName.builderWithExpectedTags(2)
-                .safeName("test")
-                .putSafeTags("key1", "value1")
-                .putSafeTags("key2", "value2")
-                .build();
-        MetricName standard = MetricName.builder()
-                .safeName("test")
-                .putSafeTags("key1", "value1")
-                .putSafeTags("key2", "value2")
-                .build();
+        @Test
+        public void builderNullTagKey() {
+            assertThatThrownBy(() -> MetricName.builder().putSafeTags(null, "v"))
+                    .isInstanceOf(NullPointerException.class);
+        }
 
-        assertThat(preSized).isEqualTo(standard);
-        assertThat(preSized).hasSameHashCodeAs(standard);
-        assertThat(preSized.safeName()).isEqualTo("test");
-        assertThat(preSized.safeTags()).containsEntry("key1", "value1").containsEntry("key2", "value2");
-    }
+        @Test
+        public void builderNullTagValue() {
+            assertThatThrownBy(() -> MetricName.builder().putSafeTags("k", null))
+                    .isInstanceOf(NullPointerException.class);
+        }
 
-    @Test
-    public void preSizedBuilder_noTags() {
-        MetricName preSized =
-                MetricName.builderWithExpectedTags(0).safeName("test").build();
-        MetricName standard = MetricName.builder().safeName("test").build();
+        @Test
+        public void builderNullEntry() {
+            assertThatThrownBy(() -> MetricName.builder().putSafeTags(null)).isInstanceOf(NullPointerException.class);
+        }
 
-        assertThat(preSized).isEqualTo(standard);
-        assertThat(preSized).hasSameHashCodeAs(standard);
-    }
+        @Test
+        public void builderNullFrom() {
+            assertThatThrownBy(() -> MetricName.builder().from(null)).isInstanceOf(NullPointerException.class);
+        }
 
-    @Test
-    public void preSizedBuilder_equalsStandardBuilderWithDifferentInsertionOrder() {
-        MetricName preSized = MetricName.builderWithExpectedTags(3)
-                .safeName("test")
-                .putSafeTags("a", "1")
-                .putSafeTags("b", "2")
-                .putSafeTags("c", "3")
-                .build();
-        MetricName standard = MetricName.builder()
-                .safeName("test")
-                .putSafeTags("c", "3")
-                .putSafeTags("a", "1")
-                .putSafeTags("b", "2")
-                .build();
+        @Test
+        public void builderNullSafeTagsMap() {
+            assertThatThrownBy(() -> MetricName.builder().safeTags(null)).isInstanceOf(NullPointerException.class);
+        }
 
-        assertThat(preSized).isEqualTo(standard);
-        assertThat(preSized).hasSameHashCodeAs(standard);
-        assertThat(preSized.toString()).isEqualTo(standard.toString());
-    }
+        @Test
+        public void builderNullPutAllSafeTagsMap() {
+            assertThatThrownBy(() -> MetricName.builder().putAllSafeTags(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
 
-    @Test
-    public void preSizedBuilder_sizeMismatchThrows() {
-        assertThatThrownBy(() -> MetricName.builderWithExpectedTags(3)
-                        .safeName("test")
-                        .putSafeTags("key1", "value1")
-                        .putSafeTags("key2", "value2")
-                        .build())
-                .isInstanceOf(IllegalArgumentException.class);
-    }
+        @Test
+        public void buildWithoutSafeName() {
+            assertThatThrownBy(() -> MetricName.builder().build()).isInstanceOf(NullPointerException.class);
+        }
 
-    @Test
-    public void preSizedBuilder_notLexicographicalOrderThrows() {
-        assertThatThrownBy(() -> MetricName.builderWithExpectedTags(3)
-                        .safeName("test")
-                        .putSafeTags("key2", "value2")
-                        .putSafeTags("key1", "value1")
-                        .build())
-                .isInstanceOf(IllegalArgumentException.class);
+        @Test
+        public void preSizedBuilderBuildWithoutSafeName() {
+            assertThatThrownBy(() -> MetricName.builderWithExpectedTags(0).build())
+                    .isInstanceOf(NullPointerException.class);
+        }
     }
 }

--- a/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TagMapTest.java
+++ b/tritium-registry/src/test/java/com/palantir/tritium/metrics/registry/TagMapTest.java
@@ -17,6 +17,7 @@
 package com.palantir.tritium.metrics.registry;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
@@ -24,6 +25,13 @@ import com.google.common.collect.Ordering;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class TagMapTest {
@@ -50,43 +58,400 @@ class TagMapTest {
         assertThat(map.entrySet().iterator().next()).isEqualTo(new SimpleImmutableEntry<>("foo", "bar"));
     }
 
-    @Test
-    void testExtraEntryKeyAlreadyExists() {
-        TagMap original = TagMap.of(Collections.singletonMap("foo", "bar"));
-        TagMap updated = original.withEntry("foo", "baz");
-        assertThat(updated)
-                .hasSize(1)
-                .containsEntry("foo", "baz")
-                .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of("foo", "baz"))
-                .as("Original must not be mutated")
-                .isNotSameAs(original)
-                .isNotEqualTo(original);
-        assertThat(original)
-                .hasSize(1)
-                .as("Original must not be mutated")
-                .containsEntry("foo", "bar")
-                .isNotEqualTo(updated);
+    @Nested
+    class OfFactory {
+
+        @Test
+        void tagMapReturnsIdentity() {
+            TagMap original = TagMap.of(ImmutableMap.of("a", "1", "b", "2"));
+            assertThat(TagMap.of(original)).isSameAs(original);
+        }
+
+        @Test
+        void sortedMaps() {
+            SortedMap<String, String> naturalMap = new TreeMap<>();
+            naturalMap.put("b", "2");
+            naturalMap.put("a", "1");
+            assertThat(TagMap.of(naturalMap)).hasSize(2).containsEntry("a", "1").containsEntry("b", "2");
+
+            SortedMap<String, String> reverseMap = new TreeMap<>(Comparator.reverseOrder());
+            reverseMap.put("b", "2");
+            reverseMap.put("a", "1");
+            TagMap fromReverse = TagMap.of(reverseMap);
+            assertThat(fromReverse).hasSize(2).containsEntry("a", "1").containsEntry("b", "2");
+            assertThat(fromReverse.firstKey()).isEqualTo("a");
+        }
+
+        @Test
+        void unsortedMap() {
+            TagMap map = TagMap.of(ImmutableMap.of("c", "3", "a", "1", "b", "2"));
+            assertThat(map).hasSize(3);
+            assertThat(map.firstKey()).isEqualTo("a");
+            assertThat(map.lastKey()).isEqualTo("c");
+        }
     }
 
-    @Test
-    void testUpdateWithExisting() {
-        TagMap map = TagMap.EMPTY.withEntry("foo", "bar");
-        assertThat(map.withEntry("foo", "bar")).isSameAs(map);
+    @Nested
+    class BuilderTest {
+
+        @Test
+        void sortsKeys() {
+            TagMap map = new TagMap.Builder(3)
+                    .put("c", "3")
+                    .put("a", "1")
+                    .put("b", "2")
+                    .build();
+            assertThat(map)
+                    .hasSize(3)
+                    .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of("a", "1", "b", "2", "c", "3"));
+            assertThat(map.keySet()).containsExactly("a", "b", "c");
+            assertThat(map.firstKey()).isEqualTo("a");
+            assertThat(map.lastKey()).isEqualTo("c");
+        }
+
+        @Test
+        void alreadySorted() {
+            TagMap map = new TagMap.Builder(2).put("a", "1").put("b", "2").build();
+            assertThat(map).hasSize(2).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of("a", "1", "b", "2"));
+        }
+
+        @Test
+        void expansion() {
+            TagMap map = new TagMap.Builder(1)
+                    .put("a", "1")
+                    .put("b", "2")
+                    .put("c", "3")
+                    .build();
+            assertThat(map)
+                    .hasSize(3)
+                    .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of("a", "1", "b", "2", "c", "3"));
+        }
+
+        @Test
+        void expansionFromZero() {
+            TagMap map = new TagMap.Builder(0).put("b", "2").put("a", "1").build();
+            assertThat(map).hasSize(2).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of("a", "1", "b", "2"));
+            assertThat(map.firstKey()).isEqualTo("a");
+        }
+
+        @Test
+        void contraction() {
+            TagMap map = new TagMap.Builder(5).put("b", "2").put("a", "1").build();
+            assertThat(map).hasSize(2).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of("a", "1", "b", "2"));
+        }
+
+        @Test
+        void empty() {
+            TagMap map = new TagMap.Builder(3).build();
+            assertThat(map).isSameAs(TagMap.EMPTY);
+        }
+
+        @Test
+        void expansionAndSorting() {
+            TagMap map = new TagMap.Builder(1)
+                    .put("d", "4")
+                    .put("b", "2")
+                    .put("c", "3")
+                    .put("a", "1")
+                    .build();
+            assertThat(map)
+                    .hasSize(4)
+                    .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of("a", "1", "b", "2", "c", "3", "d", "4"));
+            assertThat(map.firstKey()).isEqualTo("a");
+            assertThat(map.lastKey()).isEqualTo("d");
+        }
     }
 
-    @Test
-    void testNaturalOrder() {
-        assertThat(TagMap.isNaturalOrder(Ordering.natural())).isTrue();
-        assertThat(TagMap.isNaturalOrder(Comparator.naturalOrder())).isTrue();
+    @Nested
+    class WithEntry {
 
-        assertThat(TagMap.isNaturalOrder(Comparator.reverseOrder())).isFalse();
-        Comparator<?> immutableSortedMapComparator = ImmutableSortedMap.naturalOrder()
-                .put("a", "b")
-                .put("c", "d")
-                .buildOrThrow()
-                .comparator();
-        assertThat(TagMap.isNaturalOrder(immutableSortedMapComparator))
-                .as("Expected ImmutableSortedMap comparator %s to be natural", immutableSortedMapComparator)
-                .isTrue();
+        @Test
+        void updateExisting() {
+            TagMap original = TagMap.of(Collections.singletonMap("foo", "bar"));
+            assertThat(original.withEntry("foo", "bar")).isSameAs(original);
+
+            TagMap updated = original.withEntry("foo", "baz");
+            assertThat(updated)
+                    .hasSize(1)
+                    .containsEntry("foo", "baz")
+                    .isNotSameAs(original)
+                    .isNotEqualTo(original);
+            assertThat(original).containsEntry("foo", "bar");
+        }
+
+        @Test
+        void insertPositions() {
+            TagMap base = TagMap.of(ImmutableMap.of("b", "2", "d", "4"));
+
+            TagMap withBefore = base.withEntry("a", "1");
+            assertThat(withBefore.firstKey()).isEqualTo("a");
+            assertThat(withBefore).hasSize(3);
+
+            TagMap withBetween = base.withEntry("c", "3");
+            assertThat(withBetween).hasSize(3).containsEntry("c", "3");
+
+            TagMap withAfter = base.withEntry("e", "5");
+            assertThat(withAfter.lastKey()).isEqualTo("e");
+            assertThat(withAfter).hasSize(3);
+
+            TagMap fromEmpty = TagMap.EMPTY.withEntry("a", "1");
+            assertThat(fromEmpty).hasSize(1).containsEntry("a", "1");
+        }
+    }
+
+    @Nested
+    class MapMethods {
+
+        @Test
+        void naturalOrder() {
+            assertThat(TagMap.isNaturalOrder(Ordering.natural())).isTrue();
+            assertThat(TagMap.isNaturalOrder(Comparator.naturalOrder())).isTrue();
+
+            assertThat(TagMap.isNaturalOrder(Comparator.reverseOrder())).isFalse();
+            Comparator<?> immutableSortedMapComparator = ImmutableSortedMap.naturalOrder()
+                    .put("a", "b")
+                    .put("c", "d")
+                    .buildOrThrow()
+                    .comparator();
+            assertThat(TagMap.isNaturalOrder(immutableSortedMapComparator))
+                    .as("Expected ImmutableSortedMap comparator %s to be natural", immutableSortedMapComparator)
+                    .isTrue();
+        }
+
+        @Test
+        void forEach() {
+            TagMap map = TagMap.of(ImmutableMap.of("b", "2", "a", "1"));
+            ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+            map.forEach(builder::put);
+            assertThat(builder.buildOrThrow()).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of("a", "1", "b", "2"));
+        }
+
+        @Test
+        void testToString() {
+            assertThat(TagMap.EMPTY.toString()).isEqualTo("{}");
+            assertThat(TagMap.of(Collections.singletonMap("k", "v")).toString()).isEqualTo("{k=v}");
+            assertThat(TagMap.of(ImmutableMap.of("a", "1", "b", "2")).toString())
+                    .isEqualTo("{a=1, b=2}");
+        }
+
+        @Test
+        void testEquals() {
+            TagMap map = TagMap.of(ImmutableMap.of("a", "1", "b", "2"));
+            assertThat(map.equals(map)).isTrue();
+            assertThat(map).isEqualTo(TagMap.of(ImmutableMap.of("a", "1", "b", "2")));
+            assertThat(map).isEqualTo(ImmutableMap.of("a", "1", "b", "2"));
+
+            assertThat(map).isNotEqualTo(TagMap.of(ImmutableMap.of("a", "1", "b", "different")));
+            assertThat(map).isNotEqualTo("not a map");
+            assertThat(map).isNotEqualTo(ImmutableMap.of("a", "1"));
+            assertThat(map).isNotEqualTo(ImmutableMap.of("a", "1", "b", "different"));
+        }
+
+        @Test
+        void testHashCode() {
+            assertThat(TagMap.EMPTY).hasSameHashCodeAs(ImmutableMap.of());
+            assertThat(TagMap.of(ImmutableMap.of("a", "1", "b", "2")))
+                    .hasSameHashCodeAs(ImmutableMap.of("a", "1", "b", "2"));
+        }
+
+        @Test
+        void comparator() {
+            assertThat(TagMap.EMPTY.comparator()).isEqualTo(Comparator.naturalOrder());
+        }
+
+        @Test
+        void containsKeyAndValue() {
+            TagMap map = TagMap.of(ImmutableMap.of("a", "1"));
+            assertThat(map.containsKey("a")).isTrue();
+            assertThat(map.containsKey("missing")).isFalse();
+            assertThat(map.containsValue("1")).isTrue();
+            assertThat(map.containsValue("missing")).isFalse();
+        }
+
+        @Test
+        void getMissing() {
+            assertThat(TagMap.of(ImmutableMap.of("a", "1")).get("b")).isNull();
+        }
+
+        @Test
+        void keySetAndValues() {
+            TagMap map = TagMap.of(ImmutableMap.of("c", "3", "a", "1", "b", "2"));
+            assertThat(map.keySet()).containsExactly("a", "b", "c");
+            assertThat(map.values()).containsExactly("1", "2", "3");
+        }
+    }
+
+    @Nested
+    class SortedMapViews {
+
+        @Test
+        void subMap() {
+            TagMap map = TagMap.of(ImmutableMap.of("a", "1", "b", "2", "c", "3", "d", "4"));
+            assertThat(map.subMap("b", "d")).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of("b", "2", "c", "3"));
+            assertThat(map.subMap("e", "f")).isEmpty();
+            assertThat(TagMap.of(ImmutableMap.of("a", "1", "c", "3")).subMap("b", "c"))
+                    .isEmpty();
+        }
+
+        @Test
+        void headMap() {
+            TagMap map = TagMap.of(ImmutableMap.of("a", "1", "b", "2", "c", "3"));
+            assertThat(map.headMap("c")).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of("a", "1", "b", "2"));
+            assertThat(TagMap.of(ImmutableMap.of("b", "2", "c", "3")).headMap("a"))
+                    .isEmpty();
+        }
+
+        @Test
+        void tailMap() {
+            TagMap map = TagMap.of(ImmutableMap.of("a", "1", "b", "2", "c", "3"));
+            assertThat(map.tailMap("b")).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of("b", "2", "c", "3"));
+            assertThat(TagMap.of(ImmutableMap.of("a", "1", "b", "2")).tailMap("c"))
+                    .isEmpty();
+        }
+
+        @Test
+        void firstLastKeyOnEmpty() {
+            assertThatThrownBy(TagMap.EMPTY::firstKey).isInstanceOf(NoSuchElementException.class);
+            assertThatThrownBy(TagMap.EMPTY::lastKey).isInstanceOf(NoSuchElementException.class);
+        }
+    }
+
+    @Nested
+    class Immutability {
+
+        @Test
+        void mapMutatorsThrow() {
+            assertThatThrownBy(() -> TagMap.EMPTY.put("k", "v")).isInstanceOf(UnsupportedOperationException.class);
+            assertThatThrownBy(() -> TagMap.EMPTY.putAll(ImmutableMap.of("k", "v")))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            assertThatThrownBy(() -> TagMap.EMPTY.remove("k")).isInstanceOf(UnsupportedOperationException.class);
+            assertThatThrownBy(TagMap.EMPTY::clear).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        void entrySetMutatorsThrow() {
+            assertThatThrownBy(() -> TagMap.EMPTY.entrySet().add(new SimpleImmutableEntry<>("k", "v")))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            assertThatThrownBy(() -> TagMap.EMPTY.entrySet().remove(new SimpleImmutableEntry<>("k", "v")))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            assertThatThrownBy(() -> TagMap.EMPTY.entrySet().addAll(List.of(new SimpleImmutableEntry<>("k", "v"))))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            assertThatThrownBy(() -> TagMap.EMPTY.entrySet().retainAll(List.of()))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            assertThatThrownBy(() -> TagMap.EMPTY.entrySet().removeAll(List.of()))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            assertThatThrownBy(() -> TagMap.EMPTY.entrySet().clear()).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    class EntrySetTest {
+
+        @Test
+        void contains() {
+            TagMap map = TagMap.of(ImmutableMap.of("a", "1"));
+            assertThat(map.entrySet().contains(new SimpleImmutableEntry<>("a", "1")))
+                    .isTrue();
+            assertThat(map.entrySet().contains(new SimpleImmutableEntry<>("a", "2")))
+                    .isFalse();
+        }
+
+        @Test
+        void toArray() {
+            TagMap map = TagMap.of(ImmutableMap.of("a", "1", "b", "2"));
+            Object[] array = map.entrySet().toArray();
+            assertThat(array).hasSize(2);
+            assertThat(array[0]).isEqualTo(new SimpleImmutableEntry<>("a", "1"));
+            assertThat(array[1]).isEqualTo(new SimpleImmutableEntry<>("b", "2"));
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void toArrayTyped() {
+            TagMap map = TagMap.of(ImmutableMap.of("a", "1", "b", "2"));
+            Map.Entry<String, String>[] smallResult = map.entrySet().toArray(new Map.Entry[0]);
+            assertThat(smallResult).hasSize(2);
+            assertThat(smallResult[0]).isEqualTo(new SimpleImmutableEntry<>("a", "1"));
+
+            TagMap single = TagMap.of(ImmutableMap.of("a", "1"));
+            Map.Entry<String, String>[] largeArray = new Map.Entry[3];
+            largeArray[1] = new SimpleImmutableEntry<>("stale", "stale");
+            largeArray[2] = new SimpleImmutableEntry<>("stale", "stale");
+            Map.Entry<String, String>[] largeResult = single.entrySet().toArray(largeArray);
+            assertThat(largeResult).isSameAs(largeArray);
+            assertThat(largeResult[0]).isEqualTo(new SimpleImmutableEntry<>("a", "1"));
+            assertThat(largeResult[1]).isNull();
+            assertThat(largeResult[2]).isNull();
+        }
+
+        @Test
+        void containsAll() {
+            TagMap map = TagMap.of(ImmutableMap.of("a", "1", "b", "2"));
+            assertThat(map.entrySet()
+                            .containsAll(List.of(
+                                    new SimpleImmutableEntry<>("a", "1"), new SimpleImmutableEntry<>("b", "2"))))
+                    .isTrue();
+            assertThat(TagMap.of(ImmutableMap.of("a", "1"))
+                            .entrySet()
+                            .containsAll(List.of(
+                                    new SimpleImmutableEntry<>("a", "1"), new SimpleImmutableEntry<>("b", "2"))))
+                    .isFalse();
+        }
+
+        @Test
+        void testEquals() {
+            TagMap map = TagMap.of(ImmutableMap.of("a", "1"));
+            assertThat(map.entrySet().equals(map.entrySet())).isTrue();
+            assertThat(map.entrySet())
+                    .isEqualTo(TagMap.of(ImmutableMap.of("a", "1")).entrySet());
+            assertThat(map.entrySet()).isEqualTo(ImmutableMap.of("a", "1").entrySet());
+
+            assertThat(map.entrySet())
+                    .isNotEqualTo(TagMap.of(ImmutableMap.of("a", "2")).entrySet());
+            assertThat(map.entrySet()).isNotEqualTo("not a set");
+            assertThat(map.entrySet())
+                    .isNotEqualTo(ImmutableMap.of("a", "1", "b", "2").entrySet());
+        }
+
+        @Test
+        void hashCodeAndToString() {
+            TagMap map = TagMap.of(ImmutableMap.of("a", "1", "b", "2"));
+            assertThat(map.entrySet().hashCode())
+                    .isEqualTo(ImmutableMap.of("a", "1", "b", "2").entrySet().hashCode());
+            assertThat(map.entrySet().toString()).contains("a", "1");
+        }
+    }
+
+    @Nested
+    class IteratorTest {
+
+        @Test
+        void traversal() {
+            TagMap map = TagMap.of(ImmutableMap.of("b", "2", "a", "1"));
+            Iterator<Map.Entry<String, String>> it = map.entrySet().iterator();
+            assertThat(it.hasNext()).isTrue();
+            assertThat(it.next()).isEqualTo(new SimpleImmutableEntry<>("a", "1"));
+            assertThat(it.hasNext()).isTrue();
+            Map.Entry<String, String> second = it.next();
+            assertThat(second).isEqualTo(new SimpleImmutableEntry<>("b", "2"));
+            assertThat(it.hasNext()).isFalse();
+            assertThatThrownBy(it::next).isInstanceOf(NoSuchElementException.class);
+            assertThatThrownBy(it::remove).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    class TagEntryTest {
+
+        @Test
+        void properties() {
+            TagMap map = TagMap.of(ImmutableMap.of("k", "v"));
+            Map.Entry<String, String> entry = map.entrySet().iterator().next();
+            assertThat(entry.toString()).isEqualTo("{k=v}");
+            assertThat(entry.equals(entry)).isTrue();
+            assertThat(entry).isNotEqualTo("not an entry");
+            assertThat(entry.hashCode()).isEqualTo(new SimpleImmutableEntry<>("k", "v").hashCode());
+            assertThatThrownBy(() -> entry.setValue("new")).isInstanceOf(UnsupportedOperationException.class);
+        }
     }
 }


### PR DESCRIPTION
## Before this PR
Comments on https://github.com/palantir/tritium/pull/2451

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
TagMap.Builder no longer requires exact pre-sizing or sorted insertion:
- put() dynamically resizes the backing array by 1.5x when capacity is exceeded
- build() shrinks the array when fewer entries are inserted than initially allocated
- build() sorts key/value pairs when keys were not inserted in lexicographic order, tracked via a `sorted` flag set during put()
- When keys are already sorted (the metric-schema hot path), the sort is skipped entirely

Also fixes two pre-existing bugs found by expanded test coverage:
- subMap() returned the full map instead of EMPTY when no keys fell within [fromKey, toKey)
- toArray(T[]) used array.length instead of result.length in Arrays.fill, causing IllegalArgumentException when the passed-in array was smaller

Benchmark results from M2 Max (pre-sized builder, sorted keys):

  3 tags:  10.5 ns/op -> 7.4 ns/op  (1.4x faster, 80B alloc)
  7 tags:  34.0 ns/op -> 15.2 ns/op (2.2x faster, 112B alloc)
  13 tags: 59.0 ns/op -> 29.6 ns/op (2.0x faster, 160B alloc)

Standard builder path is unchanged (~68/213/286 ns/op).


Benchmark results from AMD EPYC 7R13 (pre-sized builder, sorted keys)

```
┌──────┬─────────────────┬──────────────────┬─────────┬───────────────┬────────────────┬─────────────────┐
│ Tags │ Regular (ns/op) │ PreSized (ns/op) │ Speedup │ Regular Alloc │ PreSized Alloc │ Alloc Reduction │
├──────┼─────────────────┼──────────────────┼─────────┼───────────────┼────────────────┼─────────────────┤
│ 3    │ 56.37 ± 4.20    │ 12.42 ± 1.70     │ 4.5×    │ 136 B/op      │ 80 B/op        │ −41%            │
├──────┼─────────────────┼──────────────────┼─────────┼───────────────┼────────────────┼─────────────────┤
│ 7    │ 242.60 ± 13.97  │ 44.61 ± 3.04     │ 5.4×    │ 416 B/op      │ 112 B/op       │ −73%            │
├──────┼─────────────────┼──────────────────┼─────────┼───────────────┼────────────────┼─────────────────┤
│ 13   │ 802.12 ± 37.91  │ 93.74 ± 4.00     │ 8.6×    │ 976 B/op      │ 160 B/op       │ −84%            │
└──────┴─────────────────┴──────────────────┴─────────┴───────────────┴────────────────┴─────────────────┘
```


==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

