### PR TITLE
Serialize instrumentation tests on dynamic-proxy system property

### DIFF
--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/InstrumentationTest.java
@@ -69,6 +69,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -80,6 +82,7 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 @ExtendWith({MockitoExtension.class, SystemStubsExtension.class})
+@ResourceLock(value = "instrument.dynamic-proxy", mode = ResourceAccessMode.READ_WRITE)
 @SuppressWarnings({"NullAway", "WeakerAccess"}) // mock injection, dumping metrics to standard out
 public abstract class InstrumentationTest {
     @SystemStub

--- a/tritium-lib/src/test/java/com/palantir/tritium/proxy/subpackage/ByteBuddyInstrumentationPackageAccessTest.java
+++ b/tritium-lib/src/test/java/com/palantir/tritium/proxy/subpackage/ByteBuddyInstrumentationPackageAccessTest.java
@@ -23,11 +23,14 @@ import com.palantir.tritium.proxy.Instrumentation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 @ExtendWith(SystemStubsExtension.class)
+@ResourceLock(value = "instrument.dynamic-proxy", mode = ResourceAccessMode.READ_WRITE)
 class ByteBuddyInstrumentationPackageAccessTest {
     @SystemStub
     private SystemProperties systemProperties;


### PR DESCRIPTION
## Before this PR

Test flakes, e.g. [`check` on release 0.130.0 ](https://app.circleci.com/pipelines/github/palantir/tritium/5405/workflows/0516b722-007c-449d-b153-1a5a0d4d7892/jobs/25279/tests#failed-test-0)

`testPackagePrivateInterface()` [FLAKY](https://app.circleci.com/insights/github/palantir/tritium/workflows/build/tests)
com.palantir.tritium.proxy.subpackage.ByteBuddyInstrumentationPackageAccessTest

```
java.lang.AssertionError: [inaccessible interfaces cannot be implemented, the original should be returned] 
Expecting actual:
  com.palantir.tritium.proxy.subpackage.ByteBuddyInstrumentationPackageAccessTest$$Lambda/0x000000001c373a48@76298aa3
and:
  com.palantir.tritium.proxy.subpackage.ByteBuddyInstrumentationPackageAccessTest$$Lambda/0x000000001c373a48@76298aa3
to refer to the same object
	at com.palantir.tritium.proxy.subpackage.ByteBuddyInstrumentationPackageAccessTest.testPackagePrivateInterface(ByteBuddyInstrumentationPackageAccessTest.java:48)
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The `instrument.dynamic-proxy` system property is JVM-global, but `InstrumentationTest` (via `DynamicProxyInstrumentationTest` and `ByteBuddyInstrumentationTest`) and `ByteBuddyInstrumentationPackageAccessTest` all mutate it from `@BeforeEach`. With JUnit's class-level parallel execution they could race, occasionally flipping the property mid-test and causing `testPackagePrivateInterface()` to fall through to the JDK dynamic-proxy path (which can wrap package-private interfaces) instead of the ByteBuddy path that returns the raw delegate.

Add `@ResourceLock` on both test classes so JUnit serializes access to the shared property while keeping other tests parallel.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

