### PR TITLE
CircleCI uses JDK 17 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ aliases:
 jobs:
 
   check:
-    docker: [{ image: 'cimg/openjdk:11.0.22-node' }]
+    docker: [{ image: 'cimg/openjdk:17.0.10-node' }]
     resource_class: large
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -79,7 +79,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   publish:
-    docker: [{ image: 'cimg/openjdk:11.0.22-node' }]
+    docker: [{ image: 'cimg/openjdk:17.0.10-node' }]
     resource_class: medium
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit

--- a/.circleci/template.sh
+++ b/.circleci/template.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 export CIRCLECI_TEMPLATE=java-library-oss
-export JDK=11
+export JDK=17


### PR DESCRIPTION
## Before this PR

CircleCI was using JDK 11 base image

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
CircleCI uses JDK 17 base image to unblock gradle 9
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

We need to excavate this [across many other repos](https://github.com/search?q=org%3Apalantir%20export%20JDK%3D11&type=code)

