### PR TITLE
Cache stat meters don't record moving averages

### DIFF
--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/CacheStats.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Maps;
 import com.palantir.logsafe.Safe;
 import com.palantir.tritium.metrics.caffeine.CacheMetrics.Load_Result;
 import com.palantir.tritium.metrics.caffeine.CacheMetrics.Request_Result;
+import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -67,7 +68,7 @@ public final class CacheStats implements StatsCounter, Supplier<StatsCounter> {
      * {@link com.github.benmanes.caffeine.cache.Caffeine#recordStats(Supplier)}.
      */
     public static CacheStats of(TaggedMetricRegistry taggedMetricRegistry, @Safe String name) {
-        return new CacheStats(CacheMetrics.of(taggedMetricRegistry), name);
+        return new CacheStats(taggedMetricRegistry, CacheMetrics.of(taggedMetricRegistry), name);
     }
 
     /**
@@ -144,12 +145,15 @@ public final class CacheStats implements StatsCounter, Supplier<StatsCounter> {
         return cache;
     }
 
-    private CacheStats(CacheMetrics metrics, @Safe String name) {
+    private CacheStats(TaggedMetricRegistry registry, CacheMetrics metrics, @Safe String name) {
         this.metrics = metrics;
         this.name = name;
-        this.hitMeter = metrics.request().cache(name).result(Request_Result.HIT).build();
-        this.missMeter =
-                metrics.request().cache(name).result(Request_Result.MISS).build();
+        this.hitMeter = countOnlyMeter(
+                registry,
+                metrics.request().cache(name).result(Request_Result.HIT).buildMetricName());
+        this.missMeter = countOnlyMeter(
+                registry,
+                metrics.request().cache(name).result(Request_Result.MISS).buildMetricName());
         this.loadSuccessTimer =
                 metrics.load().cache(name).result(Load_Result.SUCCESS).build();
         this.loadFailureTimer =
@@ -157,17 +161,25 @@ public final class CacheStats implements StatsCounter, Supplier<StatsCounter> {
         this.evictionMeters = Arrays.stream(RemovalCause.values())
                 .collect(Maps.toImmutableEnumMap(
                         cause -> cause,
-                        cause -> metrics.eviction()
-                                .cache(name)
-                                .cause(cause.toString())
-                                .build()));
+                        cause -> countOnlyMeter(
+                                registry,
+                                metrics.eviction()
+                                        .cache(name)
+                                        .cause(cause.toString())
+                                        .buildMetricName())));
         this.evictionWeightMeters = Arrays.stream(RemovalCause.values())
                 .collect(Maps.toImmutableEnumMap(
                         cause -> cause,
-                        cause -> metrics.evictionWeight()
-                                .cache(name)
-                                .cause(cause.toString())
-                                .build()));
+                        cause -> countOnlyMeter(
+                                registry,
+                                metrics.evictionWeight()
+                                        .cache(name)
+                                        .cause(cause.toString())
+                                        .buildMetricName())));
+    }
+
+    private static Meter countOnlyMeter(TaggedMetricRegistry registry, MetricName metricName) {
+        return registry.meter(metricName, DisabledMovingAverages::meter);
     }
 
     @Override

--- a/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/DisabledMovingAverages.java
+++ b/tritium-caffeine/src/main/java/com/palantir/tritium/metrics/caffeine/DisabledMovingAverages.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.caffeine;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MovingAverages;
+
+enum DisabledMovingAverages implements MovingAverages {
+    INSTANCE;
+
+    static Meter meter() {
+        return new Meter(INSTANCE);
+    }
+
+    @Override
+    public void tickIfNecessary() {}
+
+    @Override
+    public void update(long _events) {}
+
+    @Override
+    public double getM1Rate() {
+        return 0.0d;
+    }
+
+    @Override
+    public double getM5Rate() {
+        return 0.0d;
+    }
+
+    @Override
+    public double getM15Rate() {
+        return 0.0d;
+    }
+}

--- a/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/DisabledMovingAveragesTest.java
+++ b/tritium-caffeine/src/test/java/com/palantir/tritium/metrics/caffeine/DisabledMovingAveragesTest.java
@@ -1,0 +1,47 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.metrics.caffeine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Meter;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+final class DisabledMovingAveragesTest {
+
+    @Test
+    void countsWithoutRates() {
+        AtomicLong nanos = new AtomicLong();
+        Meter meter = new Meter(DisabledMovingAverages.INSTANCE, new Clock() {
+            @Override
+            public long getTick() {
+                return nanos.get();
+            }
+        });
+
+        meter.mark(5);
+        nanos.addAndGet(Duration.ofMinutes(1).toNanos());
+
+        assertThat(meter.getCount()).isEqualTo(5L);
+        assertThat(meter.getOneMinuteRate()).isZero();
+        assertThat(meter.getFiveMinuteRate()).isZero();
+        assertThat(meter.getFifteenMinuteRate()).isZero();
+    }
+}

--- a/tritium-jmh/build.gradle
+++ b/tritium-jmh/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
     api 'io.dropwizard.metrics:metrics-core'
 
+    jmhImplementation 'com.github.ben-manes.caffeine:caffeine'
     jmhImplementation 'com.google.guava:guava'
     jmhImplementation 'com.palantir.safe-logging:preconditions'
     jmhImplementation 'com.palantir.safe-logging:safe-logging'
@@ -21,6 +22,7 @@ dependencies {
     jmhImplementation 'org.jspecify:jspecify'
     jmhImplementation 'org.slf4j:slf4j-api'
     jmhImplementation project(':tritium-api')
+    jmhImplementation project(':tritium-caffeine')
     jmhImplementation project(':tritium-core')
     jmhImplementation project(':tritium-lib')
     jmhImplementation project(':tritium-metrics')

--- a/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/CacheStatsBenchmark.java
+++ b/tritium-jmh/src/jmh/java/com/palantir/tritium/microbenchmarks/CacheStatsBenchmark.java
@@ -1,0 +1,65 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tritium.microbenchmarks;
+
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.palantir.tritium.metrics.caffeine.CacheStats;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 10, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+@State(Scope.Benchmark)
+@SuppressWarnings("designforextension")
+public class CacheStatsBenchmark {
+
+    private final CacheStats stats = CacheStats.of(new DefaultTaggedMetricRegistry(), "benchmark");
+
+    @Benchmark
+    public void recordHit() {
+        stats.recordHits(1);
+    }
+
+    @Benchmark
+    public void recordEviction() {
+        stats.recordEviction(1, RemovalCause.SIZE);
+    }
+
+    public static void main(String[] _args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(CacheStatsBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
When recording hits and misses for caffeine caches, we use a meter. This requires, broadly:
- one call to System.nanotime()
- 4 increments (1 for counter, and 3 for moving averages)

We'd like to remove some of this overhead - we never use the moving averages, so we end up paying the cost for no reason. Additionally, they somewhat harm local benchmarks non-obviously - eg on an M5 mac, running the benchmark on 6 threads contends heavily on nanoTime in a way that's not obvious to the user. (note it's also not clear from JFRs, since System.nanoTime is a JIT intrinsic which will not emit a frame - benefits will likely be fairly platform-dependent).

The natural choice would be using a counter, but https://github.com/palantir/tritium/pull/1897#discussion_r1516789394 indicates that we want to keep those as meters - so opting to just zero out the moving averages.

running the benchmark on develop:
t=1
```
Benchmark                           Mode  Cnt   Score   Error  Units

CacheStatsBenchmark.recordEviction  avgt   30  33.113 ± 0.961  ns/op

CacheStatsBenchmark.recordHit       avgt   30  15.856 ± 0.187  ns/op
```
t=6
```
Benchmark                           Mode  Cnt    Score   Error  Units

CacheStatsBenchmark.recordEviction  avgt   30  392.320 ± 3.555  ns/op

CacheStatsBenchmark.recordHit       avgt   30  197.206 ± 3.214  ns/op
```

on this branch
t=1
```
Benchmark                           Mode  Cnt  Score   Error  Units

CacheStatsBenchmark.recordEviction  avgt   30  4.601 ± 0.048  ns/op

CacheStatsBenchmark.recordHit       avgt   30  4.285 ± 0.063  ns/op
```
t=6
```
Benchmark                           Mode  Cnt  Score   Error  Units

CacheStatsBenchmark.recordEviction  avgt   30  6.030 ± 0.157  ns/op

CacheStatsBenchmark.recordHit       avgt   30  4.384 ± 0.037  ns/op
```

Note I don't think the contention will be real on linux (those numbers are from an M5 mac), but this is hard to measure.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Cache stat meters don't record moving averages
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
it's pretty confusing that the rate() metrics will get zero'd out... it feels like we should just bite the bullet and make those counters instead.
