### PR TITLE
Use JDK 25 circle CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ aliases:
 jobs:
 
   check:
-    docker: [{ image: 'cimg/openjdk:17.0.10-node' }]
+    docker: [{ image: 'cimg/openjdk:25.0.3-node' }]
     resource_class: large
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
@@ -79,7 +79,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   publish:
-    docker: [{ image: 'cimg/openjdk:17.0.10-node' }]
+    docker: [{ image: 'cimg/openjdk:25.0.3-node' }]
     resource_class: medium
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit

--- a/.circleci/template.sh
+++ b/.circleci/template.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 export CIRCLECI_TEMPLATE=java-library-oss
-export JDK=17
+export JDK=25


### PR DESCRIPTION
## Before this PR

Uses OpenJDK 17 circle CI images per https://circleci.com/developer/images/image/cimg/openjdk

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use OpenJDK 25 circle CI image per https://circleci.com/developer/images/image/cimg/openjdk
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

