### PR TITLE
Support bounded generic parameters on interface generation

### DIFF
--- a/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessorStrategy.java
+++ b/tritium-processor/src/main/java/com/palantir/tritium/processor/TritiumAnnotationProcessorStrategy.java
@@ -215,7 +215,10 @@ enum TritiumAnnotationProcessorStrategy implements DelegateProcessorStrategy {
                                         method.implementation().getParameters().stream()
                                                 .map(parameter -> CodeBlock.of(
                                                         "$T.class",
-                                                        TypeNames.erased(TypeName.get(parameter.asType())))))
+                                                        TypeName.get(arguments
+                                                                .context()
+                                                                .types()
+                                                                .erasure(parameter.asType())))))
                                 .collect(CodeBlock.joining(",")));
             });
             staticBlock

--- a/tritium-processor/src/test/java/com/palantir/tritium/examples/Parameterized.java
+++ b/tritium-processor/src/test/java/com/palantir/tritium/examples/Parameterized.java
@@ -29,4 +29,6 @@ public interface Parameterized<T> {
     void consumeListOfParameter(List<T> value);
 
     <U extends T> T methodParameter(T first, U second);
+
+    <U extends CharSequence> void consumeBoundedParameter(U value);
 }

--- a/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedParameterized.java.generated
+++ b/tritium-processor/src/test/resources/com/palantir/tritium/examples/InstrumentedParameterized.java.generated
@@ -21,12 +21,16 @@ public final class InstrumentedParameterized<T> implements Parameterized<T> {
 
     private static final Method METHOD_PARAMETER_307142f3;
 
+    private static final Method CONSUME_BOUNDED_PARAMETER_9d507432;
+
     static {
         try {
             PRODUCE_PARAMETER_2ab71087 = Parameterized.class.getMethod("produceParameter");
             CONSUME_PARAMETER_c93c1b74 = Parameterized.class.getMethod("consumeParameter", Object.class);
             CONSUME_LIST_OF_PARAMETER_0236f37a = Parameterized.class.getMethod("consumeListOfParameter", List.class);
             METHOD_PARAMETER_307142f3 = Parameterized.class.getMethod("methodParameter", Object.class, Object.class);
+            CONSUME_BOUNDED_PARAMETER_9d507432 =
+                    Parameterized.class.getMethod("consumeBoundedParameter", CharSequence.class);
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
@@ -100,6 +104,21 @@ public final class InstrumentedParameterized<T> implements Parameterized<T> {
             T _result = this.delegate.methodParameter(first, second);
             Handlers.onSuccess(this.handler, _invocationContext, _result);
             return _result;
+        } catch (Throwable _throwable) {
+            Handlers.onFailure(this.handler, _invocationContext, _throwable);
+            throw _throwable;
+        }
+    }
+
+    @Override
+    public <U extends CharSequence> void consumeBoundedParameter(U value) {
+        InvocationContext _invocationContext = this.handler.isEnabled()
+                ? Handlers.pre(
+                        this.handler, this.filter, this, CONSUME_BOUNDED_PARAMETER_9d507432, new Object[] {value})
+                : Handlers.disabled();
+        try {
+            this.delegate.consumeBoundedParameter(value);
+            Handlers.onSuccess(this.handler, _invocationContext);
         } catch (Throwable _throwable) {
             Handlers.onFailure(this.handler, _invocationContext, _throwable);
             throw _throwable;


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Generating instrumented implementations for interfaces with methods like `<U extends CharSequence> void consumeBoundedParameter(U value);` would fail.

## After this PR
Generating implementations no longer fail.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

